### PR TITLE
Bump lit versions to the 1.0 stable releases

### DIFF
--- a/packages/building-webpack/package.json
+++ b/packages/building-webpack/package.json
@@ -43,7 +43,7 @@
     "@babel/register": "^7.0.0",
     "@webpack-cli/serve": "^0.1.3",
     "http-server": "^0.11.1",
-    "lit-element": "^2.0.0-rc.3",
+    "lit-element": "^2.0.1",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14"

--- a/packages/generator-open-wc/generators/scaffold-vanilla/templates/_package.json
+++ b/packages/generator-open-wc/generators/scaffold-vanilla/templates/_package.json
@@ -7,6 +7,6 @@
   "license": "MIT",
   "repository": "https://github.com/open-wc/open-wc/",
   "dependencies": {
-    "lit-html": "^1.0.0-rc.2"
+    "lit-html": "^1.0.0"
   }
 }

--- a/packages/owc-dev-server/package.json
+++ b/packages/owc-dev-server/package.json
@@ -30,6 +30,6 @@
     "opn": "^5.4.0"
   },
   "devDependencies": {
-    "lit-html": "^1.0.0-rc.2"
+    "lit-html": "^1.0.0"
   }
 }


### PR DESCRIPTION
lit-html bumped to 1.0.0
lit-element bumped to 2.0.1 (That was the version which uses 1.0.0 of lit-html)