### PR TITLE
chore(demoing-storybook): add knob exports

### DIFF
--- a/packages/demoing-storybook/index.js
+++ b/packages/demoing-storybook/index.js
@@ -16,6 +16,9 @@ export {
   color,
   array,
   boolean,
+  radios,
+  files,
+  optionsKnob,
 } from '@storybook/addon-knobs';
 
 export { withClassPropertiesKnobs } from './withClassPropertiesKnobs.js';


### PR DESCRIPTION
Storybook has a couple of knobs that are cool but not re-exported in open-wc, so here's a MR :). 