### PR TITLE
fix(create): fix tests in barebone-app

### DIFF
--- a/packages/create/src/generators/barebone-app/templates/_app.js
+++ b/packages/create/src/generators/barebone-app/templates/_app.js
@@ -1,9 +1,15 @@
 import { LitElement, html } from 'lit-element';
 
 class <%= className %> extends LitElement {
+	static get properties() {
+		return {
+			heading: { type: String },
+		};
+	}
+
 	render() {
 		return html`
-			<h1>Hello world!</h1>
+			<h1>${this.heading}</h1>
 		`;
 	}
 }

--- a/packages/create/src/generators/testing/templates/_my-el.test.js
+++ b/packages/create/src/generators/testing/templates/_my-el.test.js
@@ -3,15 +3,17 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../src/<%= tagName %>.js';
 
 describe('<<%= tagName %>>', () => {
-  it('has a default property header', async () => {
+  it('has a default property heading', async () => {
     const el = await fixture('<<%= tagName %>></<%= tagName %>>');
-    expect(el.header).to.equal('My Example');
+
+    expect(el.heading).to.equal('Hello world!');
   });
 
-  it('allows property header to be overwritten', async () => {
+  it('allows property heading to be overwritten', async () => {
     const el = await fixture(html`
-      <<%= tagName %> .header=${'different'}></<%= tagName %>>
+      <<%= tagName %> heading="different heading"></<%= tagName %>>
     `);
-    expect(el.header).to.equal('different');
+
+    expect(el.heading).to.equal('different heading');
   });
 });

--- a/packages/create/src/generators/wc-lit-element/templates/_MyEl.js
+++ b/packages/create/src/generators/wc-lit-element/templates/_MyEl.js
@@ -13,18 +13,18 @@ export default class <%= className %> extends LitElement {
 
   static get properties() {
     return {
-      header: { type: String }
+      heading: { type: String }
     }
   }
 
   constructor() {
     super();
-    this.header = 'My Example';
+    this.heading = 'Hello world!';
   }
 
   render() {
     return html`
-      <h2>${this.header}</h2>
+      <h2>${this.heading}</h2>
       <div>
         <slot></slot>
       </div>


### PR DESCRIPTION
fixes https://github.com/open-wc/open-wc/issues/423

also changed `header` to `heading` because a `heading` is the content and `header` is the thing :D