### PR TITLE
Move index.html to root of generated apps

### DIFF
--- a/docs/developing/README.md
+++ b/docs/developing/README.md
@@ -20,7 +20,7 @@ npm i -D owc-dev-server lit-element
 <!doctype html>
 <html>
   <head>
-    <script type="module" src="./my-component.js"></script>
+    <script type="module" src="./src/my-component.js"></script>
     </head>
   <body>
     <my-component></my-component>

--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -27,7 +27,7 @@ npm i -D @open-wc/building-rollup rollup rimraf http-server
 ```javascript
 import createDefaultConfig from '@open-wc/building-rollup/modern-config';
 
-export default createDefaultConfig({ input: './src/index.html' });
+export default createDefaultConfig({ input: './index.html' });
 ```
 
 Our rollup config will look through your `index.html` and extract all module scripts (nothing else -- see below) and feed them to rollup.
@@ -40,7 +40,7 @@ Our rollup config will look through your `index.html` and extract all module scr
   <body>
     <your-app></your-app>
 
-    <script type="module" src="./your-app.js"></script>
+    <script type="module" src="./src/your-app.js"></script>
   </body>
 </html>
 ```
@@ -53,7 +53,7 @@ To illustrate this, here is an example of scripts which our rollup config will *
     // this *is* a module, but it's inlined in the HTML, so
     // `my-app` will not be picked up by rollup and needs
     // to be copied separately
-    import { MyApp } from './my-app';
+    import { MyApp } from './src/my-app';
   </script>
 
   <!--
@@ -61,7 +61,7 @@ To illustrate this, here is an example of scripts which our rollup config will *
     it is not type="module", it will still not be picked up
     by rollup and needs to be copied separately
   -->
-  <script src="other-script.js"></script>
+  <script src="src/other-script.js"></script>
 ```
 
 4. Add the following commands to your `package.json`:
@@ -86,7 +86,7 @@ If you need to support older browsers or Edge and IE11 you use our `modern-and-l
 ```javascript
 import createDefaultConfig from '@open-wc/building-rollup/modern-and-legacy-config';
 
-export default createDefaultConfig({ input: './src/index.html' });
+export default createDefaultConfig({ input: './index.html' });
 ```
 
 In addition to outputting your app as a module, it outputs a legacy build of your app and loads the appropriate version based on browser support. Depending on your app's own code, this will work on Chrome, Safari, Firefox, Edge and IE11.
@@ -128,7 +128,7 @@ Our config accepts two options:
 ```javascript
 export default createDefaultConfig({
   // your app's index.html. required
-  input: './src/index.html',
+  input: './index.html',
   // the directory to output files into, defaults to 'dist'. optional
   outputDir: '',
 });
@@ -154,7 +154,7 @@ A rollup config is just a plain object. It's easy to extend it using javascript:
 ```javascript
 import createDefaultConfig from '@open-wc/building-rollup/modern-config';
 
-const config = createDefaultConfig({ input: './src/index.html' });
+const config = createDefaultConfig({ input: './index.html' });
 
 export default {
   ...config,
@@ -174,7 +174,7 @@ If you use `modern-and-legacy-config.js`, it is actually an array of configs so 
 ```javascript
 import createDefaultConfig from '@open-wc/building-rollup/modern-and-legacy-config';
 
-const configs = createDefaultConfig({ input: './src/index.html' });
+const configs = createDefaultConfig({ input: './index.html' });
 
 export default configs.map(config => ({
   ...config,
@@ -202,7 +202,7 @@ CommonJS is the module format for NodeJS, and not suitable for the browser. Roll
 import createDefaultConfig from '@open-wc/building-rollup/modern-and-legacy-config';
 import commonjs from 'rollup-plugin-commonjs';
 
-const configs = createDefaultConfig({ input: './src/index.html' });
+const configs = createDefaultConfig({ input: './index.html' });
 
 // map if you use an array of configs, otherwise just extend the config
 export default configs.map(config => ({
@@ -224,7 +224,7 @@ import cpy from 'rollup-plugin-cpy';
 import createDefaultConfig from '@open-wc/building-rollup/modern-and-legacy-config';
 
 const config = createDefaultConfig({
-  input: './src/index.html',
+  input: './index.html',
 });
 
 // if you use an array of configs, you don't need the copy task to be executed for both builds.
@@ -260,7 +260,7 @@ To import a typescript file, use the `.ts` extension in your `index.html`:
 <head></head>
 <body>
   <my-app></my-app>
-  <script type="module" src="./my-app.ts"></script>
+  <script type="module" src="./src/my-app.ts"></script>
 </body>
 </html>
 ```
@@ -288,7 +288,7 @@ import typescript from 'rollup-plugin-typescript2';
 import createDefaultConfig from '@open-wc/building-rollup/modern-and-legacy-config';
 
 const configs = createDefaultConfig({
-  input: './src/index.html',
+  input: './index.html',
 });
 
 export default configs.map(config => ({
@@ -320,7 +320,7 @@ To separate your lit-html styles in css files, you can use [rollup-plugin-lit-cs
 import createDefaultConfig from '@open-wc/building-rollup/modern-and-legacy-config';
 import litcss from 'rollup-plugin-lit-css';
 
-const configs = createDefaultConfig({ input: './src/index.html' });
+const configs = createDefaultConfig({ input: './index.html' });
 
 // map if you use an array of configs, otherwise just extend the config
 export default configs.map(config => ({

--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -61,7 +61,7 @@ To illustrate this, here is an example of scripts which our rollup config will *
     it is not type="module", it will still not be picked up
     by rollup and needs to be copied separately
   -->
-  <script src="src/other-script.js"></script>
+  <script src="./src/other-script.js"></script>
 ```
 
 4. Add the following commands to your `package.json`:

--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -32,7 +32,7 @@ const createDefaultConfig = require('@open-wc/building-webpack/modern-and-legacy
 // import createDefaultConfig from '@open-wc/building-webpack/modern-config';
 
 module.exports = createDefaultConfig({
-  input: path.resolve(__dirname, './src/index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 ```
 
@@ -44,7 +44,7 @@ module.exports = createDefaultConfig({
   <body>
     <your-app></your-app>
 
-    <script type="module" src="./your-app.js"></script>
+    <script type="module" src="./src/your-app.js"></script>
   </body>
 </html>
 ```
@@ -130,7 +130,7 @@ const merge = require('webpack-merge');
 const createDefaultConfig = require('@open-wc/building-webpack/modern-config');
 
 const config = createDefaultConfig({
-  input: path.resolve(__dirname, './src/index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 
 module.exports = merge(config, {
@@ -147,7 +147,7 @@ const merge = require('webpack-merge');
 const createDefaultConfigs = require('@open-wc/building-webpack/modern-and-legacy-config');
 
 const configs = createDefaultConfigs({
-  input: path.resolve(__dirname, './src/index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 
 module.exports = configs.map(config => merge(config, {
@@ -174,7 +174,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const createDefaultConfigs = require('@open-wc/building-webpack/modern-and-legacy-config');
 
 const configs = createDefaultConfigs({
-  input: path.resolve(__dirname, './src/index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 
 // with modern-and-legacy-config, the config is actually an array of configs for a modern and
@@ -251,7 +251,7 @@ const merge = require('webpack-merge');
 const createDefaultConfigs = require('@open-wc/building-webpack/modern-and-legacy-config');
 
 const configs = createDefaultConfigs({
-  input: path.resolve(__dirname, './src/index.html'),
+  input: path.resolve(__dirname, './index.html'),
 });
 
 module.exports = configs.map(config =>

--- a/packages/create/src/generators/barebone-app/templates/_package.json
+++ b/packages/create/src/generators/barebone-app/templates/_package.json
@@ -2,7 +2,7 @@
   "name": "<%= tagName %>",
   "license": "MIT",
   "scripts": {
-    "start": "owc-dev-server --open src"
+    "start": "owc-dev-server --open"
   },
   "dependencies": {
     "lit-html": "^1.0.0",

--- a/packages/create/src/generators/barebone-app/templates/static/index.html
+++ b/packages/create/src/generators/barebone-app/templates/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="description" content="Put your description here.">
 
-  <script type="module" src="./<%= tagName %>.js"></script>
+  <script type="module" src=".src//<%= tagName %>.js"></script>
 
   <style>
     body {

--- a/packages/create/src/generators/barebone-app/templates/static/index.html
+++ b/packages/create/src/generators/barebone-app/templates/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="description" content="Put your description here.">
 
-  <script type="module" src=".src//<%= tagName %>.js"></script>
+  <script type="module" src="./src/<%= tagName %>.js"></script>
 
   <style>
     body {

--- a/packages/create/src/generators/barebone-app/templates/static/index.html
+++ b/packages/create/src/generators/barebone-app/templates/static/index.html
@@ -12,7 +12,7 @@
       background-color: #ededed;
     }
   </style>
-  <title>Open Web Components Basebone App</title>
+  <title>Open Web Components Barebone App</title>
 </head>
 <body>
   <<%= tagName %>></<%= tagName %>>

--- a/packages/create/src/generators/building-rollup/templates/static/index.html
+++ b/packages/create/src/generators/building-rollup/templates/static/index.html
@@ -21,7 +21,7 @@
 <body>
   <<%= tagName %>></<%= tagName %>>
 
-  <script type="module" src="./<%= tagName %>.js"></script>
+  <script type="module" src="./src/<%= tagName %>.js"></script>
 </body>
 
 </html>

--- a/packages/create/src/generators/building-rollup/templates/static/rollup.config.js
+++ b/packages/create/src/generators/building-rollup/templates/static/rollup.config.js
@@ -1,3 +1,3 @@
 import createDefaultConfig from '@open-wc/building-rollup/modern-config';
 
-export default createDefaultConfig({ input: './src/index.html' });
+export default createDefaultConfig({ input: './index.html' });

--- a/packages/create/src/generators/building-webpack/templates/static/index.html
+++ b/packages/create/src/generators/building-webpack/templates/static/index.html
@@ -21,7 +21,7 @@
 <body>
   <<%= tagName %>></<%= tagName %>>
 
-  <script type="module" src="./<%= tagName %>.js"></script>
+  <script type="module" src="./src/<%= tagName %>.js"></script>
 </body>
 
 </html>

--- a/packages/create/src/generators/building-webpack/templates/static/webpack.config.js
+++ b/packages/create/src/generators/building-webpack/templates/static/webpack.config.js
@@ -5,5 +5,5 @@ const createDefaultConfig = require('@open-wc/building-webpack/modern-and-legacy
 // import createDefaultConfig from '@open-wc/building-webpack/modern-config';
 
 module.exports = createDefaultConfig({
-  input: resolve(__dirname, './src/index.html'),
+  input: resolve(__dirname, './index.html'),
 });

--- a/packages/create/src/generators/starter-app/templates/static/index.html
+++ b/packages/create/src/generators/starter-app/templates/static/index.html
@@ -21,7 +21,7 @@
 <body>
   <<%= tagName %>></<%= tagName %>>
 
-  <script type="module" src="./<%= tagName %>.js"></script>
+  <script type="module" src="./src/<%= tagName %>.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Why?

Currently apps generated from `npm init @open-wc` have all source in the src directory.

This is rather weird when running with dev servers because the URL is similar to `http://localhost:8080/src/` and the `src` segment will be absent from production environment. It also applies to serving prod build with `http-server`.

With `index.html` placed in the root, there is no URL mismatch between environments.