### PR TITLE
fix(building-rollup): default configs should be commonjs modules

### DIFF
--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -55,9 +55,9 @@ Note: our config will **not** handle inline module such as:
 ```json
 {
   "scripts": {
-    "build": "rimraf dist && rollup",
+    "build": "rimraf dist && rollup -c rollup.config.js",
     "start:build": "http-server dist -o",
-    "watch:build": "rimraf dist && rollup --watch & http-server dist -o",
+    "watch:build": "rimraf dist && rollup --watch -c rollup.config.js & http-server dist -o",
   }
 }
 ```

--- a/packages/building-rollup/demo/js/rollup.config.js
+++ b/packages/building-rollup/demo/js/rollup.config.js
@@ -1,11 +1,11 @@
-import cpy from 'rollup-plugin-cpy';
-import createDefaultConfig from '../../modern-and-legacy-config';
+const cpy = require('rollup-plugin-cpy');
+const createDefaultConfig = require('../../modern-and-legacy-config');
 
 const config = createDefaultConfig({
   input: './demo/js/index.html',
 });
 
-export default [
+module.exports = [
   {
     ...config[0],
     plugins: [

--- a/packages/building-rollup/demo/js/rollup.modern.config.js
+++ b/packages/building-rollup/demo/js/rollup.modern.config.js
@@ -1,11 +1,11 @@
-import cpy from 'rollup-plugin-cpy';
-import createDefaultConfig from '../../modern-config';
+const cpy = require('rollup-plugin-cpy');
+const createDefaultConfig = require('../../modern-config');
 
 const config = createDefaultConfig({
   input: './demo/js/index.html',
 });
 
-export default {
+module.exports = {
   ...config,
   plugins: [
     ...config.plugins,

--- a/packages/building-rollup/demo/js/rollup.visualizer.config.js
+++ b/packages/building-rollup/demo/js/rollup.visualizer.config.js
@@ -1,12 +1,12 @@
-import visualizer from 'rollup-plugin-visualizer';
-import createDefaultConfig from '../../modern-and-legacy-config';
+const visualizer = require('rollup-plugin-visualizer');
+const createDefaultConfig = require('../../modern-and-legacy-config');
 
 const configs = createDefaultConfig({
   input: './demo/js/index.html',
 });
 const config = configs[0];
 
-export default {
+module.exports = {
   ...config,
   plugins: [
     ...config.plugins,

--- a/packages/building-rollup/demo/ts-babel/rollup.config.js
+++ b/packages/building-rollup/demo/ts-babel/rollup.config.js
@@ -1,5 +1,5 @@
-import createDefaultConfig from '../../modern-and-legacy-config';
+const createDefaultConfig = require('../../modern-and-legacy-config');
 
-export default createDefaultConfig({
+module.exports = createDefaultConfig({
   input: './demo/ts-babel/index.html',
 });

--- a/packages/building-rollup/demo/ts/rollup.config.js
+++ b/packages/building-rollup/demo/ts/rollup.config.js
@@ -1,11 +1,11 @@
-import typescript from 'rollup-plugin-typescript2';
-import createDefaultConfig from '../../modern-and-legacy-config';
+const typescript = require('rollup-plugin-typescript2');
+const createDefaultConfig = require('../../modern-and-legacy-config');
 
 const configs = createDefaultConfig({
   input: './demo/ts/index.html',
 });
 
-export default configs.map(config => ({
+module.exports = configs.map(config => ({
   ...config,
   plugins: [
     ...config.plugins,

--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -1,8 +1,8 @@
-import resolve from 'rollup-plugin-node-resolve';
-import { terser } from 'rollup-plugin-terser';
-import babel from 'rollup-plugin-babel';
-import minifyHTML from 'rollup-plugin-minify-html-literals';
-import modernWeb from './plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js';
+const resolve = require('rollup-plugin-node-resolve');
+const { terser } = require('rollup-plugin-terser');
+const babel = require('rollup-plugin-babel');
+const minifyHTML = require('rollup-plugin-minify-html-literals').default;
+const modernWeb = require('./plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js');
 
 const production = !process.env.ROLLUP_WATCH;
 const prefix = '[owc-building-rollup]';
@@ -76,7 +76,7 @@ function createConfig(_options, legacy) {
   };
 }
 
-export default function createDefaultConfig(options) {
+module.exports = function createDefaultConfig(options) {
   if (!options.input) {
     throw new Error(`${prefix}: missing option 'input'.`);
   }
@@ -86,4 +86,4 @@ export default function createDefaultConfig(options) {
   }
 
   return [createConfig(options, false), createConfig(options, true)];
-}
+};

--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -1,12 +1,12 @@
-import resolve from 'rollup-plugin-node-resolve';
-import { terser } from 'rollup-plugin-terser';
-import babel from 'rollup-plugin-babel';
-import minifyHTML from 'rollup-plugin-minify-html-literals';
-import modernWeb from './plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js';
+const resolve = require('rollup-plugin-node-resolve');
+const { terser } = require('rollup-plugin-terser');
+const babel = require('rollup-plugin-babel');
+const minifyHTML = require('rollup-plugin-minify-html-literals').default;
+const modernWeb = require('./plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js');
 
 const production = !process.env.ROLLUP_WATCH;
 
-export default function createBasicConfig(_options) {
+module.exports = function createBasicConfig(_options) {
   const options = {
     outputDir: 'dist',
     ..._options,
@@ -64,4 +64,4 @@ export default function createBasicConfig(_options) {
       production && terser(),
     ],
   };
-}
+};

--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
@@ -1,14 +1,14 @@
-import path from 'path';
-import mkdirp from 'mkdirp';
-import { copyFileSync, existsSync } from 'fs';
-import { query, queryAll, predicates, getAttribute, append, remove } from 'dom5';
-import {
+const path = require('path');
+const mkdirp = require('mkdirp');
+const { copyFileSync, existsSync } = require('fs');
+const { query, queryAll, predicates, getAttribute, append, remove } = require('dom5');
+const {
   readHTML,
   writeOutputHTML,
   createElement,
   createScript,
   createScriptModule,
-} from './utils.js';
+} = require('./utils.js');
 
 const prefix = '[rollup-plugin-legacy-browsers]:';
 let writtenModules = false;
@@ -172,7 +172,7 @@ function writeLegacyModules(pluginConfig, outputConfig, entryModules) {
   writeOutputHTML(outputDir, indexHTML);
 }
 
-export default (_pluginConfig = {}) => {
+module.exports = (_pluginConfig = {}) => {
   const pluginConfig = {
     // Whether this the systemjs output for legacy browsers
     legacy: false,

--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/utils.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/utils.js
@@ -1,22 +1,22 @@
-import path from 'path';
-import mkdirp from 'mkdirp';
-import { readFileSync, writeFileSync } from 'fs';
-import { parse, serialize } from 'parse5';
-import { constructors, setAttribute, append } from 'dom5';
+const path = require('path');
+const mkdirp = require('mkdirp');
+const { readFileSync, writeFileSync } = require('fs');
+const { parse, serialize } = require('parse5');
+const { constructors, setAttribute, append } = require('dom5');
 
 /** Reads file as HTML AST */
-export function readHTML(file) {
+function readHTML(file) {
   return parse(readFileSync(file, 'utf-8'));
 }
 
 /** Writes given HTML AST to output index.html */
-export function writeOutputHTML(dir, html) {
+function writeOutputHTML(dir, html) {
   const outputPath = path.join(dir, 'index.html');
   mkdirp.sync(path.dirname(outputPath));
   writeFileSync(outputPath, serialize(html));
 }
 
-export function createElement(tag, attributes) {
+function createElement(tag, attributes) {
   const element = constructors.element(tag);
   if (attributes) {
     Object.keys(attributes).forEach(key => {
@@ -26,7 +26,7 @@ export function createElement(tag, attributes) {
   return element;
 }
 
-export function createScript(attributes, code) {
+function createScript(attributes, code) {
   const script = createElement('script', attributes);
   if (code) {
     const scriptText = constructors.text(code);
@@ -35,6 +35,14 @@ export function createScript(attributes, code) {
   return script;
 }
 
-export function createScriptModule(code) {
+function createScriptModule(code) {
   return createScript({ type: 'module' }, code);
 }
+
+module.exports = {
+  readHTML,
+  writeOutputHTML,
+  createElement,
+  createScript,
+  createScriptModule,
+};


### PR DESCRIPTION
Fixes https://github.com/open-wc/open-wc/issues/283

- Fixes docs to mention specifying a config file to rollup
- Fixes default config to be exported as a commonjs module, instead of an es module