### PR TITLE
fix(testing-helpers): force focus/blur for IE

### DIFF
--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -75,7 +75,11 @@ export async function triggerBlurFor(element) {
   }
   element.blur();
   if (isIE()) {
-    await nextFrame();
+    while (element === document.activeElement) {
+      element.blur();
+      // eslint-disable-next-line no-await-in-loop
+      await nextFrame();
+    }
     await nextFrame();
   }
 }
@@ -102,7 +106,11 @@ export async function triggerFocusFor(element) {
   }
   element.focus();
   if (isIE()) {
-    await nextFrame();
+    while (element !== document.activeElement) {
+      element.focus();
+      // eslint-disable-next-line no-await-in-loop
+      await nextFrame();
+    }
     await nextFrame();
   }
 }


### PR DESCRIPTION
focus/blur helpers are flaky on IE11... let's see if we can improve it