### PR TITLE
fix(owc-dev-server): fix CLI options table formatting in README

### DIFF
--- a/packages/owc-dev-server/README.md
+++ b/packages/owc-dev-server/README.md
@@ -84,7 +84,7 @@ npx owc-dev-server --app-index demo/index.html --open
 
 ### Command line options
 |name|alias|type|description|
-|---|---|---|---|---|
+|---|---|---|---|
 |--port|-p|number|The port to use. Default: 8080|
 |--hostname|-h|string|The hostname to use. Default: localhost|
 |--open|-o|string/boolean|Opens the default browser on the given path or default /|


### PR DESCRIPTION
![before and after](https://user-images.githubusercontent.com/22416150/52551282-6b72f480-2de4-11e9-92c7-0de92808f411.png)