### PR TITLE
chore: don't depend on lit-html directly for usage from bower

### DIFF
--- a/packages/chai-dom-equals/package.json
+++ b/packages/chai-dom-equals/package.json
@@ -22,7 +22,6 @@
     "@open-wc/testing-wallaby": "^0.1.3",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "chai": "^4.0.0",
-    "lit-html": "^0.12.0",
     "mocha": "^5.0.0",
     "sinon": "^7.0.0"
   }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -24,7 +24,6 @@
     "@storybook/polymer": "^4.0.0-alpha.25",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "babel-loader": "^8.0.0",
-    "lit-html": "^0.12.0",
     "moment": "^2.0.0",
     "polymer-webpack-loader": "^2.0.0"
   }

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -13,7 +13,7 @@
     "test": "karma start",
     "test:bs": "karma start karma-bs.config.js"
   },
-  "dependencies": {
+  "peerDependencies": {
     "lit-html": "^0.12.0"
   },
   "devDependencies": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -17,7 +17,6 @@
     "@open-wc/chai-dom-equals": "^0.1.1",
     "@open-wc/testing-helpers": "^0.1.2",
     "chai": "^4.0.0",
-    "lit-html": "^0.12.0",
     "mocha": "^5.0.0",
     "sinon": "^7.0.0"
   },


### PR DESCRIPTION
We only use lit-html in the lit fixture. If people use lit fixture, they must already have lit-html installed so we can get away with this trick.