### PR TITLE
fix: check on tagname

### DIFF
--- a/packages/create/src/helpers.js
+++ b/packages/create/src/helpers.js
@@ -20,7 +20,7 @@ export async function askTagInfo() {
   let tagName = '';
   let className = '';
 
-  if (!cliOptions['tag-name']) {
+  if (cliOptions['tag-name'] === '') {
     tagName = '';
     do {
       // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
Something is not completely going well yet with specifying the tagname:

<img width="544" alt="Screen Shot 2019-03-11 at 21 38 51" src="https://user-images.githubusercontent.com/17054057/54156215-16a7b580-4446-11e9-9750-7b9176c4e67c.png">

Hopefully this fixes it