### PR TITLE
[testing-helpers] ensure ShadyDOM finished its job in fixture

### DIFF
--- a/packages/testing-helpers/elementUpdated.js
+++ b/packages/testing-helpers/elementUpdated.js
@@ -9,6 +9,8 @@ const isDefinedPromise = action => typeof action === 'object' && Promise.resolve
  *
  * If none of these is available we await the next frame.
  *
+ * Ensures that ShadyDOM finished its job if available.
+ *
  * @param {HTMLElement} el
  * @returns {Promise<Element>}
  */
@@ -29,5 +31,10 @@ export async function elementUpdated(el) {
   if (!hasSpecificAwait) {
     await nextFrame();
   }
+
+  if (window.ShadyDOM && typeof window.ShadyDOM.flush === 'function') {
+    window.ShadyDOM.flush();
+  }
+
   return el;
 }

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -31,6 +31,7 @@
     "@open-wc/testing-wallaby": "^0.1.11",
     "lit-html": "^1.0.0",
     "mocha": "^5.0.0",
+    "sinon": "^7.2.7",
     "webpack-merge": "^4.1.5"
   }
 }

--- a/packages/testing-helpers/test/fixture.test.js
+++ b/packages/testing-helpers/test/fixture.test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { expect } from '@bundled-es-modules/chai';
 import { cachedWrappers } from '../fixtureWrapper.js';
 import { defineCE } from '../helpers';
@@ -64,6 +65,20 @@ describe('fixtureSync & fixture', () => {
     const litTag = unsafeStatic(tag);
     await fixture(html`<${litTag}></${litTag}>`);
     expect(counter).to.equal(2);
+  });
+
+  it('ensures ShadyDOM finished its job', async () => {
+    const originalShadyDOM = window.ShadyDOM;
+
+    window.ShadyDOM = { flush: sinon.spy() };
+
+    class Test extends HTMLElement {}
+
+    const tag = defineCE(Test);
+    await fixture(`<${tag}></${tag}>`);
+    expect(window.ShadyDOM.flush.callCount).to.equal(1);
+
+    window.ShadyDOM = originalShadyDOM;
   });
 
   it('waits for componentOnReady', async () => {


### PR DESCRIPTION
# Expected behavior

In IE11 and older versions of other browsers without native ShadowDOM this test works:

```js
it('my test', async () => {
  class MyElement extends LitElement {
    static get styles() {
      return css`
        :host .wrapper ::slotted(div) {
          position: absolute;
        }
      `;
    }

    render() {
      return html`
        <div class="wrapper">
          <slot></slot>
        </div>
      `;
    }
  }
  const tag = defineCE(MyElement);
  const el = await fixture(`<${tag}><div></div></${tag}>`);
  const div = el.querySelector('div');
  expect(window.getComputedStyle(div).position).to.equal('absolute');
});
```

# Actual behavior

AssertionError: expected 'static' to equal 'absolute'

# Explanation

ShadyCSS polyfill hasn't yet rewrite all class names and apply styles to elements. To ensure it did its job we can run `window.ShadyDOM.flush()`.

```js
  const el = await fixture(`<${tag}><div></div></${tag}>`);
  const div = el.querySelector('div');
  if (window.ShadyDOM) {
    window.ShadyDOM.flush();
  }
  expect(window.getComputedStyle(div).position).to.equal('absolute');
```

I implemented this in the fixture helper since I think the examples above shows very well that this is kinda useless boilerplate and is expected by a fixture user to be done automatically.