### PR TITLE
FIX: install new testing-karma with generator

### DIFF
--- a/packages/create/src/generators/testing-karma/templates/_package.json
+++ b/packages/create/src/generators/testing-karma/templates/_package.json
@@ -8,7 +8,7 @@
     "test:legacy:watch": "karma start --legacy --auto-watch=true --single-run=false"
   },
   "devDependencies": {
-    "@open-wc/testing-karma": "^1.0.0",
+    "@open-wc/testing-karma": "^2.0.0",
     "webpack-merge": "^4.1.5"
   }
 }


### PR DESCRIPTION
The testing generator installs `1.x` version of `@open-wc/testing-karma` which does not properly handle the new syntax for karma files.

It causes IE11 tests to fail silently unless that package is updated to 2+