### PR TITLE
feat(webpack): added import.meta.url loader

### DIFF
--- a/packages/webpack/LICENSE
+++ b/packages/webpack/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 open-wc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -1,0 +1,9 @@
+# Open Web Component Recommendations for webpack
+
+> Part of Open Web Component Recommendations [open-wc](https://github.com/open-wc/open-wc/)
+
+We want to provide a good set of default on how to facilitate your web component.
+
+[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
+[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
+[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)

--- a/packages/webpack/loaders/import-meta-url-loader.js
+++ b/packages/webpack/loaders/import-meta-url-loader.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+const regex = /(?!\()import.meta.url(?=\))/g;
+
+/** Webpack loader to rewrite `import.meta.url` in modules to the source code file location. */
+module.exports = function (source) {
+  const relativePath = this.context.substring(
+    this.context.indexOf(this.rootContext) + this.rootContext.length,
+    this.resource.lastIndexOf('/') + 1
+  );
+
+  const fileName = this.resource.substring(this.resource.lastIndexOf('/') + 1);
+  return source.replace(regex, () => `'./${relativePath}/${fileName}'`);
+};

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@open-wc/webpack",
+  "version": "0.0.1",
+  "description": "Webpack configuration following open-wc recommendations",
+  "author": "open-wc",
+  "homepage": "https://github.com/open-wc/open-wc/",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "https://github.com/open-wc/open-wc/tree/master/packages/webpack",
+  "dependencies": {
+  }
+}


### PR DESCRIPTION
Webpack does not support `import.meta.url` yet. This adds a small webpack loader which takes care of that.