### PR TITLE
fix(building-webpack): defaultOptions indexJS is not an array

### DIFF
--- a/packages/building-webpack/default-config.js
+++ b/packages/building-webpack/default-config.js
@@ -9,7 +9,7 @@ const developmentEs5 = !!process.argv.find(arg => arg.includes('es5'));
 
 const defaultOptions = {
   indexHTML: './index.html',
-  indexJS: ['./index.js'],
+  indexJS: './index.js',
 };
 
 const es6Target = {


### PR DESCRIPTION
closes https://github.com/open-wc/open-wc/issues/187