### PR TITLE
chore: run all needed karma tests in one session

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,26 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const merge = require('webpack-merge');
+const defaultSettings = require('./packages/testing-karma/default-settings.js');
+
+module.exports = config => {
+  config.set(
+    merge(defaultSettings(config), {
+      files: [
+        // allows running single tests with the --grep flag
+        config.grep ? config.grep : 'packages/!(webpack-import-meta-loader)/test/*.test.js',
+      ],
+
+      coverageIstanbulReporter: {
+        thresholds: {
+          global: {
+            statements: 80,
+            lines: 80,
+            branches: 80,
+            functions: 80,
+          },
+        },
+      },
+    }),
+  );
+  return config;
+};

--- a/karma.es5.bs.config.js
+++ b/karma.es5.bs.config.js
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const merge = require('webpack-merge');
+const bsSettings = require('./packages/testing-karma-bs/bs-settings.js');
+const karmaEs5Config = require('./karma.es5.config.js');
+
+module.exports = config => {
+  config.set(
+    merge(bsSettings(config), karmaEs5Config(config), {
+      browserStack: {
+        project: 'open-wc',
+      },
+    }),
+  );
+
+  return config;
+};

--- a/karma.es5.config.js
+++ b/karma.es5.config.js
@@ -1,0 +1,8 @@
+const merge = require('webpack-merge');
+const es5Settings = require('./packages/testing-karma/es5-settings.js');
+const karmaConf = require('./karma.conf.js');
+
+module.exports = config => {
+  config.set(merge(es5Settings(config), karmaConf(config)));
+  return config;
+};

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "publish": "lerna publish --message 'chore: release new versions'",
     "site:build": "npm run vuepress:build",
     "site:start": "npm run vuepress:start",
-    "test": "lerna run test --stream --concurrency 1",
+    "test": "karma start",
     "test:ci": "lerna run test:ci",
-    "test:es5": "lerna run test:es5 --stream --concurrency 1",
-    "test:es5:bs": "lerna run test:es5:bs --stream --concurrency 1",
+    "test:es5": "karma start karma.es5.config.js",
+    "test:es5:bs": "karma start karma.es5.bs.config.js",
     "vuepress:build": "vuepress build docs",
     "vuepress:start": "vuepress dev docs"
   },
@@ -31,6 +31,8 @@
     "@commitlint/cli": "7.2.1",
     "@commitlint/config-conventional": "7.1.2",
     "@commitlint/config-lerna-scopes": "7.2.1",
+    "@open-wc/testing-karma": "file:./packages/testing-karma",
+    "@open-wc/testing-karma-bs": "file:./packages/testing-karma-bs",
     "@vuepress/plugin-google-analytics": "^1.0.0-alpha.30",
     "eslint": "^5.13.0",
     "eslint-config-prettier": "^3.3.0",
@@ -39,6 +41,7 @@
     "lint-staged": "^8.1.0",
     "npm-run-all": "4.1.3",
     "prettier": "^1.15.0",
-    "vuepress": "^1.0.0-alpha.30"
+    "vuepress": "^1.0.0-alpha.30",
+    "webpack-merge": "^4.1.5"
   }
 }


### PR DESCRIPTION
This reduces the time the ci needs to run the tests by ~50%.

e.g. ~2:30min instead of ~5:00min