### PR TITLE
fix(eslint-config): loosen up rules for test and stories files

### DIFF
--- a/packages/create/test/core.test.js
+++ b/packages/create/test/core.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 /* eslint-disable no-template-curly-in-string */
 
 import chai from 'chai';

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -19,7 +19,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/test/**/*.js', '**/stories/**/*.js'],
+      files: ['**/test/**/*.js', '**/demo/**/*.js', '**/stories/**/*.js'],
       rules: {
         'no-console': 'off',
         'no-unused-expressions': 'off',

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -17,4 +17,14 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['**/test/**/*.js', '**/stories/**/*.js'],
+      rules: {
+        'no-console': 'off',
+        'no-unused-expressions': 'off',
+        'class-methods-use-this': 'off',
+      },
+    },
+  ],
 };

--- a/packages/testing-helpers/test/elementUpdated.test.js
+++ b/packages/testing-helpers/test/elementUpdated.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { expect } from '@bundled-es-modules/chai';
 import { elementUpdated } from '../src/elementUpdated.js';
 import { nextFrame } from '../src/helpers.js';

--- a/packages/testing-helpers/test/stringLitFixture.test.js
+++ b/packages/testing-helpers/test/stringLitFixture.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { expect } from '@bundled-es-modules/chai';
 import { stringFixture, stringFixtureSync } from '../src/stringFixture.js';
 import { litFixture, litFixtureSync } from '../src/litFixture.js';

--- a/packages/testing/demo/test/get-result.test.js
+++ b/packages/testing/demo/test/get-result.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 import { html, fixture, litFixture, expect } from '../../index.js';
 
 import '../src/get-result.js';

--- a/packages/testing/test/side-effects.test.js
+++ b/packages/testing/test/side-effects.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-expressions */
-
 import { fixture, expect } from '../index.js';
 
 describe('BDD', () => {


### PR DESCRIPTION
disable
- `no-console` => useful especially in stories to show actions
- `no-unused-expressions` => mostly for tests to use `.to.be.true;`
- `class-methods-use-this` => mostly for tests when mocking

for test and stories files...