### PR TITLE
Feat/browserslist

### DIFF
--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -149,6 +149,13 @@ For example to add support for class properties:
 }
 ```
 
+## Adjusting browser support for the modern build
+The legacy build targets IE11, which is the earliest browser supported by the webcomponents polyfill. For the modern build we target the lates 2 versions of the major browsers (chrome, firefox, safari and edge).
+
+You can adjust this by adding a [browserslist](https://github.com/browserslist/browserslist) configuration. For example by adding a `.browserslistrc` file to your project, or adding an entry to your package.json. See the [browserslist documentation](https://github.com/browserslist/browserslist) for more information.
+
+> Note: you should not add IE11 or other very early browsers as a target in your browserslist, as it would result in a broken modern build because it makes some assumptions around browser support. Use the `--legacy` flag for legacy builds.
+
 ## Extending the rollup config
 A rollup config is just a plain object. It's easy to extend it using javascript:
 ```javascript

--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+const { findSupportedBrowsers } = require('@open-wc/building-utils');
 const resolve = require('rollup-plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
 const babel = require('rollup-plugin-babel');
@@ -57,16 +58,7 @@ function createConfig(_options, legacy) {
           [
             '@babel/env',
             {
-              targets: legacy
-                ? ['ie 11']
-                : [
-                    'last 2 Chrome major versions',
-                    'last 2 ChromeAndroid major versions',
-                    'last 2 Edge major versions',
-                    'last 2 Firefox major versions',
-                    'last 2 Safari major versions',
-                    'last 2 iOS major versions',
-                  ],
+              targets: legacy ? ['ie 11'] : findSupportedBrowsers(),
               useBuiltIns: false,
             },
           ],

--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+const { findSupportedBrowsers } = require('@open-wc/building-utils');
 const resolve = require('rollup-plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
 const babel = require('rollup-plugin-babel');
@@ -48,14 +49,7 @@ module.exports = function createBasicConfig(_options) {
           [
             '@babel/env',
             {
-              targets: [
-                'last 2 Chrome major versions',
-                'last 2 ChromeAndroid major versions',
-                'last 2 Edge major versions',
-                'last 2 Firefox major versions',
-                'last 2 Safari major versions',
-                'last 2 iOS major versions',
-              ],
+              targets: findSupportedBrowsers(),
               useBuiltIns: false,
             },
           ],

--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -39,6 +39,7 @@
     "*.js"
   ],
   "dependencies": {
+    "@open-wc/building-utils": "^1.0.0",
     "@babel/core": "^7.3.3",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-syntax-import-meta": "^7.2.0",
@@ -46,6 +47,7 @@
     "@babel/preset-env": "^7.0.0",
     "@webcomponents/webcomponentsjs": "^2.2.0",
     "babel-plugin-bundled-import-meta": "^0.3.0",
+    "browserslist": "^4.5.6",
     "clone": "^2.1.2",
     "mkdirp": "^0.5.1",
     "parse5": "^5.1.0",

--- a/packages/building-utils/README.md
+++ b/packages/building-utils/README.md
@@ -1,0 +1,17 @@
+# Building utils
+
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
+
+Utils for `@open-wc` building packages.
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/building-rollup/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/building-utils/find-supported-browsers.js
+++ b/packages/building-utils/find-supported-browsers.js
@@ -1,0 +1,41 @@
+const browserslist = require('browserslist');
+
+const openWcTargets = [
+  'last 2 Chrome major versions',
+  'last 2 ChromeAndroid major versions',
+  'last 2 Firefox major versions',
+  'last 2 Edge major versions',
+  'last 2 Safari major versions',
+  'last 2 iOS major versions',
+];
+
+/**
+ * Finds the supported browsers. Uses a user-defined configuration if defined,
+ * otherwise uses a default set of supported browsers
+ * @returns {string[]}
+ */
+module.exports = function findSupportedBrowsers() {
+  // generate default list
+  const browserslistDefaultTargets = browserslist(browserslist.defaults);
+  // empty call causes browserslist to find a user-defined configuration
+  // for example in .bowerslistrc or the package.json
+  const userTargets = browserslist();
+
+  // there is no way to know if browserslist found a user defined configuration, or if it
+  // returns a default list. but we can check if the default list and the list returned from
+  // an empty call are the same
+  const userHasDefinedTargets =
+    userTargets.length !== browserslistDefaultTargets.length ||
+    userTargets.some(e => !browserslistDefaultTargets.includes(e));
+
+  if (userHasDefinedTargets && userTargets.includes('ie 11')) {
+    throw new Error(
+      'Your browserslist configuration should not include ie 11.\n' +
+        'The browserslists configuration is for the modern build.\n' +
+        'Use the --legacy flag for a build for legacy browsers.\n',
+    );
+  }
+
+  // use user defined targets, otherwise use our own defaults
+  return userHasDefinedTargets ? userTargets : browserslist(openWcTargets);
+};

--- a/packages/building-utils/index.js
+++ b/packages/building-utils/index.js
@@ -1,0 +1,5 @@
+const findSupportedBrowsers = require('./find-supported-browsers');
+
+module.exports = {
+  findSupportedBrowsers,
+};

--- a/packages/building-utils/package.json
+++ b/packages/building-utils/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@open-wc/building-utils",
+  "version": "1.0.0",
+  "description": "Utils for @open-wc packages that do build stuff",
+  "author": "open-wc",
+  "homepage": "https://github.com/open-wc/open-wc/",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wc/open-wc.git",
+    "directory": "packages/building-utils"
+  },
+  "files": [
+    "src",
+    "*.js"
+  ],
+  "dependencies": {
+    "browserslist": "^4.5.6"
+  }
+}

--- a/packages/building-webpack/.browserslistrc
+++ b/packages/building-webpack/.browserslistrc
@@ -1,6 +1,0 @@
-last 2 Chrome major versions
-last 2 ChromeAndroid major versions
-last 2 Edge major versions
-last 2 Firefox major versions
-last 2 Safari major versions
-last 2 iOS major versions

--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -53,19 +53,7 @@ We use [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) to
 
 Remember to not add your app's entry point to your index.html, as it will be injected dynamically by `html-webpack-plugin`.
 
-4. Create a `.browserslistrc` in the root of your project. Adjust it based on your browser support, for example:
-```
-last 2 Chrome major versions
-last 2 ChromeAndroid major versions
-last 2 Edge major versions
-last 2 Firefox major versions
-last 2 Safari major versions
-last 2 iOS major versions
-```
-
-Do **not** put IE11 in your `.browserslistrc`. `modern-and-legacy-config` already creates a separate build for IE11, the `.browserslistrc` is used for the modern build.
-
-5. Add the following commands to your `package.json`:
+4. Add the following commands to your `package.json`:
 ```json
 {
   "scripts": {
@@ -80,13 +68,12 @@ Do **not** put IE11 in your `.browserslistrc`. `modern-and-legacy-config` alread
 - `start:build` runs your built app from `dist` directory, it uses a simple http-server to make sure that it runs without magic
 
 ## Browser support
-`modern-config.js` creates a single build of your app, based on your `.browserslistrc`. This is recommended if you only need to support modern browsers, otherwise you will need to ship compatibility code for browsers which don't need it.
+`modern-config.js` creates a single build of your app for modern browsers (by default last 2 of major browsers). This is recommended if you only need to support modern browsers, otherwise you will need to ship compatibility code for browsers which don't need it.
 
-`modern-and-legacy-config.js` creates two builds of your app. A modern build based on your `.browserslistrc` and a legacy build for IE11. Additional code is injected to load polyfills and the correct version of your app. This is recommended if you need to support IE11.
+`modern-and-legacy-config.js` creates two builds of your app. A modern build like the above, and a legacy build for IE11. Additional code is injected to load polyfills and the correct version of your app. This is recommended if you need to support IE11.
 
 ## Config features
 All configs:
-- compilation target based on `.browserslistrc`
 - resolve bare imports (`import { html } from 'lit-html'`)
 - preserve `import.meta.url` value from before bundling
 - minify + treeshake js
@@ -99,7 +86,7 @@ All configs:
 `modern-and-legacy-config.js`:
 - Two build outputs:
   - Modern:
-    - compilation target based on `.browserslistrc`
+    - compatible with modern browsers (default: last 2 chrome, firefox safari and edge)
     - does not penalize users with modern browser with compatibility code for IE11
   - Legacy:
     - compatible down to IE11
@@ -122,6 +109,13 @@ For example to add support for class properties:
   ]
 }
 ```
+
+## Adjusting browser support for the modern build
+The legacy build targets IE11, which is the earliest browser supported by the webcomponents polyfill. For the modern build we target the lates 2 versions of the major browsers (chrome, firefox, safari and edge).
+
+You can adjust this by adding a [browserslist](https://github.com/browserslist/browserslist) configuration. For example by adding a `.browserslistrc` file to your project, or adding an entry to your package.json. See the [browserslist documentation](https://github.com/browserslist/browserslist) for more information.
+
+> Note: you should not add IE11 or other very early browsers as a target in your browserslist, as it would result in a broken modern build because it makes some assumptions around browser support. Use the `--legacy` flag for legacy builds.
 
 ## Extending the webpack config
 A webpack config is an object. To extend it, we recommend using `webpack-merge` to ensure plugins are merged correctly. For example to adjust the output folder:

--- a/packages/building-webpack/modern-and-legacy-config.js
+++ b/packages/building-webpack/modern-and-legacy-config.js
@@ -1,3 +1,4 @@
+const { findSupportedBrowsers } = require('@open-wc/building-utils');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
@@ -77,7 +78,7 @@ function createConfig(options, legacy) {
                 [
                   '@babel/preset-env',
                   // hardcode IE11 for legacy build, otherwise use browserslist configuration
-                  { targets: legacy ? 'IE 11' : undefined },
+                  { targets: legacy ? 'IE 11' : findSupportedBrowsers() },
                 ],
               ],
             },

--- a/packages/building-webpack/modern-config.js
+++ b/packages/building-webpack/modern-config.js
@@ -1,3 +1,4 @@
+const { findSupportedBrowsers } = require('@open-wc/building-utils');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
@@ -94,7 +95,7 @@ module.exports = userOptions => {
                 ['bundled-import-meta', { importStyle: 'baseURI' }],
               ].filter(_ => !!_),
 
-              presets: ['@babel/preset-env'],
+              presets: [['@babel/preset-env', { targets: findSupportedBrowsers() }]],
             },
           },
         },

--- a/packages/building-webpack/package.json
+++ b/packages/building-webpack/package.json
@@ -35,6 +35,7 @@
     "*.js"
   ],
   "dependencies": {
+    "@open-wc/building-utils": "^1.0.0",
     "@babel/core": "^7.3.3",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-syntax-import-meta": "^7.2.0",

--- a/packages/create/src/generators/building-webpack/templates/static/.browserslistrc
+++ b/packages/create/src/generators/building-webpack/templates/static/.browserslistrc
@@ -1,6 +1,0 @@
-last 2 Chrome major versions
-last 2 ChromeAndroid major versions
-last 2 Edge major versions
-last 2 Firefox major versions
-last 2 Safari major versions
-last 2 iOS major versions

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,21 +1822,21 @@
     url-template "^2.0.8"
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.0.6"
+  version "1.1.1"
   dependencies:
-    "@open-wc/testing-karma" "^1.1.2"
+    "@open-wc/testing-karma" "^2.0.1"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "1.1.2"
+  version "2.0.1"
   dependencies:
     "@babel/core" "^7.3.3"
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
     "@babel/plugin-syntax-import-meta" "^7.2.0"
     "@babel/polyfill" "^7.0.0"
     "@babel/preset-env" "^7.0.0"
-    "@open-wc/karma-esm" "^1.0.0"
+    "@open-wc/karma-esm" "^1.0.1"
     "@types/node" "^11.13.0"
     "@webcomponents/webcomponentsjs" "^2.2.0"
     babel-loader "^8.0.0"
@@ -4871,6 +4871,15 @@ browserslist@^4.0.0, browserslist@^4.3.4, browserslist@^4.5.2, browserslist@^4.5
     electron-to-chromium "^1.3.124"
     node-releases "^1.1.14"
 
+browserslist@^4.5.6:
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.6.tgz#ea42e8581ca2513fa7f371d4dd66da763938163d"
+  integrity sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==
+  dependencies:
+    caniuse-lite "^1.0.30000963"
+    electron-to-chromium "^1.3.127"
+    node-releases "^1.1.17"
+
 browserstack-local@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.3.7.tgz#cac9fc958eaa0a352e8f1ca1dc91bb141ba5da6f"
@@ -5163,6 +5172,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, can
   version "1.0.30000963"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz#5be481d5292f22aff5ee0db4a6c049b65b5798b1"
   integrity sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==
+
+caniuse-lite@^1.0.30000963:
+  version "1.0.30000966"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz#f3c6fefacfbfbfb981df6dfa68f2aae7bff41b64"
+  integrity sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -7071,6 +7085,11 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.103, electron-to-chromium
   version "1.3.127"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.127.tgz#9b34d3d63ee0f3747967205b953b25fe7feb0e10"
   integrity sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A==
+
+electron-to-chromium@^1.3.127:
+  version "1.3.131"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz#205a0b7a276b3f56bc056f19178909243054252a"
+  integrity sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -12246,7 +12265,7 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.14, node-releases@^1.1.3:
+node-releases@^1.1.14, node-releases@^1.1.17, node-releases@^1.1.3:
   version "1.1.17"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.17.tgz#71ea4631f0a97d5cd4f65f7d04ecf9072eac711a"
   integrity sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==


### PR DESCRIPTION
Fixes https://github.com/open-wc/open-wc/issues/426

- Devs no longer need to always provide a browserslist configuration. If none is given, the default is taken.
- Updated instructions on how to add your own browserslist configuration
- Add warning if adding IE11 in your browserslist configuration (this would cause a broken es5 build as we don't load es2015 polyfills)