### PR TITLE
fix(owc-dev-server): use current working directory for app index

### DIFF
--- a/packages/owc-dev-server/owc-dev-server.js
+++ b/packages/owc-dev-server/owc-dev-server.js
@@ -133,7 +133,7 @@ app.use(express.static(rootDir));
 
 // serve app index.html for non asset requests to allow for SPA routing
 if (appIndex) {
-  const fullAppIndexPath = `${__dirname}/${appIndex}`;
+  const fullAppIndexPath = `${process.cwd()}/${appIndex}`;
   if (!fs.existsSync(fullAppIndexPath)) {
     throw new Error(`Could not find "${fullAppIndexPath}". The apps index file needs to exist.`);
   }


### PR DESCRIPTION
fixes the app-index path by using the current working directory instead of the __dirname path which locates to the module path.