### PR TITLE
feat(building-webpack): enable single entry point html file

### DIFF
--- a/docs/building/README.md
+++ b/docs/building/README.md
@@ -13,6 +13,19 @@ Building is a necessary optimization when shipping apps to production. Generally
 
 Our recommended setups address the first four points but refrain from introducing non-standard features. We think it's best to avoid those, as they might lock your source code to a specific build setup which can be hard to get away from at a later time. Javascript is evolving fast, your code can quickly become out of sync with new developments.
 
+## Using `index.html` as an entry point
+Our configs for `rollup` & `webpack` are unique in that sense that they take a single html file as an entry point.
+Doing so allows you to work with the same entry point no matter if you use
+- webpack
+- rollup
+- owc-dev-server
+- polymer serve
+- etc
+
+This means you can easily compare how different setups affect your app size and loading time.
+This allows you to easily switch between build configurations; if you want to switch to webpack for a while, your entrypoint will be exactly the same.
+It also means you can use `owc-dev-server` for your regular development, and then use either `rollup` or `webpack` to prepare your application for your production environment.
+
 ## Rollup
 We recommend [Rollup](https://rollupjs.org/) for building front-end projects. Rollup is convenient to use and gets out of your way. It is easy to understand what's going on. Quite a relief in a world of complex javascript tooling.
 

--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -31,8 +31,7 @@ const createDefaultConfig = require('@open-wc/building-webpack/modern-and-legacy
 // import createDefaultConfig from '@open-wc/building-webpack/modern-config';
 
 module.exports = createDefaultConfig({
-  entry: resolve(__dirname, './src/index.js'),
-  indexHTML: resolve(__dirname, './src/index.html'),
+  input: path.resolve(__dirname, './src/index.html'),
 });
 ```
 
@@ -43,6 +42,8 @@ module.exports = createDefaultConfig({
   <head></head>
   <body>
     <your-app></your-app>
+
+    <script type="module" src="./your-app.js"></script>
   </body>
 </html>
 ```
@@ -128,8 +129,7 @@ const merge = require('webpack-merge');
 const createDefaultConfig = require('@open-wc/building-webpack/modern-config');
 
 const config = createDefaultConfig({
-  entry: path.resolve(__dirname, './my-app.js'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './src/index.html'),
 });
 
 module.exports = merge(config, {
@@ -146,8 +146,7 @@ const merge = require('webpack-merge');
 const createDefaultConfigs = require('@open-wc/building-webpack/modern-and-legacy-config');
 
 const configs = createDefaultConfigs({
-  entry: path.resolve(__dirname, './my-app.js'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './src/index.html'),
 });
 
 module.exports = configs.map(config => merge(config, {
@@ -174,8 +173,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const createDefaultConfigs = require('@open-wc/building-webpack/modern-and-legacy-config');
 
 const configs = createDefaultConfigs({
-  entry: path.resolve(__dirname, './demo-app.js'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './src/index.html'),
 });
 
 // with modern-and-legacy-config, the config is actually an array of configs for a modern and
@@ -231,8 +229,7 @@ const merge = require('webpack-merge');
 const createDefaultConfigs = require('@open-wc/building-webpack/modern-and-legacy-config');
 
 const configs = createDefaultConfigs({
-  entry: path.resolve(__dirname, './demo-app.ts'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './src/index.html'),
 });
 
 module.exports = configs.map(config =>

--- a/packages/building-webpack/demo/js/index.html
+++ b/packages/building-webpack/demo/js/index.html
@@ -7,5 +7,8 @@
     <h1>Static content in index.html is preserved</h1>
 
     <demo-app></demo-app>
+
+    <script type="module" src="./demo-app.js"></script>
+    <script type="module" src="./a/meta-url-test-2.js"></script>
   </body>
 </html>

--- a/packages/building-webpack/demo/js/webpack.config.js
+++ b/packages/building-webpack/demo/js/webpack.config.js
@@ -4,11 +4,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const createDefaultConfigs = require('../../modern-and-legacy-config');
 
 const configs = createDefaultConfigs({
-  entry: [
-    path.resolve(__dirname, './demo-app.js'),
-    path.resolve(__dirname, './a/meta-url-test-2.js'),
-  ],
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 
 module.exports = [

--- a/packages/building-webpack/demo/js/webpack.modern.config.js
+++ b/packages/building-webpack/demo/js/webpack.modern.config.js
@@ -4,8 +4,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const createDefaultConfig = require('../../modern-config');
 
 const defaultConfig = createDefaultConfig({
-  entry: path.resolve(__dirname, './demo-app.js'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 
 module.exports = merge(defaultConfig, {

--- a/packages/building-webpack/demo/ts-babel/index.html
+++ b/packages/building-webpack/demo/ts-babel/index.html
@@ -13,6 +13,8 @@
   <h1>Static content in index.html is preserved</h1>
 
   <babel-demo-app></babel-demo-app>
+
+  <script type="module" src="./babel-demo-app.ts"></script>
 </body>
 
 </html>

--- a/packages/building-webpack/demo/ts-babel/webpack.config.js
+++ b/packages/building-webpack/demo/ts-babel/webpack.config.js
@@ -2,6 +2,5 @@ const path = require('path');
 const defaultConfig = require('../../modern-and-legacy-config');
 
 module.exports = defaultConfig({
-  entry: path.resolve(__dirname, './demo-app.ts'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });

--- a/packages/building-webpack/demo/ts/index.html
+++ b/packages/building-webpack/demo/ts/index.html
@@ -13,6 +13,8 @@
   <h1>Static content in index.html is preserved</h1>
 
   <demo-app></demo-app>
+
+  <script type="module" src="./demo-app.ts"></script>
 </body>
 
 </html>

--- a/packages/building-webpack/demo/ts/webpack.config.js
+++ b/packages/building-webpack/demo/ts/webpack.config.js
@@ -3,8 +3,7 @@ const merge = require('webpack-merge');
 const createDefaultConfig = require('../../modern-and-legacy-config');
 
 const defaultConfig = createDefaultConfig({
-  entry: path.resolve(__dirname, './demo-app.ts'),
-  indexHTML: path.resolve(__dirname, './index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 
 module.exports = defaultConfig.map(config =>

--- a/packages/building-webpack/dom5-fork/README.md
+++ b/packages/building-webpack/dom5-fork/README.md
@@ -1,0 +1,3 @@
+This is a "fork" of dom5. See [npm](https://www.npmjs.com/package/dom5) and [github source](https://github.com/Polymer/tools/tree/master/packages/dom5).
+
+We will use it until [issues/3385](https://github.com/Polymer/tools/issues/3385) is resolved.

--- a/packages/building-webpack/dom5-fork/index.js
+++ b/packages/building-webpack/dom5-fork/index.js
@@ -1,0 +1,635 @@
+/* eslint-disable */
+// @ts-nocheck
+
+'use strict';
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+var cloneObject = require('clone');
+var parse5_1 = require('parse5');
+function getAttributeIndex(element, name) {
+  if (!element.attrs) {
+    return -1;
+  }
+  var n = name.toLowerCase();
+  for (var i = 0; i < element.attrs.length; i++) {
+    if (element.attrs[i].name.toLowerCase() === n) {
+      return i;
+    }
+  }
+  return -1;
+}
+/**
+ * @returns `true` iff [element] has the attribute [name], `false` otherwise.
+ */
+function hasAttribute(element, name) {
+  return getAttributeIndex(element, name) !== -1;
+}
+module.exports.hasAttribute = hasAttribute;
+function hasSpaceSeparatedAttrValue(name, value) {
+  return function(element) {
+    var attributeValue = getAttribute(element, name);
+    if (typeof attributeValue !== 'string') {
+      return false;
+    }
+    return attributeValue.split(' ').indexOf(value) !== -1;
+  };
+}
+module.exports.hasSpaceSeparatedAttrValue = hasSpaceSeparatedAttrValue;
+/**
+ * @returns The string value of attribute `name`, or `null`.
+ */
+function getAttribute(element, name) {
+  var i = getAttributeIndex(element, name);
+  if (i > -1) {
+    return element.attrs[i].value;
+  }
+  return null;
+}
+module.exports.getAttribute = getAttribute;
+function setAttribute(element, name, value) {
+  var i = getAttributeIndex(element, name);
+  if (i > -1) {
+    element.attrs[i].value = value;
+  } else {
+    element.attrs.push({ name: name, value: value });
+  }
+}
+module.exports.setAttribute = setAttribute;
+function removeAttribute(element, name) {
+  var i = getAttributeIndex(element, name);
+  if (i > -1) {
+    element.attrs.splice(i, 1);
+  }
+}
+module.exports.removeAttribute = removeAttribute;
+function hasTagName(name) {
+  var n = name.toLowerCase();
+  return function(node) {
+    if (!node.tagName) {
+      return false;
+    }
+    return node.tagName.toLowerCase() === n;
+  };
+}
+/**
+ * Returns true if `regex.match(tagName)` finds a match.
+ *
+ * This will use the lowercased tagName for comparison.
+ */
+function hasMatchingTagName(regex) {
+  return function(node) {
+    if (!node.tagName) {
+      return false;
+    }
+    return regex.test(node.tagName.toLowerCase());
+  };
+}
+function hasClass(name) {
+  return hasSpaceSeparatedAttrValue('class', name);
+}
+function collapseTextRange(parent, start, end) {
+  if (!parent.childNodes) {
+    return;
+  }
+  var text = '';
+  for (var i = start; i <= end; i++) {
+    text += getTextContent(parent.childNodes[i]);
+  }
+  parent.childNodes.splice(start, end - start + 1);
+  if (text) {
+    var tn = newTextNode(text);
+    tn.parentNode = parent;
+    parent.childNodes.splice(start, 0, tn);
+  }
+}
+/**
+ * Normalize the text inside an element
+ *
+ * Equivalent to `element.normalize()` in the browser
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Node/normalize
+ */
+function normalize(node) {
+  if (!(isElement(node) || isDocument(node) || isDocumentFragment(node))) {
+    return;
+  }
+  if (!node.childNodes) {
+    return;
+  }
+  var textRangeStart = -1;
+  for (var i = node.childNodes.length - 1, n = void 0; i >= 0; i--) {
+    n = node.childNodes[i];
+    if (isTextNode(n)) {
+      if (textRangeStart === -1) {
+        textRangeStart = i;
+      }
+      if (i === 0) {
+        // collapse leading text nodes
+        collapseTextRange(node, 0, textRangeStart);
+      }
+    } else {
+      // recurse
+      normalize(n);
+      // collapse the range after this node
+      if (textRangeStart > -1) {
+        collapseTextRange(node, i + 1, textRangeStart);
+        textRangeStart = -1;
+      }
+    }
+  }
+}
+module.exports.normalize = normalize;
+/**
+ * Return the text value of a node or element
+ *
+ * Equivalent to `node.textContent` in the browser
+ */
+function getTextContent(node) {
+  if (isCommentNode(node)) {
+    return node.data || '';
+  }
+  if (isTextNode(node)) {
+    return node.value || '';
+  }
+  var subtree = nodeWalkAll(node, isTextNode);
+  return subtree.map(getTextContent).join('');
+}
+module.exports.getTextContent = getTextContent;
+/**
+ * Set the text value of a node or element
+ *
+ * Equivalent to `node.textContent = value` in the browser
+ */
+function setTextContent(node, value) {
+  if (isCommentNode(node)) {
+    node.data = value;
+  } else if (isTextNode(node)) {
+    node.value = value;
+  } else {
+    var tn = newTextNode(value);
+    tn.parentNode = node;
+    node.childNodes = [tn];
+  }
+}
+module.exports.setTextContent = setTextContent;
+/**
+ * Match the text inside an element, textnode, or comment
+ *
+ * Note: nodeWalkAll with hasTextValue may return an textnode and its parent if
+ * the textnode is the only child in that parent.
+ */
+function hasTextValue(value) {
+  return function(node) {
+    return getTextContent(node) === value;
+  };
+}
+function OR() {
+  var rules = new Array(arguments.length);
+  for (var i = 0; i < arguments.length; i++) {
+    rules[i] = arguments[i];
+  }
+  return function(node) {
+    for (var i = 0; i < rules.length; i++) {
+      if (rules[i](node)) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+function AND() {
+  var rules = new Array(arguments.length);
+  for (var i = 0; i < arguments.length; i++) {
+    rules[i] = arguments[i];
+  }
+  return function(node) {
+    for (var i = 0; i < rules.length; i++) {
+      if (!rules[i](node)) {
+        return false;
+      }
+    }
+    return true;
+  };
+}
+/**
+ * negate an individual predicate, or a group with AND or OR
+ */
+function NOT(predicateFn) {
+  return function(node) {
+    return !predicateFn(node);
+  };
+}
+/**
+ * Returns a predicate that matches any node with a parent matching
+ * `predicateFn`.
+ */
+function parentMatches(predicateFn) {
+  return function(node) {
+    var parent = node.parentNode;
+    while (parent !== undefined) {
+      if (predicateFn(parent)) {
+        return true;
+      }
+      parent = parent.parentNode;
+    }
+    return false;
+  };
+}
+function hasAttr(attr) {
+  return function(node) {
+    return getAttributeIndex(node, attr) > -1;
+  };
+}
+function hasAttrValue(attr, value) {
+  return function(node) {
+    return getAttribute(node, attr) === value;
+  };
+}
+function isDocument(node) {
+  return node.nodeName === '#document';
+}
+module.exports.isDocument = isDocument;
+function isDocumentFragment(node) {
+  return node.nodeName === '#document-fragment';
+}
+module.exports.isDocumentFragment = isDocumentFragment;
+function isElement(node) {
+  return node.nodeName === node.tagName;
+}
+module.exports.isElement = isElement;
+function isTextNode(node) {
+  return node.nodeName === '#text';
+}
+module.exports.isTextNode = isTextNode;
+function isCommentNode(node) {
+  return node.nodeName === '#comment';
+}
+module.exports.isCommentNode = isCommentNode;
+/**
+ * Applies `mapfn` to `node` and the tree below `node`, returning a flattened
+ * list of results.
+ */
+function treeMap(node, mapfn) {
+  var results = [];
+  nodeWalk(node, function(node) {
+    results = results.concat(mapfn(node));
+    return false;
+  });
+  return results;
+}
+module.exports.treeMap = treeMap;
+module.exports.defaultChildNodes = function(node) {
+  return node.childNodes;
+};
+module.exports.childNodesIncludeTemplate = function(node) {
+  if (node.nodeName === 'template') {
+    return parse5_1.treeAdapters['default'].getTemplateContent(node).childNodes;
+  }
+  return node.childNodes;
+};
+/**
+ * Walk the tree down from `node`, applying the `predicate` function.
+ * Return the first node that matches the given predicate.
+ *
+ * @returns `null` if no node matches, parse5 node object if a node matches.
+ */
+function nodeWalk(node, predicate, getChildNodes) {
+  if (getChildNodes === void 0) {
+    getChildNodes = module.exports.defaultChildNodes;
+  }
+  if (predicate(node)) {
+    return node;
+  }
+  var match = null;
+  var childNodes = getChildNodes(node);
+  if (childNodes) {
+    for (var i = 0; i < childNodes.length; i++) {
+      match = nodeWalk(childNodes[i], predicate, getChildNodes);
+      if (match) {
+        break;
+      }
+    }
+  }
+  return match;
+}
+module.exports.nodeWalk = nodeWalk;
+/**
+ * Walk the tree down from `node`, applying the `predicate` function.
+ * All nodes matching the predicate function from `node` to leaves will be
+ * returned.
+ */
+function nodeWalkAll(node, predicate, matches, getChildNodes) {
+  if (getChildNodes === void 0) {
+    getChildNodes = module.exports.defaultChildNodes;
+  }
+  if (!matches) {
+    matches = [];
+  }
+  if (predicate(node)) {
+    matches.push(node);
+  }
+  var childNodes = getChildNodes(node);
+  if (childNodes) {
+    for (var i = 0; i < childNodes.length; i++) {
+      nodeWalkAll(childNodes[i], predicate, matches, getChildNodes);
+    }
+  }
+  return matches;
+}
+module.exports.nodeWalkAll = nodeWalkAll;
+function _reverseNodeWalkAll(node, predicate, matches, getChildNodes) {
+  if (getChildNodes === void 0) {
+    getChildNodes = module.exports.defaultChildNodes;
+  }
+  if (!matches) {
+    matches = [];
+  }
+  var childNodes = getChildNodes(node);
+  if (childNodes) {
+    for (var i = childNodes.length - 1; i >= 0; i--) {
+      nodeWalkAll(childNodes[i], predicate, matches, getChildNodes);
+    }
+  }
+  if (predicate(node)) {
+    matches.push(node);
+  }
+  return matches;
+}
+/**
+ * Equivalent to `nodeWalk`, but only returns nodes that are either
+ * ancestors or earlier cousins/siblings in the document.
+ *
+ * Nodes are searched in reverse document order, starting from the sibling
+ * prior to `node`.
+ */
+function nodeWalkPrior(node, predicate) {
+  // Search our earlier siblings and their descendents.
+  var parent = node.parentNode;
+  if (parent && parent.childNodes) {
+    var idx = parent.childNodes.indexOf(node);
+    var siblings = parent.childNodes.slice(0, idx);
+    for (var i = siblings.length - 1; i >= 0; i--) {
+      var sibling = siblings[i];
+      if (predicate(sibling)) {
+        return sibling;
+      }
+      var found = nodeWalk(sibling, predicate);
+      if (found) {
+        return found;
+      }
+    }
+    if (predicate(parent)) {
+      return parent;
+    }
+    return nodeWalkPrior(parent, predicate);
+  }
+  return undefined;
+}
+module.exports.nodeWalkPrior = nodeWalkPrior;
+/**
+ * Walk the tree up from the parent of `node`, to its grandparent and so on to
+ * the root of the tree.  Return the first ancestor that matches the given
+ * predicate.
+ */
+function nodeWalkAncestors(node, predicate) {
+  var parent = node.parentNode;
+  if (!parent) {
+    return undefined;
+  }
+  if (predicate(parent)) {
+    return parent;
+  }
+  return nodeWalkAncestors(parent, predicate);
+}
+module.exports.nodeWalkAncestors = nodeWalkAncestors;
+/**
+ * Equivalent to `nodeWalkAll`, but only returns nodes that are either
+ * ancestors or earlier cousins/siblings in the document.
+ *
+ * Nodes are returned in reverse document order, starting from `node`.
+ */
+function nodeWalkAllPrior(node, predicate, matches) {
+  if (!matches) {
+    matches = [];
+  }
+  if (predicate(node)) {
+    matches.push(node);
+  }
+  // Search our earlier siblings and their descendents.
+  var parent = node.parentNode;
+  if (parent) {
+    var idx = parent.childNodes.indexOf(node);
+    var siblings = parent.childNodes.slice(0, idx);
+    for (var i = siblings.length - 1; i >= 0; i--) {
+      _reverseNodeWalkAll(siblings[i], predicate, matches);
+    }
+    nodeWalkAllPrior(parent, predicate, matches);
+  }
+  return matches;
+}
+module.exports.nodeWalkAllPrior = nodeWalkAllPrior;
+/**
+ * Equivalent to `nodeWalk`, but only matches elements
+ */
+function query(node, predicate, getChildNodes) {
+  if (getChildNodes === void 0) {
+    getChildNodes = module.exports.defaultChildNodes;
+  }
+  var elementPredicate = AND(isElement, predicate);
+  return nodeWalk(node, elementPredicate, getChildNodes);
+}
+module.exports.query = query;
+/**
+ * Equivalent to `nodeWalkAll`, but only matches elements
+ */
+function queryAll(node, predicate, matches, getChildNodes) {
+  if (getChildNodes === void 0) {
+    getChildNodes = module.exports.defaultChildNodes;
+  }
+  var elementPredicate = AND(isElement, predicate);
+  return nodeWalkAll(node, elementPredicate, matches, getChildNodes);
+}
+module.exports.queryAll = queryAll;
+function newTextNode(value) {
+  return {
+    nodeName: '#text',
+    value: value,
+    parentNode: undefined,
+    attrs: [],
+    __location: undefined,
+  };
+}
+function newCommentNode(comment) {
+  return {
+    nodeName: '#comment',
+    data: comment,
+    parentNode: undefined,
+    attrs: [],
+    __location: undefined,
+  };
+}
+function newElement(tagName, namespace) {
+  return {
+    nodeName: tagName,
+    tagName: tagName,
+    childNodes: [],
+    namespaceURI: namespace || 'http://www.w3.org/1999/xhtml',
+    attrs: [],
+    parentNode: undefined,
+    __location: undefined,
+  };
+}
+function newDocumentFragment() {
+  return {
+    nodeName: '#document-fragment',
+    childNodes: [],
+    parentNode: undefined,
+    quirksMode: false,
+    // TODO(rictic): update parse5 typings upstream to mention that attrs and
+    //     __location are optional and not always present.
+    attrs: undefined,
+    __location: null,
+  };
+}
+function cloneNode(node) {
+  // parent is a backreference, and we don't want to clone the whole tree, so
+  // make it null before cloning.
+  var parent = node.parentNode;
+  node.parentNode = undefined;
+  var clone = cloneObject(node);
+  node.parentNode = parent;
+  return clone;
+}
+module.exports.cloneNode = cloneNode;
+/**
+ * Inserts `newNode` into `parent` at `index`, optionally replaceing the
+ * current node at `index`. If `newNode` is a DocumentFragment, its childNodes
+ * are inserted and removed from the fragment.
+ */
+function insertNode(parent, index, newNode, replace) {
+  if (!parent.childNodes) {
+    parent.childNodes = [];
+  }
+  var newNodes = [];
+  var removedNode = replace ? parent.childNodes[index] : null;
+  if (newNode) {
+    if (isDocumentFragment(newNode)) {
+      if (newNode.childNodes) {
+        newNodes = Array.from(newNode.childNodes);
+        newNode.childNodes.length = 0;
+      }
+    } else {
+      newNodes = [newNode];
+      remove(newNode);
+    }
+  }
+  if (replace) {
+    removedNode = parent.childNodes[index];
+  }
+  Array.prototype.splice.apply(parent.childNodes, [index, replace ? 1 : 0].concat(newNodes));
+  newNodes.forEach(function(n) {
+    n.parentNode = parent;
+  });
+  if (removedNode) {
+    removedNode.parentNode = undefined;
+  }
+}
+function replace(oldNode, newNode) {
+  var parent = oldNode.parentNode;
+  var index = parent.childNodes.indexOf(oldNode);
+  insertNode(parent, index, newNode, true);
+}
+module.exports.replace = replace;
+function remove(node) {
+  var parent = node.parentNode;
+  if (parent && parent.childNodes) {
+    var idx = parent.childNodes.indexOf(node);
+    parent.childNodes.splice(idx, 1);
+  }
+  node.parentNode = undefined;
+}
+module.exports.remove = remove;
+function insertBefore(parent, target, newNode) {
+  var index = parent.childNodes.indexOf(target);
+  insertNode(parent, index, newNode);
+}
+module.exports.insertBefore = insertBefore;
+function insertAfter(parent, target, newNode) {
+  var index = parent.childNodes.indexOf(target);
+  insertNode(parent, index + 1, newNode);
+}
+module.exports.insertAfter = insertAfter;
+/**
+ * Removes a node and places its children in its place.  If the node
+ * has no parent, the operation is impossible and no action takes place.
+ */
+function removeNodeSaveChildren(node) {
+  // We can't save the children if there's no parent node to provide
+  // for them.
+  var fosterParent = node.parentNode;
+  if (!fosterParent) {
+    return;
+  }
+  var children = (node.childNodes || []).slice();
+  for (var _i = 0, children_1 = children; _i < children_1.length; _i++) {
+    var child = children_1[_i];
+    insertBefore(node.parentNode, node, child);
+  }
+  remove(node);
+}
+module.exports.removeNodeSaveChildren = removeNodeSaveChildren;
+/**
+ * When parse5 parses an HTML document with `parse`, it injects missing root
+ * elements (html, head and body) if they are missing.  This function removes
+ * these from the AST if they have no location info, so it requires that
+ * the `parse5.parse` be used with the `locationInfo` option of `true`.
+ */
+function removeFakeRootElements(ast) {
+  var injectedNodes = queryAll(
+    ast,
+    AND(function(node) {
+      return !node.__location;
+    }, hasMatchingTagName(/^(html|head|body)$/i)),
+    undefined,
+    // Don't descend past 3 levels 'document > html > head|body'
+    function(node) {
+      return node.parentNode && node.parentNode.parentNode ? undefined : node.childNodes;
+    },
+  );
+  injectedNodes.reverse().forEach(removeNodeSaveChildren);
+}
+module.exports.removeFakeRootElements = removeFakeRootElements;
+function append(parent, newNode) {
+  var index = (parent.childNodes && parent.childNodes.length) || 0;
+  insertNode(parent, index, newNode);
+}
+module.exports.append = append;
+module.exports.predicates = {
+  hasClass: hasClass,
+  hasAttr: hasAttr,
+  hasAttrValue: hasAttrValue,
+  hasMatchingTagName: hasMatchingTagName,
+  hasSpaceSeparatedAttrValue: hasSpaceSeparatedAttrValue,
+  hasTagName: hasTagName,
+  hasTextValue: hasTextValue,
+  AND: AND,
+  OR: OR,
+  NOT: NOT,
+  parentMatches: parentMatches,
+};
+module.exports.constructors = {
+  text: newTextNode,
+  comment: newCommentNode,
+  element: newElement,
+  fragment: newDocumentFragment,
+};

--- a/packages/building-webpack/modern-and-legacy-config.js
+++ b/packages/building-webpack/modern-and-legacy-config.js
@@ -7,11 +7,16 @@ const ModernWebWebpackPlugin = require('./src/modern-web-webpack-plugin');
 const development = !process.argv.find(arg => arg.includes('production'));
 const legacy = process.argv.find(arg => arg.includes('legacy'));
 
+const prefix = '[@open-wc/building-webpack/modern-and-legacy-config]:';
+const { queryAll, predicates, getAttribute } = require('./dom5-fork/index.js');
+const { readHTML } = require('./src/utils.js');
+
 const modernWebWebpackPlugin = new ModernWebWebpackPlugin({ development });
 
 const defaultOptions = {
   indexHTML: './index.html',
   entry: './index.js',
+  htmlEntryPoint: false,
 };
 
 /* eslint-disable-next-line no-shadow */
@@ -74,7 +79,11 @@ function createConfig(options, legacy) {
             },
           },
         },
-      ],
+        options.htmlEntryPoint && {
+          test: options.input,
+          loader: require.resolve('./src/clean-up-html-loader.js'),
+        },
+      ].filter(_ => !!_),
     },
 
     optimization: {
@@ -121,6 +130,28 @@ module.exports = userOptions => {
     ...defaultOptions,
     ...userOptions,
   };
+
+  if (typeof options.input === 'string' && options.input.endsWith('index.html')) {
+    options.indexHTML = options.input;
+    options.htmlEntryPoint = true;
+    const indexHTML = readHTML(options.input);
+    const scripts = queryAll(indexHTML, predicates.hasTagName('script'));
+    const moduleScripts = scripts.filter(script => getAttribute(script, 'type') === 'module');
+
+    if (moduleScripts.length === 0) {
+      throw new Error(
+        `${prefix} Could not find any module script in configured input: ${options.input}`,
+      );
+    }
+
+    if (moduleScripts.some(script => !getAttribute(script, 'src'))) {
+      throw new Error(`${prefix} Module scripts without a 'src' attribute are not supported.`);
+    }
+    const indexDir = path.dirname(options.input);
+
+    const modules = moduleScripts.map(script => getAttribute(script, 'src'));
+    options.entry = modules.map(p => path.join(indexDir, p));
+  }
 
   if (development) {
     return createConfig(options, legacy);

--- a/packages/building-webpack/package.json
+++ b/packages/building-webpack/package.json
@@ -46,6 +46,7 @@
     "clean-webpack-plugin": "^2.0.0",
     "copy-webpack-plugin": "^5.0.1",
     "html-webpack-plugin": "^3.2.0",
+    "parse5": "^5.1.0",
     "terser": "^3.17.0",
     "terser-webpack-plugin": "^1.2.1",
     "url-polyfill": "^1.1.5",

--- a/packages/building-webpack/src/clean-up-html-loader.js
+++ b/packages/building-webpack/src/clean-up-html-loader.js
@@ -1,0 +1,9 @@
+/* eslint-disable */
+// @ts-nocheck
+
+const regex = /<script.*<\/script>/g;
+
+module.exports = function(source) {
+  const output = source.replace(regex, '');
+  return `module.exports = \`${output}\`;`;
+};

--- a/packages/building-webpack/src/utils.js
+++ b/packages/building-webpack/src/utils.js
@@ -1,0 +1,11 @@
+const { readFileSync } = require('fs');
+const { parse } = require('parse5');
+
+/** Reads file as HTML AST */
+function readHTML(file) {
+  return parse(readFileSync(file, 'utf-8'));
+}
+
+module.exports = {
+  readHTML,
+};

--- a/packages/create/src/generators/building-webpack/templates/_package.json
+++ b/packages/create/src/generators/building-webpack/templates/_package.json
@@ -1,13 +1,14 @@
 {
   "scripts": {
     "start:dev": "webpack-dev-server --mode development --open",
-    "start:dev:es5": "webpack-dev-server --mode development --es5",
-    "start:prod": "npx http-server dist/ -o",
+    "start:dev:legacy": "webpack-dev-server --mode development --legacy",
+    "start:prod": "http-server dist/ -o",
     "build": "webpack --mode production",
     "build:stats": "webpack --mode production --profile --json > bundle-stats.json"
   },
   "devDependencies": {
-    "@open-wc/building-webpack": "^1.1.0",
+    "@open-wc/building-webpack": "^1.2.0",
+    "http-server": "^0.11.1",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.1.14"
   }

--- a/packages/create/src/generators/building-webpack/templates/static/webpack.config.js
+++ b/packages/create/src/generators/building-webpack/templates/static/webpack.config.js
@@ -5,6 +5,5 @@ const createDefaultConfig = require('@open-wc/building-webpack/modern-and-legacy
 // import createDefaultConfig from '@open-wc/building-webpack/modern-config';
 
 module.exports = createDefaultConfig({
-  entry: resolve(__dirname, './src/index.js'),
-  indexHTML: resolve(__dirname, './src/index.html'),
+  input: resolve(__dirname, './src/index.html'),
 });


### PR DESCRIPTION
- Allows to use a single `input` HTML File for a webpack config
- This means that the same `index.html` file can be used with rollup/webpack/polymer server/owc-dev-server
- is backward compatible as there is a new config `input` if that one is used it overrides the entry and indexHTML
- uses pretty much the same code as found in rollup (parse5, dom5)
- parse5/dom5 could probably be ditched as we only need to take care of script tags (or we could try to align with the rollup config and offer a index.html to webpack/rollup config tool)
- adds all script src urls as a webpack entry point
- removes all script tags before passing it on to `HtmlWebpackPlugin`

=> this is a POC to show the idea  
=> I think this is really promising and we should promote it as the default way of using it (even deprecating `entry & indexHTML`)