### PR TITLE
fix(testing-helpers): add `await elementUpdated(el)` supports stencil

### DIFF
--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -64,18 +64,37 @@ expect(el.bar).to.equal('baz');
 ```
 
 ## Timings
-If you need to wait for multiple elements to update you can use `nextFrame`.  
+By default fixture awaits the elements "update complete" Promise.
+- for [lit-element](https://github.com/polymer/lit-element) that is `el.updateComplete`;
+- for [stencil](https://github.com/ionic-team/stencil/) that is `el.componentOnReady()`;
 
+If none of those specfic Promise hooks are found, it will wait for one frame via `await nextFrame()`.<br>
+**Note**: this does not guarantee that the element is done rendering - it just waits for the next JavaScript tick.
+
+Essentially, `fixture` creates a synchronous fixture, then waits for the element to finish updating, checking `updateComplete` first, then falling back to `componentReady()`, and `nextFrame()` as a last resort.
+
+This way, you can write your tests more succinctly, without having to explicitly `await` those hooks yourself.
 ```js
-import { nextFrame, aTimeout, html, fixture } from '@open-wc/testing-helpers';
-
 const el = await fixture(html`<my-el .foo=${'bar'}></my-el>`);
 expect(el.foo).to.equal('bar');
-el.foo = 'baz';
+
+// vs
+
+const el = fixtureSync(html`<my-el .foo=${'bar'}></my-el>`);
+await elementUpdated(el);
+expect(el.foo).to.equal('bar');
+```
+
+### nextFrame
+Uses `requestAnimationFrame` to wait for the next frame.
+```js
 await nextFrame();
-// or as an alternative us timeout
-// await aTimeout(10); // would wait 10ms
-expect(el.shadowRoot.querySelector('#foo').innerText).to.equal('baz');
+```
+
+### aTimeout
+Waits for `x` ms via `setTimeout`;
+```js
+await aTimeout(10); // would wait 10ms
 ```
 
 ## Fixture Cleanup

--- a/packages/testing-helpers/elementUpdated.js
+++ b/packages/testing-helpers/elementUpdated.js
@@ -1,0 +1,33 @@
+import { nextFrame } from './helpers.js';
+
+const isDefinedPromise = action => typeof action === 'object' && Promise.resolve(action) === action;
+
+/**
+ * Awaits for "update complete promises" of elements
+ * - updateComplete [lit-element]
+ * - componentOnReady() [stencil]
+ *
+ * If none of these is available we await the next frame.
+ *
+ * @param {HTMLElement} el
+ * @returns {Promise<Element>}
+ */
+export async function elementUpdated(el) {
+  let hasSpecificAwait = false;
+  let update = el.updateComplete;
+  if (isDefinedPromise(update)) {
+    await update;
+    hasSpecificAwait = true;
+  }
+
+  update = el.componentOnReady ? el.componentOnReady() : false;
+  if (isDefinedPromise(update)) {
+    await update;
+    hasSpecificAwait = true;
+  }
+
+  if (!hasSpecificAwait) {
+    await nextFrame();
+  }
+  return el;
+}

--- a/packages/testing-helpers/index-no-side-effects.js
+++ b/packages/testing-helpers/index-no-side-effects.js
@@ -12,3 +12,4 @@ export { litFixture, litFixtureSync } from './litFixture.js';
 export { stringFixture, stringFixtureSync } from './stringFixture.js';
 export { fixture, fixtureSync } from './fixture-no-side-effect.js';
 export { cachedWrappers, fixtureWrapper, fixtureCleanup } from './fixtureWrapper.js';
+export { elementUpdated } from './elementUpdated.js';

--- a/packages/testing-helpers/index.js
+++ b/packages/testing-helpers/index.js
@@ -12,3 +12,4 @@ export { litFixture, litFixtureSync } from './litFixture.js';
 export { stringFixture, stringFixtureSync } from './stringFixture.js';
 export { fixture, fixtureSync } from './fixture.js';
 export { cachedWrappers, fixtureWrapper, fixtureCleanup } from './fixtureWrapper.js';
+export { elementUpdated } from './elementUpdated.js';

--- a/packages/testing-helpers/litFixture.js
+++ b/packages/testing-helpers/litFixture.js
@@ -1,6 +1,6 @@
 import { fixtureWrapper } from './fixtureWrapper.js';
 import { render } from './lit-html.js';
-import { nextFrame } from './helpers.js';
+import { elementUpdated } from './elementUpdated.js';
 
 /**
  * Setups an element synchronously from the provided lit-html template and puts it in the DOM.
@@ -22,11 +22,6 @@ export function litFixtureSync(template) {
  */
 export async function litFixture(template) {
   const el = litFixtureSync(template);
-  const update = el.updateComplete;
-  if (typeof update === 'object' && Promise.resolve(update) === update) {
-    await update;
-  } else {
-    await nextFrame();
-  }
+  await elementUpdated(el);
   return el;
 }

--- a/packages/testing-helpers/stringFixture.js
+++ b/packages/testing-helpers/stringFixture.js
@@ -1,5 +1,5 @@
-import { nextFrame } from './helpers.js';
 import { fixtureWrapper } from './fixtureWrapper.js';
+import { elementUpdated } from './elementUpdated.js';
 
 /**
  * Setups an element synchronously from the provided string template and puts it in the DOM.
@@ -23,11 +23,6 @@ export function stringFixtureSync(template) {
  */
 export async function stringFixture(template) {
   const el = stringFixtureSync(template);
-  const update = el.updateComplete;
-  if (typeof update === 'object' && Promise.resolve(update) === update) {
-    await update;
-  } else {
-    await nextFrame();
-  }
+  await elementUpdated(el);
   return el;
 }

--- a/packages/testing-helpers/test/elementUpdated.test.js
+++ b/packages/testing-helpers/test/elementUpdated.test.js
@@ -1,0 +1,48 @@
+/* eslint-disable class-methods-use-this */
+import { expect } from '@bundled-es-modules/chai';
+import { elementUpdated } from '../elementUpdated.js';
+import { nextFrame } from '../helpers.js';
+
+describe('elementUpdated', () => {
+  it('will wait for one frame', async () => {
+    let counter = 0;
+    nextFrame().then(() => {
+      counter += 1;
+    });
+
+    class TmpElement {}
+    const el = new TmpElement();
+    await elementUpdated(el);
+    expect(counter).to.equal(1);
+  });
+
+  it('will wait for lit-element to be updated via el.updateComplete', async () => {
+    let counter = 0;
+    class TmpElement {
+      get updateComplete() {
+        return new Promise(resolve => requestAnimationFrame(resolve)).then(() => {
+          counter += 1;
+        });
+      }
+    }
+    const el = new TmpElement();
+
+    await elementUpdated(el);
+    expect(counter).to.equal(1);
+  });
+
+  it('will wait for stencil to be updated via el.componentOnReady()', async () => {
+    let counter = 0;
+    class TmpElement {
+      componentOnReady() {
+        return new Promise(resolve => requestAnimationFrame(resolve)).then(() => {
+          counter += 1;
+        });
+      }
+    }
+    const el = new TmpElement();
+
+    await elementUpdated(el);
+    expect(counter).to.equal(1);
+  });
+});


### PR DESCRIPTION
closes https://github.com/open-wc/open-wc/issues/172