### PR TITLE
Merge Strategy Documentation

### DIFF
--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -64,6 +64,33 @@ For a minimal setup, extend the base config and specify where your tests are:
     return config;
   };
   ```
+   <details>
+    <summary>Replacing Default Settings Instead of Merging</summary>
+    <br/>
+    In some cases you'll want `your custom config` to include config values that replace, rather than extend, the defaults provided. To make this possible you can make advanced usage of webpack-merge to set a [merge strategy](https://github.com/survivejs/webpack-merge#mergestrategy-field-prependappendreplaceconfiguration-configuration) to follow when joining the defaults and your custom config. See below for an example that uses `replace` to change the `reports` used by `coverageIstanbulReporter`.
+  
+    ```js
+    module.exports = config => {
+      config.set(
+        merge.strategy(
+          {
+            'coverageIstanbulReporter.reports': 'replace',
+          }
+        )(defaultSettings(config), {
+          files: [
+            // allows running single tests with the --grep flag
+            config.grep ? config.grep : 'test/**/*.test.js',
+          ],
+          // your custom config
+          coverageIstanbulReporter: {
+            reports: ['html', 'lcovonly', 'text']
+          }
+        })
+      );
+      return config;
+    };
+    ```
+  </details>
 - Add these scrips to your package.json
   ```js
   "scripts": {

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -64,6 +64,7 @@ For a minimal setup, extend the base config and specify where your tests are:
     return config;
   };
   ```
+  
    <details>
     <summary>Replacing Default Settings Instead of Merging</summary>
     <br/>
@@ -91,6 +92,7 @@ For a minimal setup, extend the base config and specify where your tests are:
     };
     ```
   </details>
+  
 - Add these scrips to your package.json
   ```js
   "scripts": {

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -67,7 +67,7 @@ For a minimal setup, extend the base config and specify where your tests are:
   
    <details>
     <summary>Replacing Default Settings Instead of Merging</summary>
-    <br/>
+  
     In some cases you'll want `your custom config` to include config values that replace, rather than extend, the defaults provided. To make this possible you can make advanced usage of webpack-merge to set a [merge strategy](https://github.com/survivejs/webpack-merge#mergestrategy-field-prependappendreplaceconfiguration-configuration) to follow when joining the defaults and your custom config. See below for an example that uses `replace` to change the `reports` used by `coverageIstanbulReporter`.
   
     ```js


### PR DESCRIPTION
fixes #226

I chose the merge strategy approach namely because I'm not sure how to plumb the depths of possible issues around @daKmoR's note that:

> iirc using only config set however breaks webpack configs as they need to be "carefully" copied with keeping function in tact and such... that's why we use webpack-merge generally

If anyone else has deeper insight on this, I'd be happy to make updates here.