### PR TITLE
fix: remove deprecated flush

### DIFF
--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -71,16 +71,15 @@ expect(el.bar).to.equal('baz');
 ```
 
 ## Timings
-If you need to wait for multiple elements to update you can use flush.  
-By default it will be a timeout of 2ms but it will use a `window.flush` method if set.
+If you need to wait for multiple elements to update you can use `nextFrame`.  
 
 ```js
-import { flush, aTimeout, html, litFixture } from '@open-wc/testing-helpers';
+import { nextFrame, aTimeout, html, litFixture } from '@open-wc/testing-helpers';
 
 const el = await litFixture(html`<my-el .foo=${'bar'}></my-el>`);
 expect(el.foo).to.equal('bar');
 el.foo = 'baz';
-await flush();
+await nextFrame();
 // or as an alternative us timeout
 // await aTimeout(10); // would wait 10ms
 expect(el.shadowRoot.querySelector('#foo').innerText).to.equal('baz');

--- a/packages/testing-helpers/helpers.js
+++ b/packages/testing-helpers/helpers.js
@@ -88,24 +88,3 @@ export async function oneEvent(element, eventName) {
 export async function nextFrame() {
   return new Promise(resolve => requestAnimationFrame(resolve));
 }
-
-/**
- * DEPRECATED:
- * Only useful with WCT pls use nextFrame as an alternative.
- * If used not within WCT it will fallback to a timout of 2ms.
- *
- * @returns {Promise<void>}
- */
-export async function flush() {
-  return new Promise(resolve => {
-    if (window.flush) {
-      window.flush(() => {
-        resolve();
-      });
-    } else {
-      setTimeout(() => {
-        resolve();
-      }, 2);
-    }
-  });
-}


### PR DESCRIPTION
Removes flush from the docs at https://open-wc.org/recommendations/testing-helpers.html#timings