### PR TITLE
fix(building-rollup): support windows file paths

### DIFF
--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
@@ -10,6 +10,7 @@ const {
   remove,
 } = require('../../dom5-fork/index.js');
 const {
+  pathJoin,
   readHTML,
   writeOutputHTML,
   createElement,
@@ -56,7 +57,7 @@ function copyPolyfills(pluginConfig, outputConfig) {
 
   if (pluginConfig.polyfillDynamicImports) {
     copyFileSync(
-      path.resolve(path.join(__dirname, '../../src/dynamic-import-polyfill.js')),
+      path.resolve(pathJoin(__dirname, '../../src/dynamic-import-polyfill.js')),
       `${polyfillsDir}/dynamic-import-polyfill.js`,
     );
   }
@@ -173,7 +174,7 @@ function writeLegacyModules(pluginConfig, outputConfig, entryModules) {
 
   const loadScript = createScript(
     { nomodule: '' },
-    entryModules.map(src => `System.import('./${path.join('legacy', src)}');`).join(''),
+    entryModules.map(src => `System.import('./${pathJoin('legacy', src)}');`).join(''),
   );
   append(body, loadScript);
   writeOutputHTML(outputDir, indexHTML);
@@ -217,7 +218,7 @@ module.exports = (_pluginConfig = {}) => {
         const modules = moduleScripts.map(script => getAttribute(script, 'src'));
         return {
           ...config,
-          input: modules.map(p => path.join(indexDir, p)),
+          input: modules.map(p => pathJoin(indexDir, p)),
         };
       }
 

--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/utils.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/utils.js
@@ -4,6 +4,11 @@ const { readFileSync, writeFileSync } = require('fs');
 const { parse, serialize } = require('parse5');
 const { constructors, setAttribute, append } = require('../../dom5-fork/index.js');
 
+function pathJoin(...args) {
+  // enfore / also on windows => as it is used for web pathes
+  return path.join.apply(null, args).replace(/\\(?! )/g, '/');
+}
+
 /** Reads file as HTML AST */
 function readHTML(file) {
   return parse(readFileSync(file, 'utf-8'));
@@ -11,7 +16,7 @@ function readHTML(file) {
 
 /** Writes given HTML AST to output index.html */
 function writeOutputHTML(dir, html) {
-  const outputPath = path.join(dir, 'index.html');
+  const outputPath = pathJoin(dir, 'index.html');
   mkdirp.sync(path.dirname(outputPath));
   writeFileSync(outputPath, serialize(html));
 }
@@ -40,6 +45,7 @@ function createScriptModule(code) {
 }
 
 module.exports = {
+  pathJoin,
   readHTML,
   writeOutputHTML,
   createElement,


### PR DESCRIPTION
 Same fix to the same issue as in #344, except for the rollup build process as well.