### PR TITLE
fix(building-rollup): make ts builds work for modern ts-babel

### DIFF
--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+const { DEFAULT_EXTENSIONS } = require('@babel/core');
 const { findSupportedBrowsers } = require('@open-wc/building-utils');
 const resolve = require('rollup-plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
@@ -11,6 +12,7 @@ const production = !process.env.ROLLUP_WATCH;
 module.exports = function createBasicConfig(_options) {
   const options = {
     outputDir: 'dist',
+    extensions: DEFAULT_EXTENSIONS,
     ..._options,
   };
 
@@ -27,10 +29,13 @@ module.exports = function createBasicConfig(_options) {
       options.input.endsWith('.html') && modernWeb(),
 
       // resolve bare import specifiers
-      resolve(),
+      resolve({
+        extensions: options.extensions,
+      }),
 
       // run code through babel
       babel({
+        extensions: options.extensions,
         plugins: [
           '@babel/plugin-syntax-dynamic-import',
           '@babel/plugin-syntax-import-meta',


### PR DESCRIPTION
Recently there was a change to fix `ts-babel` builds https://github.com/open-wc/open-wc/pull/487
That change was only affecting `modern-and-legacy`, but not `modern`.

It should have been part of the first pr, but might also highlight some code duplication between the two 😄