### PR TITLE
feat: include all static modules in `entryModules`

### DIFF
--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
@@ -228,8 +228,19 @@ module.exports = (_pluginConfig = {}) => {
     // Injects generated module paths into index.html
     generateBundle(outputConfig, bundles) {
       const entryModules = Object.keys(bundles)
-        .filter(key => bundles[key].isEntry)
-        .map(e => `./${e}`);
+        .filter(key => {
+          return bundles[key].isEntry;
+        })
+        .reduce((acc, e) => {
+          acc.push(`./${e}`);
+          const imports = bundles[e].imports || [];
+          imports.map(i => {
+            if (!acc.includes(`./${i}`)) {
+              acc.push(`./${i}`)
+            }
+          });
+          return acc;
+        }, []);
 
       if (!pluginConfig.legacy && !writtenModules) {
         copyPolyfills(pluginConfig, outputConfig);

--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
@@ -228,15 +228,13 @@ module.exports = (_pluginConfig = {}) => {
     // Injects generated module paths into index.html
     generateBundle(outputConfig, bundles) {
       const entryModules = Object.keys(bundles)
-        .filter(key => {
-          return bundles[key].isEntry;
-        })
+        .filter(key => bundles[key].isEntry)
         .reduce((acc, e) => {
           acc.push(`./${e}`);
           const imports = bundles[e].imports || [];
           imports.forEach(i => {
             if (!acc.includes(`./${i}`)) {
-              acc.push(`./${i}`)
+              acc.push(`./${i}`);
             }
           });
           return acc;

--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
@@ -234,7 +234,7 @@ module.exports = (_pluginConfig = {}) => {
         .reduce((acc, e) => {
           acc.push(`./${e}`);
           const imports = bundles[e].imports || [];
-          imports.map(i => {
+          imports.forEach(i => {
             if (!acc.includes(`./${i}`)) {
               acc.push(`./${i}`)
             }


### PR DESCRIPTION
This will benefit first load experience by not requiring the browser to traverse the module graph before initiating the request of these files.

fixes #472 