### PR TITLE
Vanilla generator to compose with lint instead of just lint-eslint

### DIFF
--- a/packages/generator-open-wc/generators/vanilla/index.js
+++ b/packages/generator-open-wc/generators/vanilla/index.js
@@ -9,7 +9,7 @@ module.exports = class GeneratorVanilla extends Generator {
 
   default() {
     this.composeWith(require.resolve('../vanilla-bare'), this.config.getAll());
-    this.composeWith(require.resolve('../lint-eslint'), this.config.getAll());
+    this.composeWith(require.resolve('../lint'), this.config.getAll());
     this.composeWith(require.resolve('../publish-storybook'), this.config.getAll());
     // this.composeWith(require.resolve('../publish-vuepress'), this.config.getAll());
     this.composeWith(require.resolve('../testing-bare'), this.config.getAll());

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -165,4 +165,9 @@ Lines        : 100% ( 8/8 )
 ================================================================================
 ```
 
+::: tip Note
+Make sure you have chrome (or chromium) installed.
+Additionally you may need to set your CHROME_BIN env variable `export CHROME_BIN=/usr/bin/chromium-browser` if you get an error.
+::::
+
 For some real tests look at our [Set-Game Example Test Files](https://github.com/open-wc/example-vanilla-set-game/tree/master/test).


### PR DESCRIPTION
See title. I also added a note in the testing readme about chrome browser pre-requisite.