### PR TITLE
fix(testing-karma): exclude spec files in node_modules

### DIFF
--- a/packages/testing-karma/default-settings.js
+++ b/packages/testing-karma/default-settings.js
@@ -65,7 +65,7 @@ module.exports = config => ({
           loader: 'istanbul-instrumenter-loader',
           enforce: 'post',
           include: path.resolve('./'),
-          exclude: /node_modules|bower_components|\.test\.js$/,
+          exclude: /node_modules|bower_components|\.(spec|test)\.js$/,
           options: {
             esModules: true,
           },


### PR DESCRIPTION
previously we only excluded `test` files.