### PR TITLE
Fix(building-rollup): add proper typescript support

### DIFF
--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -289,7 +289,7 @@ You also need to specify `.ts` in the `extensions` option, for babel and node to
 ```
 const configs = createDefaultConfig({
   input: './index.html',
-  extensions: ['.js', '.ts'],
+  extensions: ['.js', '.mjs', '.ts'],
 });
 ```
 (keep `.js` in there, since node will want to resolve javascript files in node_modules)

--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -285,6 +285,14 @@ We recommend using the babel typescript plugin. Add it to your babel config file
   ],
 }
 ```
+You also need to specify `.ts` in the `extensions` option, for babel and node to properly recognize ts files:
+```
+const configs = createDefaultConfig({
+  input: './index.html',
+  extensions: ['.js', '.ts'],
+});
+```
+(keep `.js` in there, since node will want to resolve javascript files in node_modules)
 
 This is the fastest method, as it strips away types during babel transformation of your code. It will not perform any type checking though. We recommend setting up the type checking as part of your linting setup, so that you don't need to run the typechecker during development for faster builds.
 

--- a/packages/building-rollup/demo/ts-babel/demo-app.ts
+++ b/packages/building-rollup/demo/ts-babel/demo-app.ts
@@ -1,7 +1,7 @@
-import { LitElement, html } from 'lit-element';
+import { LitElement, html, TemplateResult } from 'lit-element';
 
 class DemoApp extends LitElement {
-  render() {
+  render(): TemplateResult {
     return html`
       <h1>Hello typescript!</h1>
     `;

--- a/packages/building-rollup/demo/ts-babel/rollup.config.js
+++ b/packages/building-rollup/demo/ts-babel/rollup.config.js
@@ -2,4 +2,5 @@ const createDefaultConfig = require('../../modern-and-legacy-config');
 
 module.exports = createDefaultConfig({
   input: './demo/ts-babel/index.html',
+  extensions: ['.js', '.ts'],
 });

--- a/packages/building-rollup/demo/ts-babel/rollup.config.js
+++ b/packages/building-rollup/demo/ts-babel/rollup.config.js
@@ -2,5 +2,5 @@ const createDefaultConfig = require('../../modern-and-legacy-config');
 
 module.exports = createDefaultConfig({
   input: './demo/ts-babel/index.html',
-  extensions: ['.js', '.ts'],
+  extensions: ['.js', '.mjs', '.ts'],
 });

--- a/packages/building-rollup/demo/ts/demo-app.ts
+++ b/packages/building-rollup/demo/ts/demo-app.ts
@@ -1,7 +1,7 @@
-import { LitElement, html } from 'lit-element';
+import { LitElement, html, TemplateResult } from 'lit-element';
 
 class DemoApp extends LitElement {
-  render() {
+  render(): TemplateResult {
     return html`
       <h1>Hello typescript!</h1>
     `;

--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+const { DEFAULT_EXTENSIONS } = require('@babel/core');
 const { findSupportedBrowsers } = require('@open-wc/building-utils');
 const resolve = require('rollup-plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
@@ -12,6 +13,7 @@ const prefix = '[owc-building-rollup]';
 function createConfig(_options, legacy) {
   const options = {
     outputDir: 'dist',
+    extensions: DEFAULT_EXTENSIONS,
     ..._options,
   };
 
@@ -36,10 +38,13 @@ function createConfig(_options, legacy) {
         }),
 
       // resolve bare import specifiers
-      resolve(),
+      resolve({
+        extensions: options.extensions,
+      }),
 
       // run code through babel
       babel({
+        extensions: options.extensions,
         plugins: [
           '@babel/plugin-syntax-dynamic-import',
           '@babel/plugin-syntax-import-meta',


### PR DESCRIPTION
I played around with the rollup setup for typescript, and after a lot of frustration, discovered that the rollup setup doesn't really support typescript (the demo code is just es6 with classes).

To reproduce this, add a type to the demo file, like this: `render(): TemplateResult {`,
and then run the ts-babel demo: `npm run build:ts-babel`.
You will then get the following error:
`[!] Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)`.

To fix this, all that is needed is to add `extensions` option to `node-resolve` and `babel` plugins.

Not sure what the best approach would be for adding them, but thinking options?

TODO: docs when an approach has been picked