### PR TITLE
fix: default webpack generator config and docs

### DIFF
--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -24,14 +24,15 @@ npm i -D @open-wc/building-webpack webpack http-server webpack-dev-server
 
 If you don't need to support IE11 or other legacy browsers, use `@open-wc/building-webpack/modern-config`. Otherwise, use `@open-wc/building-webpack/modern-and-legacy-config`.
 ```javascript
-import createDefaultConfig from '@open-wc/building-webpack/modern-and-legacy-config';
+const { resolve } = require('path');
+const createDefaultConfig = require('@open-wc/building-webpack/modern-and-legacy-config');
 
 // If you don't need IE11 support, use the modern-config instead
 // import createDefaultConfig from '@open-wc/building-webpack/modern-config';
 
-export default createDefaultConfig({
-  entry: path.resolve(__dirname, './my-app.js'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+module.exports = createDefaultConfig({
+  entry: resolve(__dirname, './src/index.js'),
+  indexHTML: resolve(__dirname, './src/index.html'),
 });
 ```
 
@@ -68,7 +69,7 @@ Do **not** put IE11 in your `.browserslistrc`. `modern-and-legacy-config` alread
   "scripts": {
     "build": "webpack --mode production",
     "start": "webpack-dev-server --mode development --open",
-    "start:build": "http-server dist -o",
+    "start:build": "http-server dist -o"
   }
 }
 ```

--- a/packages/building-webpack/modern-and-legacy-config.js
+++ b/packages/building-webpack/modern-and-legacy-config.js
@@ -97,7 +97,7 @@ function createConfig(options, legacy) {
       !development && new CleanWebpackPlugin(),
 
       new HtmlWebpackPlugin({
-        template: path.resolve(__dirname, options.indexHTML),
+        template: options.indexHTML,
         inject: false,
       }),
 

--- a/packages/building-webpack/modern-config.js
+++ b/packages/building-webpack/modern-config.js
@@ -90,8 +90,7 @@ module.exports = userOptions => {
       !development && new CleanWebpackPlugin(),
 
       new HtmlWebpackPlugin({
-        template: path.resolve(__dirname, options.indexHTML),
-        inject: 'head',
+        template: options.indexHTML,
       }),
     ].filter(_ => !!_),
 

--- a/packages/create/src/generators/building-webpack/templates/static/webpack.config.js
+++ b/packages/create/src/generators/building-webpack/templates/static/webpack.config.js
@@ -1,3 +1,10 @@
-const defaultConfig = require('@open-wc/building-webpack/default-config');
+const { resolve } = require('path');
+const createDefaultConfig = require('@open-wc/building-webpack/modern-and-legacy-config');
 
-module.exports = defaultConfig();
+// If you don't need IE11 support, use the modern-config instead
+// import createDefaultConfig from '@open-wc/building-webpack/modern-config';
+
+module.exports = createDefaultConfig({
+  entry: resolve(__dirname, './src/index.js'),
+  indexHTML: resolve(__dirname, './src/index.html'),
+});


### PR DESCRIPTION
I think this fixes the webpack generator/manual instructions, it doesn't seem to pick up the default options correctly though, need to dive into it more