### PR TITLE
fix(building-webpack): improve setup docu to minify user errors

### DIFF
--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -10,7 +10,7 @@ To set up the default configuration manually:
 
 1. Install the required dependencies:
 ```bash
-npm i -D @open-wc/building-webpack webpack webpack-dev-server http-server
+npm i -D @open-wc/building-webpack webpack webpack-cli webpack-dev-server http-server
 ```
 
 2. Create a file `webpack.config.js`:
@@ -21,7 +21,42 @@ const defaultConfig = require('@open-wc/building-webpack/default-config');
 module.exports = defaultConfig();
 ```
 
-3. Add the following commands to your `package.json`:
+The default configuration assumes default locations for your app's HTML and JavaScript entrypoints.
+Youll add these files in steps 3 and 4. If you're adding webpack to an existing project, you may 
+need to change the default entrypoints—see [Changing the default entrypoints](#changing-the-default-entrypoints).
+
+
+3. Create an `index.html`:
+```html
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <your-app></your-app>
+  </body>
+</html>
+```
+
+Note that the `index.html` file doesn't reference the JavaScript file—webpack will add a `<script>` tag when it builds your project. Also note that webpack does **not** process inline script tags, like:
+
+```html
+<script>
+  import { MyApp } from './src/my-app.js';
+</script>
+```
+
+4. Create a `index.js` which kickstarts your JS code.
+For older browsers we need to load the web component polyfills. We use the [polyfills-loader](https://open-wc.org/building/polyfills-loader.html) for that:
+
+```javascript
+import loadPolyfills from '@open-wc/polyfills-loader';
+
+loadPolyfills().then(() => {
+  import('./my-app.js');
+});
+```
+
+5. Add the following commands to your `package.json`:
 ```json
 {
   "scripts": {
@@ -39,29 +74,8 @@ module.exports = defaultConfig();
 - `start:build` runs your built app using a plain web server, to prove it works without magic :)
 - `build:stats` creates an analysis report of your app bundle to be consumed by Webpack [Visualizer](https://chrisbateman.github.io/webpack-visualizer/) and [Analyser](https://webpack.github.io/analyse/)
 
-4. Create an `index.html`:
-```html
-<!doctype html>
-<html>
-  <head></head>
-  <body>
-    <your-app></your-app>
-  </body>
-</html>
-```
+### Changing the default entrypoints
 
-5. Create a `index.js` which kickstarts your JS code.
-For older browser we need to load the web component polyfills. We use the [polyfills-loader](https://open-wc.org/building/polyfills-loader.html) for that:
-
-```javascript
-import loadPolyfills from '@open-wc/polyfills-loader';
-
-loadPolyfills().then(() => {
-  import('./my-app.js');
-});
-```
-
-### Notes
 You can change the default `index.html` and `index.js` files:
 
 ```javascript


### PR DESCRIPTION
Added notes to avoid problems I ran into as a Polymer CLI user using webpack for the first time.

Also moved the npm scripts to the last step. When I hit this part of the instructions, I immediately tried running the scripts, which failed because the necessary HTML and JS files weren't set up yet. Moving this step to the end prevents this user error.

Changed one header to make it more descriptive.

I'd suggest also adding a note (either in Step 4 above or in Change the default entrypoints) describing what to do if you have more than one HTML/JS entrypoint. I'd have done that but for my complete ignorance (Can indexJS take an array? Or do they need to go to the method described in "Customizing the configuration"? Can you pass a config object with indexHTML/indexJS to createDefaultConfig?)