### PR TITLE
fix: testing can not be run in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "publish": "lerna publish --message 'chore: release new versions'",
     "site:build": "npm run vuepress:build",
     "site:start": "npm run vuepress:start",
-    "test": "lerna run test --stream",
-    "test:bs": "lerna run test:bs --stream",
+    "test": "lerna run test --stream --concurrency 1",
+    "test:bs": "lerna run test:bs --stream --concurrency 1",
     "vuepress:build": "vuepress build docs",
     "vuepress:start": "vuepress dev docs"
   },


### PR DESCRIPTION
A single browser can not run tests in multiple packages at the same
time. Limiting concurrency to 1.