### PR TITLE
feat: npm install after running generators

### DIFF
--- a/packages/generator-open-wc/generators/app/index.js
+++ b/packages/generator-open-wc/generators/app/index.js
@@ -7,4 +7,8 @@ module.exports = class GeneratorApp extends Generator {
     this.composeWith(require.resolve('../demoing'), this.config.getAll());
     this.composeWith(require.resolve('../automating'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/automating-circleci/index.js
+++ b/packages/generator-open-wc/generators/automating-circleci/index.js
@@ -11,4 +11,8 @@ module.exports = class GeneratorAutomatingCircleci extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/automating/index.js
+++ b/packages/generator-open-wc/generators/automating/index.js
@@ -4,4 +4,8 @@ module.exports = class GeneratorAutomating extends Generator {
   default() {
     this.composeWith(require.resolve('../automating-circleci'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/building-webpack/index.js
+++ b/packages/generator-open-wc/generators/building-webpack/index.js
@@ -17,4 +17,8 @@ module.exports = class GeneratorBuildingWebpack extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/building/index.js
+++ b/packages/generator-open-wc/generators/building/index.js
@@ -4,4 +4,8 @@ module.exports = class GeneratorBuilding extends Generator {
   default() {
     this.composeWith(require.resolve('../building-webpack'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/demoing-storybook/index.js
+++ b/packages/generator-open-wc/generators/demoing-storybook/index.js
@@ -25,4 +25,8 @@ module.exports = class GeneratorDemoingStorybook extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/demoing/index.js
+++ b/packages/generator-open-wc/generators/demoing/index.js
@@ -4,4 +4,8 @@ module.exports = class GeneratorDemoing extends Generator {
   default() {
     this.composeWith(require.resolve('../demoing-storybook'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/linting-commitlint/index.js
+++ b/packages/generator-open-wc/generators/linting-commitlint/index.js
@@ -17,4 +17,8 @@ module.exports = class GeneratorLintingCommitlint extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/linting-eslint/index.js
+++ b/packages/generator-open-wc/generators/linting-eslint/index.js
@@ -17,4 +17,8 @@ module.exports = class GeneratorLintingEslint extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/linting-prettier/index.js
+++ b/packages/generator-open-wc/generators/linting-prettier/index.js
@@ -22,4 +22,8 @@ module.exports = class GeneratorLintingPrettier extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/linting/index.js
+++ b/packages/generator-open-wc/generators/linting/index.js
@@ -23,4 +23,8 @@ module.exports = class GeneratorLinting extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/scaffold-building/index.js
+++ b/packages/generator-open-wc/generators/scaffold-building/index.js
@@ -27,4 +27,8 @@ module.exports = class GeneratorScaffoldBuilding extends Generator {
   default() {
     this.composeWith(require.resolve('../building'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/scaffold-demoing/index.js
+++ b/packages/generator-open-wc/generators/scaffold-demoing/index.js
@@ -23,4 +23,8 @@ module.exports = class GeneratorPublishStorybook extends Generator {
   default() {
     this.composeWith(require.resolve('../demoing'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/scaffold-testing/index.js
+++ b/packages/generator-open-wc/generators/scaffold-testing/index.js
@@ -32,4 +32,8 @@ module.exports = class GeneratorTestingBare extends Generator {
   default() {
     this.composeWith(require.resolve('../testing'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/scaffold-vanilla/index.js
+++ b/packages/generator-open-wc/generators/scaffold-vanilla/index.js
@@ -52,4 +52,8 @@ module.exports = class GeneratorVanillaBare extends Generator {
     this.composeWith(require.resolve('../scaffold-demoing'), this.config.getAll());
     this.composeWith(require.resolve('../automating'), this.config.getAll());
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/testing-karma-bs/index.js
+++ b/packages/generator-open-wc/generators/testing-karma-bs/index.js
@@ -17,4 +17,8 @@ module.exports = class GeneratorTestingKarmaBs extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/testing-karma/index.js
+++ b/packages/generator-open-wc/generators/testing-karma/index.js
@@ -17,4 +17,8 @@ module.exports = class GeneratorTestingKarma extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/testing-wallaby/index.js
+++ b/packages/generator-open-wc/generators/testing-wallaby/index.js
@@ -17,4 +17,8 @@ module.exports = class GeneratorTestingBare extends Generator {
       { globOptions: { dot: true } },
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };

--- a/packages/generator-open-wc/generators/testing/index.js
+++ b/packages/generator-open-wc/generators/testing/index.js
@@ -13,4 +13,8 @@ module.exports = class GeneratorTesting extends Generator {
       this.fs.readJSON(this.templatePath('_package.json')),
     );
   }
+
+  install() {
+    this.npmInstall();
+  }
 };


### PR DESCRIPTION
fixes https://github.com/open-wc/open-wc/issues/205

> "Yeoman will ensure the npm install command is only run once even if it is called multiple times by multiple generators."

https://yeoman.io/authoring/dependencies.html