### PR TITLE
fix(testing-karma): ensure karma-webpack creates a single bundle

### DIFF
--- a/packages/chai-dom-equals/karma-test-loader.js
+++ b/packages/chai-dom-equals/karma-test-loader.js
@@ -1,0 +1,4 @@
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);

--- a/packages/chai-dom-equals/karma.conf.js
+++ b/packages/chai-dom-equals/karma.conf.js
@@ -7,11 +7,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      // allows running single tests with the --grep flag
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
-
     // only smoke tests for chai here
     coverageIstanbulReporter: {
       thresholds: {

--- a/packages/generator-open-wc/generators/testing-karma-bs/templates/static/karma.es5.bs.config.js
+++ b/packages/generator-open-wc/generators/testing-karma-bs/templates/static/karma.es5.bs.config.js
@@ -7,12 +7,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
-
     browserStack: {
       ...baseConfig.browserStack,
       project: 'your-name',

--- a/packages/generator-open-wc/generators/testing-karma/templates/static/karma-test-loader.js
+++ b/packages/generator-open-wc/generators/testing-karma/templates/static/karma-test-loader.js
@@ -1,0 +1,4 @@
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);

--- a/packages/generator-open-wc/generators/testing-karma/templates/static/karma.conf.js
+++ b/packages/generator-open-wc/generators/testing-karma/templates/static/karma.conf.js
@@ -6,10 +6,5 @@ module.exports = (config) => {
 
   config.set({
     ...baseConfig,
-
-    files: [
-      // allows running single tests with the --grep flag
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
   });
 };

--- a/packages/semantic-dom-diff/karma-test-loader.js
+++ b/packages/semantic-dom-diff/karma-test-loader.js
@@ -1,0 +1,4 @@
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);

--- a/packages/semantic-dom-diff/karma.conf.js
+++ b/packages/semantic-dom-diff/karma.conf.js
@@ -7,11 +7,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      // allows running single tests with the --grep flag
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
-
     // TODO: not yet within the 90% default
     coverageIstanbulReporter: {
       thresholds: {

--- a/packages/semantic-dom-diff/karma.es5.bs.config.js
+++ b/packages/semantic-dom-diff/karma.es5.bs.config.js
@@ -7,12 +7,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
-
     browserStack: {
       ...baseConfig.browserStack,
       project: 'open-wc',

--- a/packages/testing-helpers/karma-test-loader.js
+++ b/packages/testing-helpers/karma-test-loader.js
@@ -1,0 +1,4 @@
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);

--- a/packages/testing-helpers/karma.conf.js
+++ b/packages/testing-helpers/karma.conf.js
@@ -6,11 +6,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      // allows running single tests with the --grep flag
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
-
     // TODO: not yet within the 90% default
     coverageIstanbulReporter: {
       thresholds: {

--- a/packages/testing-helpers/karma.es5.bs.config.js
+++ b/packages/testing-helpers/karma.es5.bs.config.js
@@ -7,12 +7,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
-
     browserStack: {
       ...baseConfig.browserStack,
       project: 'open-wc',

--- a/packages/testing-karma-bs/create-karma-es5-bs.config.js
+++ b/packages/testing-karma-bs/create-karma-es5-bs.config.js
@@ -24,8 +24,8 @@ if (!process.env.BROWSER_STACK_USERNAME || !process.env.BROWSER_STACK_ACCESS_KEY
  *
  * See demo/karma.es5.config.js for an example implementation.
  */
-module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+module.exports = (config, testDir, testFilePattern) => {
+  const baseConfig = createBaseConfig(config, testDir, testFilePattern);
 
   return {
     ...baseConfig,

--- a/packages/testing-karma-bs/demo/karma-test-loader.js
+++ b/packages/testing-karma-bs/demo/karma-test-loader.js
@@ -1,0 +1,4 @@
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);

--- a/packages/testing-karma-bs/demo/karma.conf.js
+++ b/packages/testing-karma-bs/demo/karma.conf.js
@@ -6,14 +6,9 @@ const createBaseConfig = require('@open-wc/testing-karma/create-karma-config');
  * to allow running individual tests.
  */
 module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+  const baseConfig = createBaseConfig(config, '/demo');
 
   config.set({
     ...baseConfig,
-
-    files: [
-      // allows running single tests with the --grep flag
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
   });
 };

--- a/packages/testing-karma-bs/demo/karma.es5.bs.config.js
+++ b/packages/testing-karma-bs/demo/karma.es5.bs.config.js
@@ -1,16 +1,10 @@
 const createBaseConfig = require('../create-karma-es5-bs.config');
 
 module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+  const baseConfig = createBaseConfig(config, '/demo');
 
   config.set({
     ...baseConfig,
-
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
 
     browserStack: {
       ...baseConfig.browserStack,

--- a/packages/testing-karma-bs/demo/karma.es5.config.js
+++ b/packages/testing-karma-bs/demo/karma.es5.config.js
@@ -6,15 +6,9 @@ const createBaseConfig = require('@open-wc/testing-karma/create-karma-es5.config
  * to allow running individual tests.
  */
 module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+  const baseConfig = createBaseConfig(config, '/demo');
 
   config.set({
     ...baseConfig,
-
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
   });
 };

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -45,7 +45,7 @@ This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 
 ### Manual setup
-For a minimal setup, extend the base config and specify where your tests are:
+1. Extend the base config and return it without modifying any options:
 
 ```javascript
 // filename: karma.conf.js
@@ -56,23 +56,26 @@ module.exports = (config) => {
 
   config.set({
     ...baseConfig,
-
-    files: [
-      // if --grep flag is set, run those tests instead
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
   });
 };
 ```
+
+2. Create a `karma-test-loader.js` next to your config file. This file should import all your tests. This is necessary for webpack to generate a single bundle, instead of a separate bundle per test.
+You could import all the tests manually or use webpack context to collect them dynamically:
+```javascript
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);
+```
+
 Add to your scripts: `"test": "karma start karma.conf.js"` and run your tests with: `npm run test`.
 
 ### Testing single files or folders
-By default karma runs all your test files. To test only a single file or folder, use the `--grep` flag. Make sure you are handling the grep option in your config, see the above example. Pass which files to test to the grep flag: `npm run test -- --grep test/foo/bar.test.js`.
-
-Grep supports file globs.
+By default karma runs all your test files. To test only a single file, use the `--grep` flag. Pass which file to test to the grep flag: `npm run test -- --grep test/foo/bar.test.js`.
 
 ### Watch mode
-Use `npm run test -- --auto-watch=true --single-run=false` to keep karma running. Any code changes will trigger a re-run of your tests.
+Use `npm run test -- --auto-watch=true --single-run=false` to keep karma running. Any code changes will trigger a re-run of your tests. You can add this to your scripts section: `"test:watch": "karma start karma.conf.js"`
 
 ### Debugging in the browser
 While testing, it can be useful to debug your tests in a real browser so that you can use the browser's dev tools.
@@ -96,13 +99,10 @@ module.exports = (config) => {
 
   config.set({
     ...baseConfig,
-
-    files: [
-      ...baseConfig.files,
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
   });
 };
 ```
+
+For full customization you can override the `files` property. You will need to make sure to load the necessary polyfills as well.
 
 Then run your tests with: `karma start karma.es5.config.js`

--- a/packages/testing-karma/create-karma-config.js
+++ b/packages/testing-karma/create-karma-config.js
@@ -5,90 +5,97 @@ const path = require('path');
  *
  * See demo/karma.conf.js for an example implementation.
  */
-module.exports = config => ({
-  browsers: [
-    'ChromeHeadlessNoSandbox',
-  ],
+module.exports = (config) => {
+  const testFile = config.grep ? config.grep : 'karma-test-loader.js';
 
-  customLaunchers: {
-    ChromeHeadlessNoSandbox: {
-      base: 'ChromeHeadless',
-      flags: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-      ],
-    },
-  },
+  return {
+    browsers: [
+      'ChromeHeadlessNoSandbox',
+    ],
 
-  frameworks: ['mocha'],
-
-  middleware: ['static'],
-
-  static: {
-    path: path.join(__dirname, ''),
-  },
-
-  preprocessors: {
-    '**/*.test.js': ['webpack', 'sourcemap'],
-    '**/*.spec.js': ['webpack', 'sourcemap'],
-  },
-
-  webpackMiddleware: {
-    stats: 'errors-only',
-  },
-
-  reporters: ['mocha', 'coverage-istanbul'],
-
-  mochaReporter: {
-    showDiff: true,
-  },
-
-  colors: true,
-
-  // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-  logLevel: config.LOG_INFO,
-
-  // ## code coverage config
-  coverageIstanbulReporter: {
-    reports: ['html', 'lcovonly', 'text-summary'],
-    dir: 'coverage',
-    combineBrowserReports: true,
-    skipFilesWithNoCoverage: true,
-    thresholds: {
-      global: {
-        statements: 90,
-        branches: 90,
-        functions: 90,
-        lines: 90,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+        ],
       },
     },
-  },
 
-  webpack: {
-    devtool: 'inline-source-map',
-    mode: 'development',
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          loader: 'istanbul-instrumenter-loader',
-          enforce: 'post',
-          include: path.resolve('./'),
-          exclude: /node_modules|bower_components|\.test\.js$/,
-          options: {
-            esModules: true,
-          },
-        },
+    files: [
+      testFile,
+    ],
 
-        {
-          test: /\.js$/,
-          loader: require.resolve('@open-wc/webpack/loaders/import-meta-url-loader.js'),
-        },
-      ],
+    frameworks: ['mocha'],
+
+    middleware: ['static'],
+
+    static: {
+      path: path.join(__dirname, ''),
     },
-  },
 
-  autoWatch: false,
-  singleRun: true,
-  concurrency: Infinity,
-});
+    preprocessors: {
+      [testFile]: ['webpack', 'sourcemap'],
+    },
+
+    webpackMiddleware: {
+      stats: 'errors-only',
+    },
+
+    reporters: ['mocha', 'coverage-istanbul'],
+
+    mochaReporter: {
+      showDiff: true,
+    },
+
+    colors: true,
+
+    // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // ## code coverage config
+    coverageIstanbulReporter: {
+      reports: ['html', 'lcovonly', 'text-summary'],
+      dir: 'coverage',
+      combineBrowserReports: true,
+      skipFilesWithNoCoverage: true,
+      thresholds: {
+        global: {
+          statements: 90,
+          branches: 90,
+          functions: 90,
+          lines: 90,
+        },
+      },
+    },
+
+    webpack: {
+      devtool: 'inline-source-map',
+      mode: 'development',
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            loader: 'istanbul-instrumenter-loader',
+            enforce: 'post',
+            include: path.resolve('./'),
+            exclude: /node_modules|bower_components|\.test\.js$/,
+            options: {
+              esModules: true,
+            },
+          },
+
+          {
+            test: /\.js$/,
+            loader: require.resolve('@open-wc/webpack/loaders/import-meta-url-loader.js'),
+          },
+        ],
+      },
+    },
+
+    autoWatch: false,
+    singleRun: true,
+    concurrency: Infinity,
+  };
+};

--- a/packages/testing-karma/create-karma-es5.config.js
+++ b/packages/testing-karma/create-karma-es5.config.js
@@ -10,15 +10,17 @@ const createBaseConfig = require('./create-karma-config');
  *
  * See demo/karma.es5.config.js for an example implementation.
  */
-module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+module.exports = (config, testDir, testFilePattern) => {
+  const baseConfig = createBaseConfig(config, testDir, testFilePattern);
 
   return {
     ...baseConfig,
+
     files: [
       { pattern: require.resolve('@babel/polyfill/browser'), watched: false },
       { pattern: require.resolve('@webcomponents/webcomponentsjs/custom-elements-es5-adapter'), watched: false },
       { pattern: require.resolve('@webcomponents/webcomponentsjs/webcomponents-bundle'), watched: false },
+      ...baseConfig.files,
     ],
 
     webpack: {

--- a/packages/testing-karma/demo/karma-test-loader.js
+++ b/packages/testing-karma/demo/karma-test-loader.js
@@ -1,0 +1,4 @@
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);

--- a/packages/testing-karma/demo/karma.conf.js
+++ b/packages/testing-karma/demo/karma.conf.js
@@ -6,14 +6,9 @@ const createBaseConfig = require('../create-karma-config');
  * to allow running individual tests.
  */
 module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+  const baseConfig = createBaseConfig(config, '/demo/test');
 
   config.set({
     ...baseConfig,
-
-    files: [
-      // allows running single tests with the --grep flag
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
   });
 };

--- a/packages/testing-karma/demo/karma.es5.bs.config.js
+++ b/packages/testing-karma/demo/karma.es5.bs.config.js
@@ -13,16 +13,10 @@ if (!process.env.BROWSER_STACK_USERNAME || !process.env.BROWSER_STACK_ACCESS_KEY
 }
 
 module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+  const baseConfig = createBaseConfig(config, '/demo/test');
 
   config.set({
     ...baseConfig,
-
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
 
     browserStack: {
       username: process.env.BROWSER_STACK_USERNAME,

--- a/packages/testing-karma/demo/karma.es5.config.js
+++ b/packages/testing-karma/demo/karma.es5.config.js
@@ -6,15 +6,9 @@ const createBaseConfig = require('../create-karma-es5.config');
  * to allow running individual tests.
  */
 module.exports = (config) => {
-  const baseConfig = createBaseConfig(config);
+  const baseConfig = createBaseConfig(config, '/demo/test');
 
   config.set({
     ...baseConfig,
-
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
   });
 };

--- a/packages/testing-karma/karma-test-loader.js
+++ b/packages/testing-karma/karma-test-loader.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+// Imports all test files for webpack to generate one single test bundle
+const testsContext = require.context(__WEBPACK_INJECTED_TEST_DIR__, true, __WEBPACK_INJECTED_TEST_FILE_PATTERN__);
+testsContext.keys().forEach(testsContext)

--- a/packages/testing/karma-test-loader.js
+++ b/packages/testing/karma-test-loader.js
@@ -1,0 +1,4 @@
+// Imports all test files for webpack to generate one single test bundle.
+// First parameter is the test folder, third paramter is a regexp to match the file against
+const testsContext = require.context('./test', true, /.test$/);
+testsContext.keys().forEach(testsContext);

--- a/packages/testing/karma.conf.js
+++ b/packages/testing/karma.conf.js
@@ -7,11 +7,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      // allows running single tests with the --grep flag
-      config.grep ? config.grep : 'test/**/*.test.js',
-    ],
-
     // is a meta package with with just some smoke tests
     coverageIstanbulReporter: {
       thresholds: {

--- a/packages/testing/karma.es5.bs.config.js
+++ b/packages/testing/karma.es5.bs.config.js
@@ -7,12 +7,6 @@ module.exports = (config) => {
   config.set({
     ...baseConfig,
 
-    files: [
-      ...baseConfig.files,
-      // allows running single tests with the --grep flag
-      config.grep ? [config.grep] : 'test/**/*.test.js',
-    ],
-
     browserStack: {
       ...baseConfig.browserStack,
       project: 'open-wc',


### PR DESCRIPTION
This fixes the issue of karma-webpack creating a separate bundle per test file.

I think that configs should have smart defaults, but still be overrideable and understandable. I iterated over different solutions, but couldn't find a good solution that covers these. At it's core, this is a bug in karma-webpack, so we should look into whether we can fix it on their side.

With this approach, by default all files in the `/test` folder ending with `.test` are run. It can be overwritten through by parameters to the config function (can't do it through the files property). Consumers can also opt out entirely by setting their own files property.