### PR TITLE
Typo / Grammar fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,5 +35,5 @@ Open WC uses [commitlint](https://github.com/marionebl/commitlint) to standardiz
 Open WC uses package name as scope. So for example if you fix a *terrible bug* in the package `@open-wc/testing`, the commit message should look like this:
 
 ```
-fix(testing) fix terrible bug
+fix(testing): fix terrible bug
 ```

--- a/packages/generator-open-wc/README.md
+++ b/packages/generator-open-wc/README.md
@@ -26,14 +26,24 @@ npx -p yo -p generator-open-wc -c 'yo open-wc:{generator-name}'
 
 ## Available generators
 
+### Primary entry points
 - open-wc:vanilla
-  - open-wc:vanilla-bare
-  - open-wc:lint-eslint
-  - open-wc:publish-storybook
-  - open-wc:testing-bare
-  - open-wc:testing-karma
-  - open-wc:testing-karma-bs
-  - open-wc:tools-circleci
+- open-wc:lint
+- open-wc:testing
+- open-wc:testing-upgrade
+- open-wc:publish-storybook
+
+### Optional entry points
 - open-wc:testing-wallaby
+
+### Sub generators
+- open-wc:vanilla-bare
+- open-wc:lint-eslint
+- open-wc:lint-prettier
+- open-wc:lint-commitlint
+- open-wc:testing-bare
+- open-wc:testing-karma
+- open-wc:testing-karma-bs
+- open-wc:tools-circleci
 
 For what they actually do please see the details for each system at [open-wc](https://open-wc.org/)

--- a/packages/generator-open-wc/README.md
+++ b/packages/generator-open-wc/README.md
@@ -10,7 +10,7 @@ We want to provide a good set of defaults on how to facilitate your web componen
 
 ## Usage
 
-This generator is based on [yeoman](http://yeoman.io/). To us it you have 2 ways.
+This generator is based on [yeoman](http://yeoman.io/). You can use it in two ways.
 
 ```bash
 npm i -g yeoman


### PR DESCRIPTION
Fixed a typo in the contributing.md and a grammar issue in the generator-open-wc section.
Added and categorized the generators