### PR TITLE
docs(ide): replaced es6-string-html by lit-html

### DIFF
--- a/docs/ide/README.md
+++ b/docs/ide/README.md
@@ -33,7 +33,7 @@ We recommend the following plugins:
 
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)  
 Get ESLint feedback directly in your IDE => more details under [Linting](./guide/linting)
-* [es6-string-html](https://marketplace.visualstudio.com/items?itemName=Tobermory.es6-string-html)  
+* [lit-html](https://marketplace.visualstudio.com/items?itemName=bierner.lit-html)  
 Highlights all your html tagged template literals
 * [vscode-styled-components](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)  
 Highlights all your css tagged template literals


### PR DESCRIPTION
Just a proposal, maybe it isn't better at all, but that you will say.

I use this extension daily to develop Polymer's LitElements and I like it very much.