### PR TITLE
fix(building-rollup): remove legacy scripts from modern watch mode

### DIFF
--- a/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
+++ b/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js
@@ -244,7 +244,7 @@ module.exports = (_pluginConfig = {}) => {
         copyPolyfills(pluginConfig, outputConfig);
         writeModules(pluginConfig, outputConfig, entryModules);
         writtenModules = true;
-      } else if (!writtenLegacyModules) {
+      } else if (pluginConfig.legacy && !writtenLegacyModules) {
         copyPolyfills(pluginConfig, outputConfig);
         writeLegacyModules(pluginConfig, outputConfig, entryModules);
         writtenLegacyModules = true;


### PR DESCRIPTION
Found an error when using the rollup **modern** setup in watch mode.
every time you change a file, there is be a bunch of systemjs imports at the bottom of the page, which should only have been used for the legacy setup.

<img width="848" alt="rollup-watch-mode-error" src="https://user-images.githubusercontent.com/3033516/59370321-8f1e5b00-8d42-11e9-9a02-90d461c6df34.png">

Seems to be a straightforward logical `if else` error:
https://github.com/open-wc/open-wc/blob/a064acb30c21fac2b79911b001aa49a0362c41a7/packages/building-rollup/plugins/rollup-plugin-modern-web/rollup-plugin-modern-web.js#L243-L251

that should be solved by:
```
else if (pluginConfig.legacy && !writtenLegacyModules) {
```

To reproduce:

1. use this standard modern rollup config:
```
const createDefaultConfig = require('@open-wc/building-rollup/modern-config');
const config = createDefaultConfig({
  input: './index.html'
});
```
2. run rollup in watch mode
3. inspect the index file in the dist folder
3. save a file
4. inspect the index file in the dist folder