### PR TITLE
chore(testing): fix typo in docs

### DIFF
--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -113,7 +113,7 @@ it('can await an event', async () => {
   const tag = defineCE(class extends HTMLElement {
     fireDone() {
       this.done = true;
-      this.dispatchEvent(new CustomEvent('done');
+      this.dispatchEvent(new CustomEvent('done'));
     }
   });
 


### PR DESCRIPTION
Hey open-wc :). 

I was using the test-helpers and spotted this typo.

Cheers,