### PR TITLE
docs: improve unit testing init error page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -88,7 +88,7 @@ module.exports = {
         {
           title: 'Deep dives',
           collapsable: true,
-          children: ['rerender', 'unit-testing-custom-events'],
+          children: ['rerender', 'unit-testing-custom-events', 'unit-testing-init-error'],
         },
       ],
       '/about/': [['/about/', 'About'], '/about/contact', '/about/rationales', '/about/blog'],

--- a/docs/faq/unit-testing-init-error.md
+++ b/docs/faq/unit-testing-init-error.md
@@ -2,17 +2,14 @@
 
 ## The issue - components silently failing
 
-Suppose you have a component that requires certain properties to work as expected.
-You can handle this like classic built-in DOM elements by silently failing or trying as hard as possible to still deliver omething reasonable.
-Or you can throw an exception that tells the user what exactly went wrong. Depending on the target audience of your web omponent you would choose either way.
-
-For the target audience of JavaScript developers using your component, you should rather throw than to silently fail.
+Suppose you have a component that requires certain properties to work in a certain way.
+You can handle this like classic built-in DOM elements by silently failing, or you can throw an exception that tells the user what exactly went wrong. We recommend you help the consumer of your web component by throwing an exception rather than silently failing.
 
 ## Setting up your component for testing
 
 The problem is that the error of web components is thrown in a different "context" and can be not caught in a test.
 
-First thing you should do is to have a special method that takes care of the checking and throws when the check fails:
+The first thing you can do is have a special method that takes care of checking if the property exists, and throw if that check fails:
 
 ```js
 class StringField extends ... {
@@ -25,7 +22,7 @@ class StringField extends ... {
 }
 ```
 
-This method would be called before first rendering when the element gets attached to the DOM in [connectedCallback](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks) or [update](https://lit-element.polymer-project.org/guide/lifecycle#update) when using [LitElement](https://lit-element.polymer-project.org/).
+This method should be called before the first render when the element gets attached to the DOM in [connectedCallback](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks) or [update](https://lit-element.polymer-project.org/guide/lifecycle#update) when using [LitElement](https://lit-element.polymer-project.org/).
 
 ## The test case
 


### PR DESCRIPTION
I missed the PR that added this section but I have some improvements for this page, and added it to the sidebar menu as well. Deep dives need to be added in the .vuepress config file to show up in the sidebar