### PR TITLE
fix: unify npm readme header for all open-wc packages

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -120,4 +120,10 @@ module.exports = {
     ['meta', { name: 'twitter:card', content: 'summary' }],
     ['meta', { name: 'twitter:title', content: 'Open Web Components' }],
   ],
+  // temporary set to develop mode as Terser seems to have a problem :/
+  configureWebpack: (config, isServer) => {
+    if (!isServer) {
+      config.mode = 'development';
+    }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@commitlint/config-conventional": "7.1.2",
     "@commitlint/config-lerna-scopes": "7.2.1",
     "@vuepress/plugin-google-analytics": "^1.0.0-alpha.30",
+    "eslint": "^5.13.0",
     "eslint-config-prettier": "^3.3.0",
     "husky": "1.1.2",
     "lerna": "3.4.3",

--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -1,12 +1,6 @@
 # Webpack
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 ## Default configuration
 We provide default configuration to help you get started building your web component project with webpack.

--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -136,3 +136,15 @@ module.exports = merge(defaultConfig, {
 We recommend extending the config only to make small additions.
 If your configuration deviates too much from our default setup, simply copy paste what we have and use it as a starting point.
 It will keep your configuration easier to understand.
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/building-webpack/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/building-webpack/package.json
+++ b/packages/building-webpack/package.json
@@ -13,7 +13,8 @@
     "start": "webpack-dev-server --mode development --config demo/webpack.config.js --open",
     "start:es5": "webpack-dev-server --mode development --config demo/webpack.config.js --es5 --open",
     "build": "webpack --mode production --config demo/webpack.config.js",
-    "build:stats": "webpack --mode production --config demo/webpack.config.js --profile --json > build-stats.json"
+    "build:stats": "webpack --mode production --config demo/webpack.config.js --profile --json > build-stats.json",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "keywords": [
     "open-wc",

--- a/packages/chai-dom-equals/README.md
+++ b/packages/chai-dom-equals/README.md
@@ -71,5 +71,16 @@ it('literally equals', () => {
   expect(outerHTML).to.equal(`<${tag}></${tag}>`);
   expect(innerHTML).to.equal('<p>  shadow content</p> <!-- comment --> <slot></slot>');
 });
-
 ```
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/chai-dom-equals/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/chai-dom-equals/README.md
+++ b/packages/chai-dom-equals/README.md
@@ -1,16 +1,10 @@
 # Testing Chai Dom Equals
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 Usually, you don't want to literally compare dom when testing your Web Components. Additionally, when using ShadyDOM and/or ShadyCSS there will be additional classes you are not interested in. This package provides a solution for that problem.
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/chai-dom-equals/package.json
+++ b/packages/chai-dom-equals/package.json
@@ -14,7 +14,8 @@
     "test:watch": "karma start --auto-watch=true --single-run=false",
     "test:es5": "karma start karma.es5.config.js",
     "test:es5:watch": "karma start karma.es5.config.js --auto-watch=true --single-run=false",
-    "test:es5:bs": "karma start karma.es5.bs.config.js"
+    "test:es5:bs": "karma start karma.es5.bs.config.js",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "dependencies": {
     "@open-wc/semantic-dom-diff": "^0.7.7",

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,12 +1,6 @@
 # Linting ESLint
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 Use [ESLint](https://eslint.org/) to lint your es6 code.
 
@@ -18,7 +12,7 @@ npm i -g generator-open-wc
 yo open-wc:linting-eslint
 ```
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -43,3 +43,15 @@ This will install `@open-wc/eslint-config`, a config based on airbnb but allows 
 Run:
 - `npm run lint:eslint` to check if any file is not correctly formatted
 - `npm run format:eslint` to auto format your files
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/eslint-config/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,6 +10,9 @@
   },
   "repository": "https://github.com/open-wc/open-wc/tree/master/packages/eslint-config",
   "main": "index.js",
+  "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js"
+  },
   "dependencies": {
     "babel-eslint": "^10.0.0",
     "eslint": "^5.0.0",

--- a/packages/generator-open-wc/README.md
+++ b/packages/generator-open-wc/README.md
@@ -1,12 +1,6 @@
 # Generator Open WC
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 ## Usage
 

--- a/packages/generator-open-wc/README.md
+++ b/packages/generator-open-wc/README.md
@@ -171,3 +171,14 @@ You can use these generators if you already have an existing project that you wo
 - `yo open-wc:automating-circleci`<br>
   This generator adds continuous integration with CircleCi to your existing project.
 
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/generator-open-wc/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/generator-open-wc/package.json
+++ b/packages/generator-open-wc/package.json
@@ -10,6 +10,9 @@
     "yeoman-generator",
     "open-wc"
   ],
+  "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js"
+  },
   "dependencies": {
     "glob": "^7.0.0",
     "yeoman-generator": "^3.0.0"

--- a/packages/owc-dev-server/README.md
+++ b/packages/owc-dev-server/README.md
@@ -20,7 +20,7 @@ Note: import paths are only resolved within `.js` files. This means you cannot d
 ```html
 <html>
   <head>
-    <script type="module">
+    <script>
       import { html } from 'lit-html'; // does not work
     </script>
   </head>
@@ -92,3 +92,15 @@ npx owc-dev-server --app-index demo/index.html --open
 |--root-dir|-r|string|The root directory to serve files from. Defaults to the project root.|
 |--modules-dir|-m|string|Directory to resolve modules from. Default: node_modules|
 |--help|none|none|See all options|
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/owc-dev-server/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/owc-dev-server/README.md
+++ b/packages/owc-dev-server/README.md
@@ -1,12 +1,6 @@
 # Dev server
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 A simple web server for simple web developers. Does the minimal amount of work required for web development on modern web browsers. Specifically designed to work with the native es module loader available in all major browsers.
 

--- a/packages/owc-dev-server/package.json
+++ b/packages/owc-dev-server/package.json
@@ -13,7 +13,8 @@
     "access": "public"
   },
   "scripts": {
-    "start": "./owc-dev-server.js -o demo --app-index demo/index.html"
+    "start": "./owc-dev-server.js -o demo --app-index demo/index.html",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "repository": "https://github.com/open-wc/open-wc/tree/master/packages/dev-server",
   "dependencies": {

--- a/packages/polyfills-loader/README.md
+++ b/packages/polyfills-loader/README.md
@@ -41,3 +41,15 @@ The webcomponent polyfill requires:
 - Symbol
 
 Make sure the required polyfills are loaded before calling the loader. If you configure babel to load these polyfills on usage, this is done automatically.
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/polyfills-loader/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/polyfills-loader/README.md
+++ b/packages/polyfills-loader/README.md
@@ -1,12 +1,6 @@
 # Polyfills loader
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 A modern loader for the web components polyfills.
 

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -15,6 +15,9 @@
     "polyfill",
     "web-components"
   ],
+  "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js"
+  },
   "dependencies": {
     "@bundled-es-modules/url-polyfill": "^1.1.3",
     "@webcomponents/custom-elements": "^1.2.1",

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,16 +1,10 @@
 # Linting Prettier
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 Use [Prettier](https://prettier.io) to format your JS, CSS and HTML code.
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -67,3 +67,15 @@ test/set-game.test.js
 ```
 
 Simply run `npm run format:prettier` to format your files automatically.
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/prettier-config/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -10,6 +10,9 @@
   },
   "repository": "https://github.com/open-wc/open-wc/tree/master/packages/prettier-config",
   "main": "prettier.config.js",
+  "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js"
+  },
   "dependencies": {
     "eslint-config-prettier": "^3.3.0",
     "prettier": "^1.15.0"

--- a/packages/semantic-dom-diff/README.md
+++ b/packages/semantic-dom-diff/README.md
@@ -1,12 +1,6 @@
 # Semantic Dom Diff
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-We want to provide a good set of default on how to facilitate your web component.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 ## Manual Setup
 ```bash

--- a/packages/semantic-dom-diff/README.md
+++ b/packages/semantic-dom-diff/README.md
@@ -22,3 +22,15 @@ const rightTree = `
 // Diff will be an object if there is a difference, otherwise undefined
 const diff = getSemanticDomDiff(leftTree, rightTree);
 ```
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/semantic-dom-diff/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/semantic-dom-diff/package.json
+++ b/packages/semantic-dom-diff/package.json
@@ -14,7 +14,8 @@
     "test:es5:bs": "karma start karma.es5.bs.config.js",
     "test:watch": "karma start --auto-watch=true --single-run=false",
     "test:es5": "karma start karma.es5.config.js",
-    "test:es5:watch": "karma start karma.es5.config.js --auto-watch=true --single-run=false"
+    "test:es5:watch": "karma start karma.es5.config.js --auto-watch=true --single-run=false",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "dependencies": {
     "@bundled-es-modules/diffable-html": "^4.0.0-rc.2",

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -40,3 +40,15 @@ npm run storybook:start
 ## Example
 The [Set-Game Example](https://github.com/open-wc/example-vanilla-set-game/) has the default publishing via storybook on netlify.
 You can see the finished page at: [https://example-set-game-open-wc.netlify.com/](https://example-set-game-open-wc.netlify.com/).
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/storybook/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -4,7 +4,7 @@
 
 For demoing and showcasing different states of your Web Component, we recommend using [storybook](https://storybook.js.org/).
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -1,16 +1,10 @@
 # Testing Helpers
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 In order to efficiently test Web Components you will need some helpers to register and instantiate them for you.
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -95,3 +95,15 @@ afterEach(() => {
   fixtureCleanup();
 });
 ```
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/testing-helpers/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -14,7 +14,8 @@
     "test:watch": "karma start --auto-watch=true --single-run=false",
     "test:es5": "karma start karma.es5.config.js",
     "test:es5:watch": "karma start karma.es5.config.js --auto-watch=true --single-run=false",
-    "test:es5:bs": "karma start karma.es5.bs.config.js"
+    "test:es5:bs": "karma start karma.es5.bs.config.js",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "peerDependencies": {
     "lit-html": "^0.12.0"

--- a/packages/testing-karma-bs/README.md
+++ b/packages/testing-karma-bs/README.md
@@ -54,3 +54,15 @@ echo "Key: $BROWSER_STACK_ACCESS_KEY"
 ```bash
 npm run test:es5:bs
 ```
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/testing-karma-bs/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/testing-karma-bs/README.md
+++ b/packages/testing-karma-bs/README.md
@@ -1,12 +1,6 @@
 # Testing via Browserstack
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 This will run your local test via Browserstack browsers/devices.
 You will need to have a Browserstack automate account.
@@ -15,7 +9,7 @@ Using:
 - Karma via `@open-wc/testing-karma`
 - Testing via [Browserstack](https://www.browserstack.com/) via [karma-browserstack-launcher](https://github.com/karma-runner/karma-browserstack-launcher)
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/testing-karma-bs/package.json
+++ b/packages/testing-karma-bs/package.json
@@ -13,7 +13,8 @@
     "test": "karma start demo/karma.conf.js",
     "test:watch": "karma start demo/karma.conf.js --auto-watch=true --single-run=false",
     "test:es5": "karma start demo/karma.es5.config.js",
-    "test:es5:bs": "karma start demo/karma.es5.bs.config.js"
+    "test:es5:bs": "karma start demo/karma.es5.bs.config.js",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "dependencies": {
     "@open-wc/testing-karma": "^0.4.8",

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -113,3 +113,15 @@ module.exports = config => {
 ```
 
 Then run your tests with: `karma start karma.es5.config.js`
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/testing-karma/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -1,12 +1,6 @@
 # Testing with Karma
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 ## Browser testing
 Web Components are at the cutting edge of browser support. Testing solutions that run a simulated browser are often not suitable due to missing features. We therefore recommend running tests in a real browser. With headless Chrome and Firefox this is very convenient to set up and use, and will give more testing confidence as you can run the same tests across multiple browsers.
@@ -43,7 +37,7 @@ npm i -g generator-open-wc
 yo open-wc:testing-karma
 ```
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/testing-karma/package.json
+++ b/packages/testing-karma/package.json
@@ -13,7 +13,8 @@
     "test": "karma start demo/karma.conf.js",
     "test:watch": "karma start demo/karma.conf.js --auto-watch=true --single-run=false",
     "test:es5": "karma start demo/karma.es5.config.js",
-    "test:es5:bs": "karma start demo/karma.es5.bs.config.js"
+    "test:es5:bs": "karma start demo/karma.es5.bs.config.js",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "dependencies": {
     "@babel/core": "^7.1.6",

--- a/packages/testing-wallaby/README.md
+++ b/packages/testing-wallaby/README.md
@@ -1,12 +1,6 @@
 # Testing in IDE via Wallaby
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 Wallaby.js is a Plugin for your IDE and runs tests in real time while you are typing.
 

--- a/packages/testing-wallaby/README.md
+++ b/packages/testing-wallaby/README.md
@@ -24,3 +24,15 @@ Open your wallaby.js supported IDE and start with the provided config.
 
 ## Example
 The [Set-Game Example](https://github.com/open-wc/example-vanilla-set-game/) has Wallaby Setup.
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/testing-wallaby/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/testing-wallaby/package.json
+++ b/packages/testing-wallaby/package.json
@@ -9,6 +9,9 @@
     "access": "public"
   },
   "repository": "https://github.com/open-wc/open-wc/tree/master/packages/testing-wallaby",
+  "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js"
+  },
   "dependencies": {
     "wallaby-webpack": "^3.0.0",
     "webpack": "^4.0.0"

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,12 +1,6 @@
 # Testing
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your Web Component. Our recommendations include: developing, linting, testing, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 We believe that testing is fundamental to every production-ready product.
 
@@ -18,7 +12,7 @@ Using:
   - Plugin [chai-dom-equals](https://www.npmjs.com/package/@open-wc/chai-dom-equals)
 - Mocks via [sinon](https://sinonjs.org/)
 
-::: tip Info
+::: tip
 This is part of the default [open-wc](https://open-wc.org/) recommendation
 :::
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -182,3 +182,15 @@ afterEach(() => {
   fixtureCleanup();
 });
 ```
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/testing/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -15,7 +15,8 @@
     "test:demo": "karma start demo/karma.conf.js",
     "test:es5": "karma start karma.es5.config.js",
     "test:es5:watch": "karma start karma.es5.config.js --auto-watch=true --single-run=false",
-    "test:es5:bs": "karma start karma.es5.bs.config.js"
+    "test:es5:bs": "karma start karma.es5.bs.config.js",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "dependencies": {
     "@bundled-es-modules/chai": "^4.2.0",

--- a/packages/webpack-import-meta-loader/README.md
+++ b/packages/webpack-import-meta-loader/README.md
@@ -1,12 +1,6 @@
 # Webpack Helpers
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your Web Component. Our recommendations include: developing, linting, testing, tooling, demoing, publishing and automating.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 If you need support to use `import.meta` within webpack this is a minimal loader to support it.
 

--- a/packages/webpack-import-meta-loader/README.md
+++ b/packages/webpack-import-meta-loader/README.md
@@ -27,3 +27,15 @@ module: {
   ],
 },
 ```
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/webpack-import-meta-loader/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/webpack-import-meta-loader/package.json
+++ b/packages/webpack-import-meta-loader/package.json
@@ -12,7 +12,8 @@
   "repository": "https://github.com/open-wc/open-wc/tree/master/packages/webpack-import-meta-loader",
   "scripts": {
     "test": "mocha --require @babel/register",
-    "test:ci": "npm run test"
+    "test:ci": "npm run test",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "devDependencies": {
     "@babel/register": "^7.0.0",

--- a/packages/webpack-import-meta-loader/test/compiler.js
+++ b/packages/webpack-import-meta-loader/test/compiler.js
@@ -4,6 +4,7 @@ import MemoryFs from 'memory-fs';
 
 export default (fixture, rules = [{}]) => {
   const compiler = webpack({
+    mode: 'development',
     context: __dirname,
     entry: `./${fixture}`,
     output: {

--- a/packages/webpack-import-meta-loader/test/webpack-import-meta-loader.test.js
+++ b/packages/webpack-import-meta-loader/test/webpack-import-meta-loader.test.js
@@ -34,8 +34,8 @@ describe('import-meta-url-loader', () => {
 
   it('Replaces nested instances of import.meta', async () => {
     const stats = await compiler('caseB/index.js', rules);
-    const caseB = stats.toJson().modules[0].source;
-    const caseBsub = stats.toJson().modules[1].source;
+    const caseB = stats.toJson().modules[1].source;
+    const caseBsub = stats.toJson().modules[0].source;
 
     expect(caseB).to.equal(
       '' +

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -1,12 +1,6 @@
 # Webpack Helpers
 
-> Part of Open Web Component Recommendation [open-wc](https://github.com/open-wc/open-wc/)
-
-We want to provide a good set of defaults on how to facilitate your web component.
-
-[![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
-[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
 
 If you need support to use `import.meta.url` within webpack this is a minimal loader to support it.
 

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -11,7 +11,8 @@
   "repository": "https://github.com/open-wc/open-wc/tree/master/packages/webpack",
   "scripts": {
     "test": "mocha --require @babel/register",
-    "test:ci": "npm run test"
+    "test:ci": "npm run test",
+    "prepublishOnly": "../../scripts/insert-header.js"
   },
   "devDependencies": {
     "@babel/register": "^7.0.0",

--- a/packages/webpack/test/compiler.js
+++ b/packages/webpack/test/compiler.js
@@ -4,6 +4,7 @@ import MemoryFs from 'memory-fs';
 
 export default (fixture, rules = [{}]) => {
   const compiler = webpack({
+    mode: 'development',
     context: __dirname,
     entry: `./${fixture}`,
     output: {

--- a/packages/webpack/test/import-meta-url-loader.test.js
+++ b/packages/webpack/test/import-meta-url-loader.test.js
@@ -34,8 +34,8 @@ describe('import-meta-url-loader', () => {
 
   it('Replaces nested instances of import.meta', async () => {
     const stats = await compiler('caseB/index.js', rules);
-    const caseB = stats.toJson().modules[0].source;
-    const caseBsub = stats.toJson().modules[1].source;
+    const caseB = stats.toJson().modules[1].source;
+    const caseBsub = stats.toJson().modules[0].source;
 
     expect(caseB).to.equal(
       '' +

--- a/scripts/insert-header.js
+++ b/scripts/insert-header.js
@@ -10,7 +10,7 @@ function escapeRegExp(text) {
 const filePath = `${process.cwd()}/README.md`;
 const findPattern = escapeRegExp('[//]: # (AUTO INSERT HEADER PREPUBLISH)');
 const text = `
-> Part of Open Web Components [open-wc](https://github.com/open-wc/open-wc/)
+> Part of [Open Web Components](https://github.com/open-wc/open-wc/)
 
 Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
 


### PR DESCRIPTION
fixes https://github.com/open-wc/open-wc/issues/157 by adding the header only on prePublish

I tested it with the storybook package:
- visible: 
  - npmjs: https://www.npmjs.com/package/@open-wc/storybook
- not visible:
  - Github: https://github.com/open-wc/open-wc/tree/master/packages/storybook
  - open-wc.org: https://open-wc.org/demoing/

this applies the same solution to all of our packages

fixes https://github.com/open-wc/open-wc/issues/166 by manually updating the edit urls for docs that are symlinked 