### PR TITLE
fix(building-rollup): clean falsy plugins in legacy watch

### DIFF
--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -66,7 +66,7 @@ function createConfig(_options, legacy) {
               },
             },
           ],
-        ],
+        ].filter(_ => !!_),
         presets: [
           [
             '@babel/env',


### PR DESCRIPTION
When running watch mode using the legacy config, babel throws an error, since one of the plugins evaluates to falsy when not in production mode:

<img width="540" alt="Screenshot 2019-06-13 at 13 04 51" src="https://user-images.githubusercontent.com/3033516/59427849-ea505c00-8ddb-11e9-99c2-d9aa32d4ac16.png">

this is not the case for the modern config, since it filters out these plugins:

https://github.com/open-wc/open-wc/blob/6a0dce7ebd060c1d2a4c7c42a34ca8a9a8f22f6e/packages/building-rollup/modern-config.js#L33-L55