### PR TITLE
Added section on Serving With Apache HTTP Server

### DIFF
--- a/docs/publishing/README.md
+++ b/docs/publishing/README.md
@@ -26,7 +26,7 @@ You can see the finished page here: [https://example-set-game-open-wc.netlify.co
 If you're using our [build configuration](http://open-wc.org/building), the `dist` directory created by the `npm run build` command can be deployed on any local web server. These directions are for the [Apache HTTP Server](http://httpd.apache.org/) specifically, but should be adaptable to other web servers.
 
 - Build command: `npm run build`
-- Copy `dist` to the desired location: `sudo cp -R dist /Library/WebServer/Documents/myapp`
+- Copy the `dist` directory to your desired location: `sudo cp -R dist /Library/WebServer/Documents/myapp`
 - Add a `<VirtualHost>` directive to `httpd.conf`, either directly or by include:
 ```
 <VirtualHost *:80>

--- a/docs/publishing/README.md
+++ b/docs/publishing/README.md
@@ -20,3 +20,27 @@ And you're all set up.
 ## Example
 The [Set-Game Example](https://github.com/open-wc/example-vanilla-set-game/) has the default publishing via storybook on netlify.
 You can see the finished page here: [https://example-set-game-open-wc.netlify.com/](https://example-set-game-open-wc.netlify.com/).
+
+## Serving With Apache HTTP Server
+
+The `dist` directory created by `npm run build` can be deployed on a local web server. These directions are for the [Apache HTTP Server](http://httpd.apache.org/), but should be adaptable to other web servers.
+
+- Build command: `npm run build`
+- Copy `dist` to the desired location: `sudo cp -R dist /Library/WebServer/Documents/myapp`
+- Add a `<VirtualHost>` directive to `httpd.conf`, either directly or by include:
+```
+<VirtualHost *:80>
+    DocumentRoot "/Library/WebServer/Documents/myapp"
+    ServerName mypwa.localhost
+    Alias "/mypwa" "/Library/WebServer/Documents/myapp"
+    <Directory "/Library/WebServer/Documents/myapp">
+      Options -Indexes
+      AllowOverride None
+      Require all granted
+    </Directory>
+</VirtualHost>
+```
+- Restart Apache: `sudo /usr/sbin/apachectl restart`
+- Open the page in your browser using the URL `http://mypwa.localhost/`
+
+If the app was built to support [legacy browsers](https://open-wc.org/building/building-rollup.html#supporting-legacy-browsers), the `dist` directory will include the subdirectories `legacy` and `polyfills`, and legacy browsers such as Internet Explorer 11 will be served suitable content.

--- a/docs/publishing/README.md
+++ b/docs/publishing/README.md
@@ -23,7 +23,7 @@ You can see the finished page here: [https://example-set-game-open-wc.netlify.co
 
 ## Serving With Apache HTTP Server
 
-The `dist` directory created by `npm run build` can be deployed on a local web server. These directions are for the [Apache HTTP Server](http://httpd.apache.org/), but should be adaptable to other web servers.
+If you're using our [build configuration](http://open-wc.org/building), the `dist` directory created by the `npm run build` command can be deployed on any local web server. These directions are for the [Apache HTTP Server](http://httpd.apache.org/) specifically, but should be adaptable to other web servers.
 
 - Build command: `npm run build`
 - Copy `dist` to the desired location: `sudo cp -R dist /Library/WebServer/Documents/myapp`

--- a/docs/publishing/README.md
+++ b/docs/publishing/README.md
@@ -27,7 +27,7 @@ If you're using our [build configuration](http://open-wc.org/building), the `dis
 
 - Build command: `npm run build`
 - Copy the `dist` directory to your desired location: `sudo cp -R dist /Library/WebServer/Documents/myapp`
-- Add a `<VirtualHost>` directive to `httpd.conf`, either directly or by include:
+- Add a `<VirtualHost>` directive to `httpd.conf`, either directly or by an `Include` directive:
 ```
 <VirtualHost *:80>
     DocumentRoot "/Library/WebServer/Documents/myapp"


### PR DESCRIPTION
As requested, I've added a section to Publishing on how to serve using Apache. I've only been able to test this on localhost. (It will be over a week before I can try this on an internal network.)