### PR TITLE
feat: package to parse and resolve import maps

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = config => {
         {
           pattern: config.grep
             ? config.grep
-            : 'packages/!(webpack-import-meta-loader|create|building-utils|webpack-index-html-plugin|import-maps-generate)/test/*.test.js',
+            : 'packages/!(webpack-import-meta-loader|create|building-utils|webpack-index-html-plugin|import-maps-generate|import-maps-resolve)/test/*.test.js',
           type: 'module',
         },
       ],

--- a/packages/import-maps-resolve/README.md
+++ b/packages/import-maps-resolve/README.md
@@ -1,0 +1,60 @@
+# Resolve import-maps
+
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
+
+This will allow you to parse and resolve urls by a given [import-map](https://github.com/WICG/import-maps).
+
+## Usage
+
+```bash
+yarn add @import-maps/resolve
+```
+
+You may then override a resolve method in your build process.
+
+```js
+import { parseFromString, resolve } from '@import-maps/resolve';
+
+// you probably want to cache the map processing and not redo it for every resolve
+// a simple example
+const mapCache = null;
+
+function myResolve(specifier) {
+  const currentDir = process.cwd();
+  if (!mapCache) {
+    const mapString = fs.readFileSync(path.join(currentDir, 'import-map.json'), 'utf-8');
+    mapCache = parseFromString(mapString, currentDir);
+  }
+
+  return specifier => resolve(specifier, mapCache, path.join(`${currentDir}::`, 'index.html');
+}
+```
+
+### Additional info
+
+The 3rd parameter of `resolve` is the "baseUrl/basePath" and it's format is `/path/to/root::/subdir/foo`.
+You can compare it with an url `http://example.com/subdir/foo`.
+- Everything before the `::` is sort of the `domain` e.g. `http://example.com/`
+- Everything after is the path/directory to your appliaction
+
+Such a path is needed as import maps support relative pathes as values.
+
+## Acknowledgments
+This implementation is heavily based on the [import-maps reference implementation](https://github.com/WICG/import-maps/tree/master/reference-implementation).
+Thanks to @domenic and @guybedford for sharing that prototype.
+
+Some adjustments have been made
+- Allow to process/resolve node pathes besides urls
+- Use mocha/chai for testing (already available in our setup)
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/import-maps-process/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/import-maps-resolve/babel.config.js
+++ b/packages/import-maps-resolve/babel.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  plugins: ['babel-plugin-transform-dynamic-import'],
+  ignore: ['./src/generators/*/templates/**/*'],
+  presets: [
+    [
+      '@babel/env',
+      {
+        targets: {
+          node: '10',
+        },
+        corejs: 2,
+        useBuiltIns: 'usage',
+      },
+    ],
+  ],
+};

--- a/packages/import-maps-resolve/package.json
+++ b/packages/import-maps-resolve/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@import-maps/resolve",
+  "version": "0.0.0",
+  "description": "Read and resolve urls via an import map",
+  "author": "open-wc",
+  "homepage": "https://github.com/open-wc/open-wc/",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wc/open-wc.git",
+    "directory": "packages/import-maps-resolve"
+  },
+  "keywords": [
+    "import-map",
+    "import-maps"
+  ],
+  "scripts": {
+    "build": "babel src --out-dir dist --copy-files --include-dotfiles",
+    "start": "npm run build && node ./dist/index.js",
+    "test": "mocha --require @babel/register",
+    "test:ci": "npm run test",
+    "test:watch": "onchange 'src/**/*.js' 'test/**/*.js' -- npm run test --silent",
+    "prepublishOnly": "npm run build && ../../scripts/insert-header.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "devDependencies": {
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.3.3",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.0.0",
+    "babel-plugin-transform-dynamic-import": "^2.1.0",
+    "chai": "^4.2.0",
+    "mocha": "^5.0.0",
+    "onchange": "^5.2.0"
+  }
+}

--- a/packages/import-maps-resolve/src/index.js
+++ b/packages/import-maps-resolve/src/index.js
@@ -1,0 +1,2 @@
+export { parseFromString } from './parser.js';
+export { resolve } from './resolver.js';

--- a/packages/import-maps-resolve/src/parser.js
+++ b/packages/import-maps-resolve/src/parser.js
@@ -1,0 +1,217 @@
+/* eslint-disable no-continue */
+/* eslint-disable no-restricted-syntax, no-console */
+import path from 'path';
+import {
+  tryURLParse,
+  hasFetchScheme,
+  tryURLLikeSpecifierParse,
+  BUILT_IN_MODULE_PROTOCOL,
+} from './utils.js';
+
+function isJSONObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function compare(a, b) {
+  if (a > b) {
+    return 1;
+  }
+  if (b > a) {
+    return -1;
+  }
+  return 0;
+}
+
+function longerLengthThenCodeUnitOrder(a, b) {
+  return compare(b.length, a.length) || compare(a, b);
+}
+
+function normalizeSpecifierKey(specifierKey, baseURL) {
+  // Ignore attempts to use the empty string as a specifier key
+  if (specifierKey === '') {
+    return null;
+  }
+
+  const url = tryURLLikeSpecifierParse(specifierKey, baseURL);
+  if (url !== null) {
+    const urlString = url.href;
+    if (url.protocol === BUILT_IN_MODULE_PROTOCOL && urlString.includes('/')) {
+      console.warn(
+        `Invalid specifier key "${urlString}". Built-in module specifiers must not contain "/".`,
+      );
+      return null;
+    }
+    return urlString;
+  }
+
+  return specifierKey;
+}
+
+function sortAndNormalizeSpecifierMap(obj, baseURL) {
+  if (!isJSONObject(obj)) {
+    throw new Error('needs to be an obj');
+  }
+
+  // Normalize all entries into arrays
+  const normalized = {};
+  for (const [specifierKey, value] of Object.entries(obj)) {
+    const normalizedSpecifierKey = normalizeSpecifierKey(specifierKey, baseURL);
+    if (normalizedSpecifierKey === null) {
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      normalized[normalizedSpecifierKey] = [value];
+    } else if (value === null) {
+      normalized[normalizedSpecifierKey] = [];
+    } else if (Array.isArray(value)) {
+      normalized[normalizedSpecifierKey] = obj[specifierKey];
+    }
+  }
+
+  // Normalize/validate each potential address in the array
+  for (const [specifierKey, potentialAddresses] of Object.entries(normalized)) {
+    if (!Array.isArray(potentialAddresses)) {
+      throw new Error('should be an array');
+    }
+
+    const validNormalizedAddresses = [];
+    for (const potentialAddress of potentialAddresses) {
+      if (typeof potentialAddress !== 'string') {
+        continue;
+      }
+
+      const addressURL = tryURLLikeSpecifierParse(potentialAddress, baseURL);
+      let addressUrlString = '';
+      if (addressURL !== null) {
+        if (addressURL.protocol === BUILT_IN_MODULE_PROTOCOL && addressURL.href.includes('/')) {
+          console.warn(
+            `Invalid target address "${potentialAddress}". Built-in module URLs must not contain "/".`,
+          );
+          continue;
+        }
+        addressUrlString = addressURL.href;
+      } else if (baseURL.includes('::')) {
+        const [rootPath, basePath] = baseURL.split('::');
+
+        const dirPath = potentialAddress.startsWith('/') ? '' : path.dirname(basePath);
+        addressUrlString = path.normalize(path.join(rootPath, dirPath, potentialAddress));
+      }
+
+      if (specifierKey.endsWith('/') && !addressUrlString.endsWith('/')) {
+        console.warn(
+          `Invalid target address "${addressUrlString}" for package specifier "${specifierKey}". ` +
+            `Package address targets must end with "/".`,
+        );
+        continue;
+      }
+
+      if (addressUrlString !== '') {
+        validNormalizedAddresses.push(addressUrlString);
+      }
+    }
+    normalized[specifierKey] = validNormalizedAddresses;
+  }
+
+  const sortedAndNormalized = {};
+  const sortedKeys = Object.keys(normalized).sort(longerLengthThenCodeUnitOrder);
+  for (const key of sortedKeys) {
+    sortedAndNormalized[key] = normalized[key];
+  }
+
+  return sortedAndNormalized;
+}
+
+function sortAndNormalizeScopes(obj, baseURL) {
+  const normalized = {};
+  for (const [scopePrefix, potentialSpecifierMap] of Object.entries(obj)) {
+    if (!isJSONObject(potentialSpecifierMap)) {
+      throw new TypeError(`The value for the "${scopePrefix}" scope prefix must be an object.`);
+    }
+
+    const scopePrefixURL = tryURLParse(scopePrefix, baseURL);
+    let scopeString = '';
+    if (scopePrefixURL !== null) {
+      if (!hasFetchScheme(scopePrefixURL)) {
+        console.warn(`Invalid scope "${scopePrefixURL}". Scope URLs must have a fetch scheme.`);
+        continue;
+      }
+      scopeString = scopePrefixURL.href;
+    } else {
+      const scopePrefixURLWithoutBase = tryURLParse(scopePrefix);
+      if (scopePrefixURLWithoutBase !== null) {
+        if (!hasFetchScheme(scopePrefixURLWithoutBase)) {
+          console.warn(
+            `Invalid scope "${scopePrefixURLWithoutBase}". Scope URLs must have a fetch scheme.`,
+          );
+          continue;
+        }
+        scopeString = scopePrefixURLWithoutBase.href;
+      } else if (baseURL.includes('::')) {
+        const [rootPath, basePath] = baseURL.split('::');
+
+        const dirPath = scopePrefix.startsWith('/') ? '' : path.dirname(basePath);
+        scopeString = path.normalize(path.join(rootPath, dirPath, scopePrefix));
+      } else {
+        continue;
+      }
+    }
+
+    normalized[scopeString] = sortAndNormalizeSpecifierMap(potentialSpecifierMap, baseURL);
+  }
+
+  const sortedAndNormalized = {};
+  const sortedKeys = Object.keys(normalized).sort(longerLengthThenCodeUnitOrder);
+  for (const key of sortedKeys) {
+    sortedAndNormalized[key] = normalized[key];
+  }
+
+  return sortedAndNormalized;
+}
+
+/**
+ * Processes and normalizes a given import-map string.
+ *
+ * @example
+ * const importMap = `{ import: {
+ *  'foo': './node_modules/foo/foo.js',
+ *  'bar': '/node_modules/bar/bar.js'
+ * }}`;
+ * parseFromString(importMap, '/path/to/root::/src');
+ * // { import: {
+ * //   'foo': ['/path/to/root/src/node_modules/foo/foo.js'],
+ * //   'bar': ['/path/to/root/node_modules/bar/bar.js']
+ * // }}
+ *
+ * @param {string} input   The import map as a string
+ * @param {string} baseURL The base url/path to your root + executing sub directory (separated by ::)
+ */
+export function parseFromString(input, baseURL) {
+  const parsed = JSON.parse(input);
+
+  if (!isJSONObject(parsed)) {
+    throw new TypeError('Import map JSON must be an object.');
+  }
+
+  let sortedAndNormalizedImports = {};
+  if ('imports' in parsed) {
+    if (!isJSONObject(parsed.imports)) {
+      throw new TypeError("Import map's imports value must be an object.");
+    }
+    sortedAndNormalizedImports = sortAndNormalizeSpecifierMap(parsed.imports, baseURL);
+  }
+
+  let sortedAndNormalizedScopes = {};
+  if ('scopes' in parsed) {
+    if (!isJSONObject(parsed.scopes)) {
+      throw new TypeError("Import map's scopes value must be an object.");
+    }
+    sortedAndNormalizedScopes = sortAndNormalizeScopes(parsed.scopes, baseURL);
+  }
+
+  // Always have these two keys, and exactly these two keys, in the result.
+  return {
+    imports: sortedAndNormalizedImports,
+    scopes: sortedAndNormalizedScopes,
+  };
+}

--- a/packages/import-maps-resolve/src/resolver.js
+++ b/packages/import-maps-resolve/src/resolver.js
@@ -1,0 +1,120 @@
+/* eslint-disable no-restricted-syntax */
+import { URL } from 'url';
+import {
+  tryURLLikeSpecifierParse,
+  BUILT_IN_MODULE_SCHEME,
+  BUILT_IN_MODULE_PROTOCOL,
+  isUrlString,
+} from './utils.js';
+
+const supportedBuiltInModules = new Set([`${BUILT_IN_MODULE_SCHEME}:blank`]);
+
+function resolveImportsMatch(normalizedSpecifier, specifierMap) {
+  for (const [specifierKey, rawAddresses] of Object.entries(specifierMap)) {
+    const addresses = rawAddresses.map(address =>
+      isUrlString(address) ? new URL(address) : address,
+    );
+    // Exact-match case
+    if (specifierKey === normalizedSpecifier) {
+      if (addresses.length === 0) {
+        throw new TypeError(`Specifier "${normalizedSpecifier}" was mapped to no addresses.`);
+      } else if (addresses.length === 1) {
+        const singleAddress = addresses[0];
+        if (
+          singleAddress.protocol === BUILT_IN_MODULE_PROTOCOL &&
+          !supportedBuiltInModules.has(singleAddress.href)
+        ) {
+          throw new TypeError(`The "${singleAddress.href}" built-in module is not implemented.`);
+        }
+
+        return singleAddress.href ? singleAddress.href : singleAddress;
+      } else if (
+        addresses.length === 2 &&
+        addresses[0].protocol === BUILT_IN_MODULE_PROTOCOL &&
+        addresses[1].protocol !== BUILT_IN_MODULE_PROTOCOL
+      ) {
+        return supportedBuiltInModules.has(addresses[0].href)
+          ? addresses[0].href
+          : addresses[1].href;
+      } else {
+        throw new Error(
+          'The reference implementation for multi-address fallbacks that are not ' +
+            '[built-in module, fetch-scheme URL] is not yet implemented.',
+        );
+      }
+    }
+
+    // Package prefix-match case
+    if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
+      if (addresses.length === 0) {
+        throw new TypeError(
+          `Specifier "${normalizedSpecifier}" was mapped to no addresses ` +
+            `(via prefix specifier key "${specifierKey}").`,
+        );
+      } else if (addresses.length === 1) {
+        const afterPrefix = normalizedSpecifier.substring(specifierKey.length);
+        if (isUrlString(addresses[0])) {
+          return new URL(afterPrefix, addresses[0]).href;
+        }
+        return `${addresses[0]}${afterPrefix}`;
+      } else {
+        throw new Error(
+          'The reference implementation for multi-address fallbacks that are not ' +
+            '[built-in module, fetch-scheme URL] is not yet implemented.',
+        );
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolves a given specifier via a parsedImportMap. Knowledge about the path/url of the currently
+ * executing script is required.
+ *
+ * @example
+ * const importMap = { import: {
+ *  'foo': ['/node_modules/foo/foo.js']
+ * }};
+ * resolve('foo', importMap, '/path/to/root::/src/index.html');
+ * // => /path/to/root/node_modules/foo/foo.js
+ *
+ * resolve('foo', importMap, 'http://example.com/my-app/src/index.html');
+ * // => http://example.com/node_modules/foo/foo.js
+ *
+ * @param {string} specifier       can be a full URL or a bare_specifier or bare_specifier + path
+ * @param {object} parsedImportMap normalized map string (already processed by parseFromString)
+ * @param {string} scriptURL       the scripts url/path that is requesting the resolve (neded to support scopes)
+ */
+export function resolve(specifier, parsedImportMap, scriptURL) {
+  const asURL = tryURLLikeSpecifierParse(specifier, scriptURL);
+  const normalizedSpecifier = asURL ? asURL.href : specifier;
+  const scriptURLString = scriptURL;
+
+  for (const [scopePrefix, scopeImports] of Object.entries(parsedImportMap.scopes)) {
+    if (
+      scopePrefix === scriptURLString ||
+      (scopePrefix.endsWith('/') && scriptURLString.startsWith(scopePrefix))
+    ) {
+      const scopeImportsMatch = resolveImportsMatch(normalizedSpecifier, scopeImports);
+      if (scopeImportsMatch) {
+        return scopeImportsMatch;
+      }
+    }
+  }
+
+  const topLevelImportsMatch = resolveImportsMatch(normalizedSpecifier, parsedImportMap.imports);
+  if (topLevelImportsMatch) {
+    return topLevelImportsMatch;
+  }
+
+  // The specifier was able to be turned into a URL, but wasn't remapped into anything.
+  if (asURL) {
+    if (asURL.protocol === BUILT_IN_MODULE_PROTOCOL && !supportedBuiltInModules.has(asURL.href)) {
+      throw new TypeError(`The "${asURL.href}" built-in module is not implemented.`);
+    }
+    return asURL.href;
+  }
+
+  throw new TypeError(`Unmapped bare specifier "${specifier}"`);
+}

--- a/packages/import-maps-resolve/src/utils.js
+++ b/packages/import-maps-resolve/src/utils.js
@@ -1,0 +1,58 @@
+import { URL } from 'url';
+
+// https://fetch.spec.whatwg.org/#fetch-scheme
+const FETCH_SCHEMES = new Set([
+  'http',
+  'https',
+  'ftp',
+  'about',
+  'blob',
+  'data',
+  'file',
+  'filesystem',
+]);
+
+// Tentative, so better to centralize so we can change in one place as necessary (including tests).
+export const BUILT_IN_MODULE_SCHEME = 'std';
+
+// Useful for comparing to .protocol
+export const BUILT_IN_MODULE_PROTOCOL = `${BUILT_IN_MODULE_SCHEME}:`;
+
+export function tryURLParse(string, baseURL) {
+  try {
+    return new URL(string, baseURL);
+  } catch (e) {
+    // TODO remove useless binding when ESLint and Jest support that
+    return null;
+  }
+}
+
+export function isUrlString(string) {
+  return !!tryURLParse(string);
+}
+
+export function hasFetchScheme(url) {
+  return FETCH_SCHEMES.has(url.protocol.slice(0, -1));
+}
+
+export function tryURLLikeSpecifierParse(specifier, baseURL) {
+  if (baseURL.includes('::')) {
+    return null;
+  }
+
+  if (specifier.startsWith('/') || specifier.startsWith('./') || specifier.startsWith('../')) {
+    return new URL(specifier, baseURL);
+  }
+
+  const url = tryURLParse(specifier);
+
+  if (url === null) {
+    return null;
+  }
+
+  if (hasFetchScheme(url) || url.protocol === BUILT_IN_MODULE_PROTOCOL) {
+    return url;
+  }
+
+  return null;
+}

--- a/packages/import-maps-resolve/test/helpers/parsing.js
+++ b/packages/import-maps-resolve/test/helpers/parsing.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-restricted-syntax */
+import chai from 'chai';
+import { parseFromString } from '../../src/parser.js';
+
+const { expect } = chai;
+
+function testWarningHandler(expectedWarnings) {
+  const warnings = [];
+  const { warn } = console;
+  console.warn = warning => {
+    warnings.push(warning);
+  };
+  return () => {
+    console.warn = warn;
+    expect(warnings).to.deep.equal(expectedWarnings);
+  };
+}
+
+export function expectSpecifierMap(input, baseURL, output, warnings = []) {
+  const checkWarnings1 = testWarningHandler(warnings);
+
+  expect(parseFromString(`{ "imports": ${input} }`, baseURL)).to.deep.equal({
+    imports: output,
+    scopes: {},
+  });
+
+  checkWarnings1();
+
+  const checkWarnings2 = testWarningHandler(warnings);
+
+  expect(
+    parseFromString(`{ "scopes": { "https://scope.example/":  ${input} } }`, baseURL),
+  ).to.deep.equal({ imports: {}, scopes: { 'https://scope.example/': output } });
+
+  checkWarnings2();
+}
+
+export function expectScopes(inputArray, baseURL, outputArray, warnings = []) {
+  const checkWarnings = testWarningHandler(warnings);
+
+  const inputScopesAsStrings = inputArray.map(scopePrefix => `${JSON.stringify(scopePrefix)}: {}`);
+  const inputString = `{ "scopes": { ${inputScopesAsStrings.join(', ')} } }`;
+
+  const outputScopesObject = {};
+  for (const outputScopePrefix of outputArray) {
+    outputScopesObject[outputScopePrefix] = {};
+  }
+
+  expect(parseFromString(inputString, baseURL)).to.deep.equal({
+    imports: {},
+    scopes: outputScopesObject,
+  });
+
+  checkWarnings();
+}
+
+export function expectBad(input, baseURL, warnings = []) {
+  const checkWarnings = testWarningHandler(warnings);
+  expect(() => parseFromString(input, baseURL)).to.throw(TypeError);
+  checkWarnings();
+}

--- a/packages/import-maps-resolve/test/parsing-addresses.test.js
+++ b/packages/import-maps-resolve/test/parsing-addresses.test.js
@@ -1,0 +1,292 @@
+/* eslint-disable no-restricted-syntax */
+import { expectSpecifierMap } from './helpers/parsing.js';
+import { BUILT_IN_MODULE_SCHEME } from '../src/utils.js';
+
+describe('Relative URL-like addresses', () => {
+  it('should accept strings prefixed with ./, ../, or /', () => {
+    expectSpecifierMap(
+      `{
+        "dotSlash": "./foo",
+        "dotDotSlash": "../foo",
+        "slash": "/foo"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        dotSlash: ['https://base.example/path1/path2/foo'],
+        dotDotSlash: ['https://base.example/path1/foo'],
+        slash: ['https://base.example/foo'],
+      },
+    );
+  });
+
+  it('should accept the literal strings ./, ../, or / with no suffix', () => {
+    expectSpecifierMap(
+      `{
+        "dotSlash": "./",
+        "dotDotSlash": "../",
+        "slash": "/"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        dotSlash: ['https://base.example/path1/path2/'],
+        dotDotSlash: ['https://base.example/path1/'],
+        slash: ['https://base.example/'],
+      },
+    );
+  });
+
+  it('should ignore percent-encoded variants of ./, ../, or /', () => {
+    expectSpecifierMap(
+      `{
+        "dotSlash1": "%2E/",
+        "dotDotSlash1": "%2E%2E/",
+        "dotSlash2": ".%2F",
+        "dotDotSlash2": "..%2F",
+        "slash2": "%2F",
+        "dotSlash3": "%2E%2F",
+        "dotDotSlash3": "%2E%2E%2F"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        dotSlash1: [],
+        dotDotSlash1: [],
+        dotSlash2: [],
+        dotDotSlash2: [],
+        slash2: [],
+        dotSlash3: [],
+        dotDotSlash3: [],
+      },
+    );
+  });
+});
+
+describe('Built-in module addresses', () => {
+  it('should accept URLs using the built-in module scheme', () => {
+    expectSpecifierMap(
+      `{
+        "foo": "${BUILT_IN_MODULE_SCHEME}:foo"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        foo: [`${BUILT_IN_MODULE_SCHEME}:foo`],
+      },
+    );
+  });
+
+  it('should ignore percent-encoded variants of the built-in module scheme', () => {
+    expectSpecifierMap(
+      `{
+        "foo": "${encodeURIComponent(`${BUILT_IN_MODULE_SCHEME}:`)}foo"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        foo: [],
+      },
+    );
+  });
+
+  it('should ignore and warn on built-in module URLs that contain "/"', () => {
+    expectSpecifierMap(
+      `{
+        "bad1": "${BUILT_IN_MODULE_SCHEME}:foo/",
+        "bad2": "${BUILT_IN_MODULE_SCHEME}:foo/bar",
+        "good": "${BUILT_IN_MODULE_SCHEME}:foo\\\\baz"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        bad1: [],
+        bad2: [],
+        good: [`${BUILT_IN_MODULE_SCHEME}:foo\\baz`],
+      },
+      [
+        `Invalid target address "${BUILT_IN_MODULE_SCHEME}:foo/". Built-in module URLs must not contain "/".`,
+        `Invalid target address "${BUILT_IN_MODULE_SCHEME}:foo/bar". Built-in module URLs must not contain "/".`,
+      ],
+    );
+  });
+});
+
+describe('Absolute URL addresses', () => {
+  it('should only accept absolute URL addresses with fetch schemes', () => {
+    expectSpecifierMap(
+      `{
+        "about": "about:good",
+        "blob": "blob:good",
+        "data": "data:good",
+        "file": "file:///good",
+        "filesystem": "filesystem:good",
+        "http": "http://good/",
+        "https": "https://good/",
+        "ftp": "ftp://good/",
+        "import": "import:bad",
+        "mailto": "mailto:bad",
+        "javascript": "javascript:bad",
+        "wss": "wss:bad"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        about: ['about:good'],
+        blob: ['blob:good'],
+        data: ['data:good'],
+        file: ['file:///good'],
+        filesystem: ['filesystem:good'],
+        http: ['http://good/'],
+        https: ['https://good/'],
+        ftp: ['ftp://good/'],
+        import: [],
+        mailto: [],
+        javascript: [],
+        wss: [],
+      },
+    );
+  });
+
+  it('should only accept absolute URL addresses with fetch schemes inside arrays', () => {
+    expectSpecifierMap(
+      `{
+        "about": ["about:good"],
+        "blob": ["blob:good"],
+        "data": ["data:good"],
+        "file": ["file:///good"],
+        "filesystem": ["filesystem:good"],
+        "http": ["http://good/"],
+        "https": ["https://good/"],
+        "ftp": ["ftp://good/"],
+        "import": ["import:bad"],
+        "mailto": ["mailto:bad"],
+        "javascript": ["javascript:bad"],
+        "wss": ["wss:bad"]
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        about: ['about:good'],
+        blob: ['blob:good'],
+        data: ['data:good'],
+        file: ['file:///good'],
+        filesystem: ['filesystem:good'],
+        http: ['http://good/'],
+        https: ['https://good/'],
+        ftp: ['ftp://good/'],
+        import: [],
+        mailto: [],
+        javascript: [],
+        wss: [],
+      },
+    );
+  });
+
+  it('should parse absolute URLs, ignoring unparseable ones', () => {
+    expectSpecifierMap(
+      `{
+        "unparseable1": "https://ex ample.org/",
+        "unparseable2": "https://example.com:demo",
+        "unparseable3": "http://[www.example.com]/",
+        "invalidButParseable1": "https:example.org",
+        "invalidButParseable2": "https://///example.com///",
+        "prettyNormal": "https://example.net",
+        "percentDecoding": "https://ex%41mple.com/",
+        "noPercentDecoding": "https://example.com/%41"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        unparseable1: [],
+        unparseable2: [],
+        unparseable3: [],
+        invalidButParseable1: ['https://example.org/'],
+        invalidButParseable2: ['https://example.com///'],
+        prettyNormal: ['https://example.net/'],
+        percentDecoding: ['https://example.com/'],
+        noPercentDecoding: ['https://example.com/%41'],
+      },
+    );
+  });
+
+  it('should parse absolute URLs, ignoring unparseable ones inside arrays', () => {
+    expectSpecifierMap(
+      `{
+        "unparseable1": ["https://ex ample.org/"],
+        "unparseable2": ["https://example.com:demo"],
+        "unparseable3": ["http://[www.example.com]/"],
+        "invalidButParseable1": ["https:example.org"],
+        "invalidButParseable2": ["https://///example.com///"],
+        "prettyNormal": ["https://example.net"],
+        "percentDecoding": ["https://ex%41mple.com/"],
+        "noPercentDecoding": ["https://example.com/%41"]
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        unparseable1: [],
+        unparseable2: [],
+        unparseable3: [],
+        invalidButParseable1: ['https://example.org/'],
+        invalidButParseable2: ['https://example.com///'],
+        prettyNormal: ['https://example.net/'],
+        percentDecoding: ['https://example.com/'],
+        noPercentDecoding: ['https://example.com/%41'],
+      },
+    );
+  });
+
+  describe('Failing addresses: mismatched trailing slashes', () => {
+    it('should warn for the simple case', () => {
+      expectSpecifierMap(
+        `{
+          "trailer/": "/notrailer"
+        }`,
+        'https://base.example/path1/path2/path3',
+        {
+          'trailer/': [],
+        },
+        [
+          `Invalid target address "https://base.example/notrailer" for package specifier "trailer/". Package address targets must end with "/".`,
+        ],
+      );
+    });
+
+    it('should warn for a mismatch alone in an array', () => {
+      expectSpecifierMap(
+        `{
+          "trailer/": ["/notrailer"]
+        }`,
+        'https://base.example/path1/path2/path3',
+        {
+          'trailer/': [],
+        },
+        [
+          `Invalid target address "https://base.example/notrailer" for package specifier "trailer/". Package address targets must end with "/".`,
+        ],
+      );
+    });
+
+    it('should warn for a mismatch alongside non-mismatches in an array', () => {
+      expectSpecifierMap(
+        `{
+          "trailer/": ["/atrailer/", "/notrailer"]
+        }`,
+        'https://base.example/path1/path2/path3',
+        {
+          'trailer/': ['https://base.example/atrailer/'],
+        },
+        [
+          `Invalid target address "https://base.example/notrailer" for package specifier "trailer/". Package address targets must end with "/".`,
+        ],
+      );
+    });
+  });
+});
+
+describe('Other invalid addresses', () => {
+  it('should ignore unprefixed strings that are not absolute URLs', () => {
+    for (const bad of ['bar', '\\bar', '~bar', '#bar', '?bar']) {
+      expectSpecifierMap(
+        `{
+          "foo": "${bad}"
+        }`,
+        'https://base.example/path1/path2/path3',
+        {
+          foo: [],
+        },
+      );
+    }
+  });
+});

--- a/packages/import-maps-resolve/test/parsing-node-adoption.test.js
+++ b/packages/import-maps-resolve/test/parsing-node-adoption.test.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-restricted-syntax */
+import { expectSpecifierMap } from './helpers/parsing.js';
+// import { BUILT_IN_MODULE_SCHEME } from '../src/utils.js';
+
+describe('Relative node addresses', () => {
+  it('should accept strings prefixed with ./, ../, or /', () => {
+    expectSpecifierMap(
+      `{
+        "dotSlash": "./foo",
+        "dotDotSlash": "../foo",
+        "slash": "/foo"
+      }`,
+      '/home/foo/project-a::/path1/path2/path3',
+      {
+        dotSlash: ['/home/foo/project-a/path1/path2/foo'],
+        dotDotSlash: ['/home/foo/project-a/path1/foo'],
+        slash: ['/home/foo/project-a/foo'],
+      },
+    );
+  });
+
+  it('should accept the literal strings ./, ../, or / with no suffix', () => {
+    expectSpecifierMap(
+      `{
+        "dotSlash": "./",
+        "dotDotSlash": "../",
+        "slash": "/"
+      }`,
+      '/home/foo/project-a::/path1/path2/path3',
+      {
+        dotSlash: ['/home/foo/project-a/path1/path2/'],
+        dotDotSlash: ['/home/foo/project-a/path1/'],
+        slash: ['/home/foo/project-a/'],
+      },
+    );
+  });
+});

--- a/packages/import-maps-resolve/test/parsing-schema.test.js
+++ b/packages/import-maps-resolve/test/parsing-schema.test.js
@@ -1,0 +1,135 @@
+/* eslint-disable no-restricted-syntax */
+import chai from 'chai';
+import { parseFromString } from '../src/parser.js';
+import { expectBad, expectSpecifierMap } from './helpers/parsing.js';
+
+const { expect } = chai;
+
+const nonObjectStrings = ['null', 'true', '1', '"foo"', '[]'];
+
+// test('Invalid JSON', () => {
+//   expect(() => parseFromString('{ imports: {} }', 'https://base.example/')).toThrow(SyntaxError);
+// });
+
+describe('Mismatching the top-level schema', () => {
+  it('should throw for top-level non-objects', () => {
+    for (const nonObject of nonObjectStrings) {
+      expectBad(nonObject, 'https://base.example/');
+    }
+  });
+
+  it('should throw if imports is a non-object', () => {
+    for (const nonObject of nonObjectStrings) {
+      expectBad(`{ "imports": ${nonObject} }`, 'https://base.example/');
+    }
+  });
+
+  it('should throw if scopes is a non-object', () => {
+    for (const nonObject of nonObjectStrings) {
+      expectBad(`{ "scopes": ${nonObject} }`, 'https://base.example/');
+    }
+  });
+
+  it('should ignore unspecified top-level entries', () => {
+    expect(
+      parseFromString(
+        `{
+      "imports": {},
+      "new-feature": {}
+    }`,
+        'https://base.example/',
+      ),
+    ).to.deep.equal({ imports: {}, scopes: {} });
+  });
+});
+
+describe('Mismatching the specifier map schema', () => {
+  const invalidAddressStrings = ['true', '1', '{}'];
+  const invalidInsideArrayStrings = ['null', 'true', '1', '{}', '[]'];
+
+  it('should ignore entries where the address is not a string, array, or null', () => {
+    for (const invalid of invalidAddressStrings) {
+      expectSpecifierMap(
+        `{
+          "foo": ${invalid},
+          "bar": ["https://example.com/"]
+        }`,
+        'https://base.example/',
+        {
+          bar: ['https://example.com/'],
+        },
+      );
+    }
+  });
+
+  it('should ignore entries where the specifier key is an empty string', () => {
+    expectSpecifierMap(
+      `{
+        "": ["https://example.com/"]
+      }`,
+      'https://base.example/',
+      {},
+    );
+  });
+
+  it('should ignore members of an address array that are not strings', () => {
+    for (const invalid of invalidInsideArrayStrings) {
+      expectSpecifierMap(
+        `{
+          "foo": ["https://example.com/", ${invalid}],
+          "bar": ["https://example.com/"]
+        }`,
+        'https://base.example/',
+        {
+          foo: ['https://example.com/'],
+          bar: ['https://example.com/'],
+        },
+      );
+    }
+  });
+
+  it("should throw if a scope's value is not an object", () => {
+    for (const invalid of nonObjectStrings) {
+      expectBad(`{ "scopes": { "https://scope.example/": ${invalid} } }`, 'https://base.example/');
+    }
+  });
+});
+
+describe('Normalization', () => {
+  it('should normalize empty import maps to have imports and scopes keys', () => {
+    expect(parseFromString(`{}`, 'https://base.example/')).to.deep.equal({
+      imports: {},
+      scopes: {},
+    });
+  });
+
+  it('should normalize an import map without imports to have imports', () => {
+    expect(parseFromString(`{ "scopes": {} }`, 'https://base.example/')).to.deep.equal({
+      imports: {},
+      scopes: {},
+    });
+  });
+
+  it('should normalize an import map without scopes to have scopes', () => {
+    expect(parseFromString(`{ "imports": {} }`, 'https://base.example/')).to.deep.equal({
+      imports: {},
+      scopes: {},
+    });
+  });
+
+  it('should normalize addresses to arrays', () => {
+    expectSpecifierMap(
+      `{
+        "foo": "https://example.com/1",
+        "bar": ["https://example.com/2"],
+        "baz": null
+      }`,
+      'https://base.example/',
+      {
+        foo: ['https://example.com/1'],
+        bar: ['https://example.com/2'],
+        baz: [],
+      },
+    );
+  });
+});

--- a/packages/import-maps-resolve/test/parsing-scope-keys.test.js
+++ b/packages/import-maps-resolve/test/parsing-scope-keys.test.js
@@ -1,0 +1,111 @@
+import { expectScopes } from './helpers/parsing.js';
+
+describe('Relative URL scope keys', () => {
+  it('should work with no prefix', () => {
+    expectScopes(['foo'], 'https://base.example/path1/path2/path3', [
+      'https://base.example/path1/path2/foo',
+    ]);
+  });
+
+  it('should work with ./, ../, and / prefixes', () => {
+    expectScopes(['./foo', '../foo', '/foo'], 'https://base.example/path1/path2/path3', [
+      'https://base.example/path1/path2/foo',
+      'https://base.example/path1/foo',
+      'https://base.example/foo',
+    ]);
+  });
+
+  it('should work with /s, ?s, and #s', () => {
+    expectScopes(['foo/bar?baz#qux'], 'https://base.example/path1/path2/path3', [
+      'https://base.example/path1/path2/foo/bar?baz#qux',
+    ]);
+  });
+
+  it('should work with an empty string scope key', () => {
+    expectScopes([''], 'https://base.example/path1/path2/path3', [
+      'https://base.example/path1/path2/path3',
+    ]);
+  });
+
+  it('should work with / suffixes', () => {
+    expectScopes(
+      ['foo/', './foo/', '../foo/', '/foo/', '/foo//'],
+      'https://base.example/path1/path2/path3',
+      [
+        'https://base.example/path1/path2/foo/',
+        'https://base.example/path1/path2/foo/',
+        'https://base.example/path1/foo/',
+        'https://base.example/foo/',
+        'https://base.example/foo//',
+      ],
+    );
+  });
+
+  it('should deduplicate based on URL parsing rules', () => {
+    expectScopes(['foo/\\', 'foo//', 'foo\\\\'], 'https://base.example/path1/path2/path3', [
+      'https://base.example/path1/path2/foo//',
+    ]);
+  });
+});
+
+describe('Absolute URL scope keys', () => {
+  it('should only accept absolute URL scope keys with fetch schemes', () => {
+    expectScopes(
+      [
+        'about:good',
+        'blob:good',
+        'data:good',
+        'file:///good',
+        'filesystem:good',
+        'http://good/',
+        'https://good/',
+        'ftp://good/',
+        'import:bad',
+        'mailto:bad',
+        // eslint-disable-next-line no-script-url
+        'javascript:bad',
+        'wss:ba',
+      ],
+      'https://base.example/path1/path2/path3',
+      [
+        'about:good',
+        'blob:good',
+        'data:good',
+        'file:///good',
+        'filesystem:good',
+        'http://good/',
+        'https://good/',
+        'ftp://good/',
+      ],
+      [
+        'Invalid scope "import:bad". Scope URLs must have a fetch scheme.',
+        'Invalid scope "mailto:bad". Scope URLs must have a fetch scheme.',
+        'Invalid scope "javascript:bad". Scope URLs must have a fetch scheme.',
+        'Invalid scope "wss://ba/". Scope URLs must have a fetch scheme.',
+      ],
+    );
+  });
+
+  it('should parse absolute URL scope keys, ignoring unparseable ones', () => {
+    expectScopes(
+      [
+        'https://ex ample.org/',
+        'https://example.com:demo',
+        'http://[www.example.com]/',
+        'https:example.org',
+        'https://///example.com///',
+        'https://example.net',
+        'https://ex%41mple.com/foo/',
+        'https://example.com/%41',
+      ],
+      'https://base.example/path1/path2/path3',
+      [
+        'https://base.example/path1/path2/example.org', // tricky case! remember we have a base URL
+        'https://example.com///',
+        'https://example.net/',
+        'https://example.com/foo/',
+        'https://example.com/%41',
+      ],
+    );
+  });
+});

--- a/packages/import-maps-resolve/test/parsing-specifier-keys.test.js
+++ b/packages/import-maps-resolve/test/parsing-specifier-keys.test.js
@@ -1,0 +1,145 @@
+import { expectSpecifierMap } from './helpers/parsing.js';
+import { BUILT_IN_MODULE_SCHEME } from '../src/utils.js';
+
+const BLANK = `${BUILT_IN_MODULE_SCHEME}:blank`;
+
+describe('Relative URL-like specifier keys', () => {
+  it('should absolutize strings prefixed with ./, ../, or / into the corresponding URLs', () => {
+    expectSpecifierMap(
+      `{
+        "./foo": "/dotslash",
+        "../foo": "/dotdotslash",
+        "/foo": "/slash"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        'https://base.example/path1/path2/foo': ['https://base.example/dotslash'],
+        'https://base.example/path1/foo': ['https://base.example/dotdotslash'],
+        'https://base.example/foo': ['https://base.example/slash'],
+      },
+    );
+  });
+
+  it('should absolutize the literal strings ./, ../, or / with no suffix', () => {
+    expectSpecifierMap(
+      `{
+        "./": "/dotslash/",
+        "../": "/dotdotslash/",
+        "/": "/slash/"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        'https://base.example/path1/path2/': ['https://base.example/dotslash/'],
+        'https://base.example/path1/': ['https://base.example/dotdotslash/'],
+        'https://base.example/': ['https://base.example/slash/'],
+      },
+    );
+  });
+
+  it('should treat percent-encoded variants of ./, ../, or / as bare specifiers', () => {
+    expectSpecifierMap(
+      `{
+        "%2E/": "/dotSlash1/",
+        "%2E%2E/": "/dotDotSlash1/",
+        ".%2F": "/dotSlash2",
+        "..%2F": "/dotDotSlash2",
+        "%2F": "/slash2",
+        "%2E%2F": "/dotSlash3",
+        "%2E%2E%2F": "/dotDotSlash3"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        '%2E/': ['https://base.example/dotSlash1/'],
+        '%2E%2E/': ['https://base.example/dotDotSlash1/'],
+        '.%2F': ['https://base.example/dotSlash2'],
+        '..%2F': ['https://base.example/dotDotSlash2'],
+        '%2F': ['https://base.example/slash2'],
+        '%2E%2F': ['https://base.example/dotSlash3'],
+        '%2E%2E%2F': ['https://base.example/dotDotSlash3'],
+      },
+    );
+  });
+});
+
+describe('Absolute URL specifier keys', () => {
+  it('should only accept absolute URL specifier keys with fetch schemes, treating others as bare specifiers', () => {
+    expectSpecifierMap(
+      `{
+        "about:good": "/about",
+        "blob:good": "/blob",
+        "data:good": "/data",
+        "file:///good": "/file",
+        "filesystem:good": "/filesystem",
+        "http://good/": "/http/",
+        "https://good/": "/https/",
+        "ftp://good/": "/ftp/",
+        "import:bad": "/import",
+        "mailto:bad": "/mailto",
+        "javascript:bad": "/javascript",
+        "wss:bad": "/wss"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        'about:good': ['https://base.example/about'],
+        'blob:good': ['https://base.example/blob'],
+        'data:good': ['https://base.example/data'],
+        'file:///good': ['https://base.example/file'],
+        'filesystem:good': ['https://base.example/filesystem'],
+        'http://good/': ['https://base.example/http/'],
+        'https://good/': ['https://base.example/https/'],
+        'ftp://good/': ['https://base.example/ftp/'],
+        'import:bad': ['https://base.example/import'],
+        'mailto:bad': ['https://base.example/mailto'],
+        // eslint-disable-next-line no-script-url
+        'javascript:bad': ['https://base.example/javascript'],
+        'wss:bad': ['https://base.example/wss'],
+      },
+    );
+  });
+
+  it('should parse absolute URLs, treating unparseable ones as bare specifiers', () => {
+    expectSpecifierMap(
+      `{
+        "https://ex ample.org/": "/unparseable1/",
+        "https://example.com:demo": "/unparseable2",
+        "http://[www.example.com]/": "/unparseable3/",
+        "https:example.org": "/invalidButParseable1/",
+        "https://///example.com///": "/invalidButParseable2/",
+        "https://example.net": "/prettyNormal/",
+        "https://ex%41mple.com/": "/percentDecoding/",
+        "https://example.com/%41": "/noPercentDecoding"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        'https://ex ample.org/': ['https://base.example/unparseable1/'],
+        'https://example.com:demo': ['https://base.example/unparseable2'],
+        'http://[www.example.com]/': ['https://base.example/unparseable3/'],
+        'https://example.org/': ['https://base.example/invalidButParseable1/'],
+        'https://example.com///': ['https://base.example/invalidButParseable2/'],
+        'https://example.net/': ['https://base.example/prettyNormal/'],
+        'https://example.com/': ['https://base.example/percentDecoding/'],
+        'https://example.com/%41': ['https://base.example/noPercentDecoding'],
+      },
+    );
+  });
+
+  it('should only parse built-in module specifier keys without a /', () => {
+    expectSpecifierMap(
+      `{
+        "${BLANK}": "/blank",
+        "${BLANK}/": "/blank/",
+        "${BLANK}/foo": "/blank/foo",
+        "${BLANK}\\\\foo": "/blank/backslashfoo"
+      }`,
+      'https://base.example/path1/path2/path3',
+      {
+        [BLANK]: ['https://base.example/blank'],
+        [`${BLANK}\\foo`]: ['https://base.example/blank/backslashfoo'],
+      },
+      [
+        `Invalid specifier key "${BLANK}/". Built-in module specifiers must not contain "/".`,
+        `Invalid specifier key "${BLANK}/foo". Built-in module specifiers must not contain "/".`,
+      ],
+    );
+  });
+});

--- a/packages/import-maps-resolve/test/resolving-builtins.test.js
+++ b/packages/import-maps-resolve/test/resolving-builtins.test.js
@@ -1,0 +1,105 @@
+import chai from 'chai';
+import { parseFromString } from '../src/parser.js';
+import { resolve } from '../src/resolver.js';
+import { BUILT_IN_MODULE_SCHEME } from '../src/utils.js';
+
+const { expect } = chai;
+
+const mapBaseURL = 'https://example.com/app/index.html';
+const scriptURL = 'https://example.com/js/app.mjs';
+
+const BLANK = `${BUILT_IN_MODULE_SCHEME}:blank`;
+const NONE = `${BUILT_IN_MODULE_SCHEME}:none`;
+
+function makeResolveUnderTest(mapString) {
+  const map = parseFromString(mapString, mapBaseURL);
+  return specifier => resolve(specifier, map, scriptURL);
+}
+
+describe('Unmapped built-in module specifiers', () => {
+  const resolveUnderTest = makeResolveUnderTest(`{}`);
+
+  it(`should resolve "${BLANK}" to "${BLANK}"`, () => {
+    expect(resolveUnderTest(BLANK)).to.equal(BLANK);
+  });
+
+  it(`should error resolving "${NONE}"`, () => {
+    expect(() => resolveUnderTest(NONE)).to.throw(TypeError);
+  });
+});
+
+describe('Remapping built-in module specifiers', () => {
+  it('should remap built-in modules', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "${BLANK}": "./blank.mjs",
+        "${NONE}": "./none.mjs"
+      }
+    }`);
+
+    expect(resolveUnderTest(BLANK)).to.equal('https://example.com/app/blank.mjs');
+    expect(resolveUnderTest(NONE)).to.equal('https://example.com/app/none.mjs');
+  });
+
+  it('should remap built-in modules with fallbacks', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "${BLANK}": ["${BLANK}", "./blank.mjs"],
+        "${NONE}": ["${NONE}", "./none.mjs"]
+      }
+    }`);
+
+    expect(resolveUnderTest(BLANK)).to.equal(BLANK);
+    expect(resolveUnderTest(NONE)).to.equal('https://example.com/app/none.mjs');
+  });
+});
+
+describe('Remapping to built-in modules', () => {
+  const resolveUnderTest = makeResolveUnderTest(`{
+    "imports": {
+      "blank": "${BLANK}",
+      "/blank": "${BLANK}",
+      "none": "${NONE}",
+      "/none": "${NONE}"
+    }
+  }`);
+
+  it(`should remap to "${BLANK}"`, () => {
+    expect(resolveUnderTest('blank')).to.equal(BLANK);
+    expect(resolveUnderTest('/blank')).to.equal(BLANK);
+  });
+
+  it(`should remap to "${BLANK}" for URL-like specifiers`, () => {
+    expect(resolveUnderTest('/blank')).to.equal(BLANK);
+    expect(resolveUnderTest('https://example.com/blank')).to.equal(BLANK);
+    expect(resolveUnderTest('https://///example.com/blank')).to.equal(BLANK);
+  });
+
+  it(`should fail when remapping to "${NONE}"`, () => {
+    expect(() => resolveUnderTest('none')).to.throw(TypeError);
+    expect(() => resolveUnderTest('/none')).to.throw(TypeError);
+  });
+});
+
+describe('Fallbacks with built-in module addresses', () => {
+  const resolveUnderTest = makeResolveUnderTest(`{
+    "imports": {
+      "blank": [
+        "${BLANK}",
+        "./blank-fallback.mjs"
+      ],
+      "none": [
+        "${NONE}",
+        "./none-fallback.mjs"
+      ]
+    }
+  }`);
+
+  it(`should resolve to "${BLANK}"`, () => {
+    expect(resolveUnderTest('blank')).to.equal(BLANK);
+  });
+
+  it(`should fall back past "${NONE}"`, () => {
+    expect(resolveUnderTest('none')).to.equal('https://example.com/app/none-fallback.mjs');
+  });
+});

--- a/packages/import-maps-resolve/test/resolving-node-adoption.test.js
+++ b/packages/import-maps-resolve/test/resolving-node-adoption.test.js
@@ -1,0 +1,79 @@
+import chai from 'chai';
+import { parseFromString } from '../src/parser.js';
+import { resolve } from '../src/resolver.js';
+
+const { expect } = chai;
+
+const mapBaseURL = '/home/foo/project-a::/app/index.js';
+const scriptURL = '/home/foo/project-a/app/node_modules/foo/foo.js';
+
+function makeResolveUnderTest(mapString) {
+  const map = parseFromString(mapString, mapBaseURL);
+  return specifier => resolve(specifier, map, scriptURL);
+}
+
+describe('Mapped using the "imports" key only (no scopes)', () => {
+  it('should fail when the mapping is to an empty array', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "moment": null,
+        "lodash": []
+      }
+    }`);
+
+    expect(() => resolveUnderTest('moment')).to.throw(TypeError);
+    expect(() => resolveUnderTest('lodash')).to.throw(TypeError);
+  });
+
+  describe('Package-like scenarios', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "moment": "/node_modules/moment/src/moment.js",
+        "moment/": "/node_modules/moment/src/",
+        "lodash-dot": "./node_modules/lodash-es/lodash.js",
+        "lodash-dot/": "./node_modules/lodash-es/",
+        "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+        "lodash-dotdot/": "../node_modules/lodash-es/",
+        "nowhere/": []
+      }
+    }`);
+
+    it('should work for package main modules', () => {
+      expect(resolveUnderTest('moment')).to.equal(
+        '/home/foo/project-a/node_modules/moment/src/moment.js',
+      );
+      expect(resolveUnderTest('lodash-dot')).to.equal(
+        '/home/foo/project-a/app/node_modules/lodash-es/lodash.js',
+      );
+      expect(resolveUnderTest('lodash-dotdot')).to.equal(
+        '/home/foo/project-a/node_modules/lodash-es/lodash.js',
+      );
+    });
+
+    it('should work for package submodules', () => {
+      expect(resolveUnderTest('moment/foo')).to.equal(
+        '/home/foo/project-a/node_modules/moment/src/foo',
+      );
+      expect(resolveUnderTest('lodash-dot/foo')).to.equal(
+        '/home/foo/project-a/app/node_modules/lodash-es/foo',
+      );
+      expect(resolveUnderTest('lodash-dotdot/foo')).to.equal(
+        '/home/foo/project-a/node_modules/lodash-es/foo',
+      );
+    });
+
+    it('should work for package names that end in a slash by just passing through', () => {
+      // TODO: is this the right behavior, or should we throw?
+      expect(resolveUnderTest('moment/')).to.equal('/home/foo/project-a/node_modules/moment/src/');
+    });
+
+    it('should still fail for package modules that are not declared', () => {
+      expect(() => resolveUnderTest('underscore/')).to.throw(TypeError);
+      expect(() => resolveUnderTest('underscore/foo')).to.throw(TypeError);
+    });
+
+    it('should fail for package submodules that map to nowhere', () => {
+      expect(() => resolveUnderTest('nowhere/foo')).to.throw(TypeError);
+    });
+  });
+});

--- a/packages/import-maps-resolve/test/resolving-not-yet-implemented.test.js
+++ b/packages/import-maps-resolve/test/resolving-not-yet-implemented.test.js
@@ -1,0 +1,48 @@
+import chai from 'chai';
+import { parseFromString } from '../src/parser.js';
+import { resolve } from '../src/resolver.js';
+import { BUILT_IN_MODULE_SCHEME } from '../src/utils.js';
+
+const { expect } = chai;
+
+const mapBaseURL = 'https://example.com/app/index.html';
+const scriptURL = 'https://example.com/js/app.mjs';
+
+const BLANK = `${BUILT_IN_MODULE_SCHEME}:blank`;
+
+function makeResolveUnderTest(mapString) {
+  const map = parseFromString(mapString, mapBaseURL);
+  return specifier => resolve(specifier, map, scriptURL);
+}
+
+describe('Fallbacks that are not [built-in, fetch scheme]', () => {
+  const resolveUnderTest = makeResolveUnderTest(`{
+    "imports": {
+      "bad1": [
+        "${BLANK}",
+        "${BLANK}"
+      ],
+      "bad2": [
+        "${BLANK}",
+        "/bad2-1.mjs",
+        "/bad2-2.mjs"
+      ],
+      "bad3": [
+        "/bad3-1.mjs",
+        "/bad3-2.mjs"
+      ]
+    }
+  }`);
+
+  it('should fail for [built-in, built-in]', () => {
+    expect(() => resolveUnderTest('bad1')).to.throw(/not yet implemented/);
+  });
+
+  it('should fail for [built-in, fetch scheme, fetch scheme]', () => {
+    expect(() => resolveUnderTest('bad2')).to.throw(/not yet implemented/);
+  });
+
+  it('should fail for [fetch scheme, fetch scheme]', () => {
+    expect(() => resolveUnderTest('bad3')).to.throw(/not yet implemented/);
+  });
+});

--- a/packages/import-maps-resolve/test/resolving-scopes.test.js
+++ b/packages/import-maps-resolve/test/resolving-scopes.test.js
@@ -1,0 +1,277 @@
+import chai from 'chai';
+import { URL } from 'url';
+import { parseFromString } from '../src/parser.js';
+import { resolve } from '../src/resolver.js';
+
+const { expect } = chai;
+
+const mapBaseURL = 'https://example.com/app/index.html';
+
+function makeResolveUnderTest(mapString) {
+  const map = parseFromString(mapString, mapBaseURL);
+  return (specifier, baseURL) => resolve(specifier, map, baseURL);
+}
+
+describe('Mapped using scope instead of "imports"', () => {
+  const jsNonDirURL = 'https://example.com/js';
+  const jsPrefixedURL = 'https://example.com/jsiscool';
+  const inJSDirURL = 'https://example.com/js/app.mjs';
+  const topLevelURL = 'https://example.com/app.mjs';
+
+  it('should fail when the mapping is to an empty array', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "scopes": {
+        "/js/": {
+          "moment": null,
+          "lodash": []
+        }
+      }
+    }`);
+
+    expect(() => resolveUnderTest('moment', inJSDirURL)).to.throw(TypeError);
+    expect(() => resolveUnderTest('lodash', inJSDirURL)).to.throw(TypeError);
+  });
+
+  describe('Exact vs. prefix based matching', () => {
+    it('should match correctly when both are in the map', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          },
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      }`);
+
+      expect(resolveUnderTest('moment', jsNonDirURL)).to.equal(
+        'https://example.com/only-triggered-by-exact/moment',
+      );
+      expect(resolveUnderTest('moment/foo', jsNonDirURL)).to.equal(
+        'https://example.com/only-triggered-by-exact/moment/foo',
+      );
+
+      expect(resolveUnderTest('moment', inJSDirURL)).to.equal(
+        'https://example.com/triggered-by-any-subpath/moment',
+      );
+      expect(resolveUnderTest('moment/foo', inJSDirURL)).to.equal(
+        'https://example.com/triggered-by-any-subpath/moment/foo',
+      );
+
+      expect(() => resolveUnderTest('moment', jsPrefixedURL)).to.throw(TypeError);
+      expect(() => resolveUnderTest('moment/foo', jsPrefixedURL)).to.throw(TypeError);
+    });
+
+    it('should match correctly when only an exact match is in the map', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          }
+        }
+      }`);
+
+      expect(resolveUnderTest('moment', jsNonDirURL)).to.equal(
+        'https://example.com/only-triggered-by-exact/moment',
+      );
+      expect(resolveUnderTest('moment/foo', jsNonDirURL)).to.equal(
+        'https://example.com/only-triggered-by-exact/moment/foo',
+      );
+
+      expect(() => resolveUnderTest('moment', inJSDirURL)).to.throw(TypeError);
+      expect(() => resolveUnderTest('moment/foo', inJSDirURL)).to.throw(TypeError);
+
+      expect(() => resolveUnderTest('moment', jsPrefixedURL)).to.throw(TypeError);
+      expect(() => resolveUnderTest('moment/foo', jsPrefixedURL)).to.throw(TypeError);
+    });
+
+    it('should match correctly when only a prefix match is in the map', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "scopes": {
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      }`);
+
+      expect(() => resolveUnderTest('moment', jsNonDirURL)).to.throw(TypeError);
+      expect(() => resolveUnderTest('moment/foo', jsNonDirURL)).to.throw(TypeError);
+
+      expect(resolveUnderTest('moment', inJSDirURL)).to.equal(
+        'https://example.com/triggered-by-any-subpath/moment',
+      );
+      expect(resolveUnderTest('moment/foo', inJSDirURL)).to.equal(
+        'https://example.com/triggered-by-any-subpath/moment/foo',
+      );
+
+      expect(() => resolveUnderTest('moment', jsPrefixedURL)).to.throw(TypeError);
+      expect(() => resolveUnderTest('moment/foo', jsPrefixedURL)).to.throw(TypeError);
+    });
+  });
+
+  describe('Package-like scenarios', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "moment": "/node_modules/moment/src/moment.js",
+        "moment/": "/node_modules/moment/src/",
+        "lodash-dot": "./node_modules/lodash-es/lodash.js",
+        "lodash-dot/": "./node_modules/lodash-es/",
+        "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+        "lodash-dotdot/": "../node_modules/lodash-es/"
+      },
+      "scopes": {
+        "/": {
+          "moment": "/node_modules_3/moment/src/moment.js",
+          "vue": "/node_modules_3/vue/dist/vue.runtime.esm.js"
+        },
+        "/js/": {
+          "lodash-dot": "./node_modules_2/lodash-es/lodash.js",
+          "lodash-dot/": "./node_modules_2/lodash-es/",
+          "lodash-dotdot": "../node_modules_2/lodash-es/lodash.js",
+          "lodash-dotdot/": "../node_modules_2/lodash-es/"
+        }
+      }
+    }`);
+
+    it('should resolve scoped', () => {
+      expect(resolveUnderTest('lodash-dot', inJSDirURL)).to.equal(
+        'https://example.com/app/node_modules_2/lodash-es/lodash.js',
+      );
+      expect(resolveUnderTest('lodash-dotdot', inJSDirURL)).to.equal(
+        'https://example.com/node_modules_2/lodash-es/lodash.js',
+      );
+      expect(resolveUnderTest('lodash-dot/foo', inJSDirURL)).to.equal(
+        'https://example.com/app/node_modules_2/lodash-es/foo',
+      );
+      expect(resolveUnderTest('lodash-dotdot/foo', inJSDirURL)).to.equal(
+        'https://example.com/node_modules_2/lodash-es/foo',
+      );
+    });
+
+    it('should apply best scope match', () => {
+      expect(resolveUnderTest('moment', topLevelURL)).to.equal(
+        'https://example.com/node_modules_3/moment/src/moment.js',
+      );
+      expect(resolveUnderTest('moment', inJSDirURL)).to.equal(
+        'https://example.com/node_modules_3/moment/src/moment.js',
+      );
+      expect(resolveUnderTest('vue', inJSDirURL)).to.equal(
+        'https://example.com/node_modules_3/vue/dist/vue.runtime.esm.js',
+      );
+    });
+
+    it('should fallback to "imports"', () => {
+      expect(resolveUnderTest('moment/foo', topLevelURL)).to.equal(
+        'https://example.com/node_modules/moment/src/foo',
+      );
+      expect(resolveUnderTest('moment/foo', inJSDirURL)).to.equal(
+        'https://example.com/node_modules/moment/src/foo',
+      );
+      expect(resolveUnderTest('lodash-dot', topLevelURL)).to.equal(
+        'https://example.com/app/node_modules/lodash-es/lodash.js',
+      );
+      expect(resolveUnderTest('lodash-dotdot', topLevelURL)).to.equal(
+        'https://example.com/node_modules/lodash-es/lodash.js',
+      );
+      expect(resolveUnderTest('lodash-dot/foo', topLevelURL)).to.equal(
+        'https://example.com/app/node_modules/lodash-es/foo',
+      );
+      expect(resolveUnderTest('lodash-dotdot/foo', topLevelURL)).to.equal(
+        'https://example.com/node_modules/lodash-es/foo',
+      );
+    });
+
+    it('should still fail for package-like specifiers that are not declared', () => {
+      expect(() => resolveUnderTest('underscore/', inJSDirURL)).to.throw(TypeError);
+      expect(() => resolveUnderTest('underscore/foo', inJSDirURL)).to.throw(TypeError);
+    });
+  });
+
+  describe('The scope inheritance example from the README', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "a": "/a-1.mjs",
+        "b": "/b-1.mjs",
+        "c": "/c-1.mjs"
+      },
+      "scopes": {
+        "/scope2/": {
+          "a": "/a-2.mjs"
+        },
+        "/scope2/scope3/": {
+          "b": "/b-3.mjs"
+        }
+      }
+    }`);
+
+    const scope1URL = 'https://example.com/scope1/foo.mjs';
+    const scope2URL = 'https://example.com/scope2/foo.mjs';
+    const scope3URL = 'https://example.com/scope2/scope3/foo.mjs';
+
+    it('should fall back to "imports" when none match', () => {
+      expect(resolveUnderTest('a', scope1URL)).to.equal('https://example.com/a-1.mjs');
+      expect(resolveUnderTest('b', scope1URL)).to.equal('https://example.com/b-1.mjs');
+      expect(resolveUnderTest('c', scope1URL)).to.equal('https://example.com/c-1.mjs');
+    });
+
+    it('should use a direct scope override', () => {
+      expect(resolveUnderTest('a', scope2URL)).to.equal('https://example.com/a-2.mjs');
+      expect(resolveUnderTest('b', scope2URL)).to.equal('https://example.com/b-1.mjs');
+      expect(resolveUnderTest('c', scope2URL)).to.equal('https://example.com/c-1.mjs');
+    });
+
+    it('should use an indirect scope override', () => {
+      expect(resolveUnderTest('a', scope3URL)).to.equal('https://example.com/a-2.mjs');
+      expect(resolveUnderTest('b', scope3URL)).to.equal('https://example.com/b-3.mjs');
+      expect(resolveUnderTest('c', scope3URL)).to.equal('https://example.com/c-1.mjs');
+    });
+  });
+
+  describe('Relative URL scope keys', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "a": "/a-1.mjs",
+        "b": "/b-1.mjs",
+        "c": "/c-1.mjs"
+      },
+      "scopes": {
+        "": {
+          "a": "/a-empty-string.mjs"
+        },
+        "./": {
+          "b": "/b-dot-slash.mjs"
+        },
+        "../": {
+          "c": "/c-dot-dot-slash.mjs"
+        }
+      }
+    }`);
+    const inSameDirAsMap = new URL('./foo.mjs', mapBaseURL).href;
+    const inDirAboveMap = new URL('../foo.mjs', mapBaseURL).href;
+
+    it('should resolve an empty string scope using the import map URL', () => {
+      expect(resolveUnderTest('a', mapBaseURL)).to.equal('https://example.com/a-empty-string.mjs');
+      expect(resolveUnderTest('a', inSameDirAsMap)).to.equal('https://example.com/a-1.mjs');
+    });
+
+    it("should resolve a ./ scope using the import map URL's directory", () => {
+      expect(resolveUnderTest('b', mapBaseURL)).to.equal('https://example.com/b-dot-slash.mjs');
+      expect(resolveUnderTest('b', inSameDirAsMap)).to.equal('https://example.com/b-dot-slash.mjs');
+    });
+
+    it("should resolve a ../ scope using the import map URL's directory", () => {
+      expect(resolveUnderTest('c', mapBaseURL)).to.equal('https://example.com/c-dot-dot-slash.mjs');
+      expect(resolveUnderTest('c', inSameDirAsMap)).to.equal(
+        'https://example.com/c-dot-dot-slash.mjs',
+      );
+      expect(resolveUnderTest('c', inDirAboveMap)).to.equal(
+        'https://example.com/c-dot-dot-slash.mjs',
+      );
+    });
+  });
+});

--- a/packages/import-maps-resolve/test/resolving.test.js
+++ b/packages/import-maps-resolve/test/resolving.test.js
@@ -1,0 +1,308 @@
+import chai from 'chai';
+import { parseFromString } from '../src/parser.js';
+import { resolve } from '../src/resolver.js';
+
+const { expect } = chai;
+
+const mapBaseURL = 'https://example.com/app/index.html';
+const scriptURL = 'https://example.com/js/app.mjs';
+
+function makeResolveUnderTest(mapString) {
+  const map = parseFromString(mapString, mapBaseURL);
+  return specifier => resolve(specifier, map, scriptURL);
+}
+
+describe('Unmapped', () => {
+  const resolveUnderTest = makeResolveUnderTest(`{}`);
+
+  it('should resolve ./ specifiers as URLs', () => {
+    expect(resolveUnderTest('./foo')).to.equal('https://example.com/js/foo');
+    expect(resolveUnderTest('./foo/bar')).to.equal('https://example.com/js/foo/bar');
+    expect(resolveUnderTest('./foo/../bar')).to.equal('https://example.com/js/bar');
+    expect(resolveUnderTest('./foo/../../bar')).to.equal('https://example.com/bar');
+  });
+
+  it('should resolve ../ specifiers as URLs', () => {
+    expect(resolveUnderTest('../foo')).to.equal('https://example.com/foo');
+    expect(resolveUnderTest('../foo/bar')).to.equal('https://example.com/foo/bar');
+    expect(resolveUnderTest('../../../foo/bar')).to.equal('https://example.com/foo/bar');
+  });
+
+  it('should resolve / specifiers as URLs', () => {
+    expect(resolveUnderTest('/foo')).to.equal('https://example.com/foo');
+    expect(resolveUnderTest('/foo/bar')).to.equal('https://example.com/foo/bar');
+    expect(resolveUnderTest('/../../foo/bar')).to.equal('https://example.com/foo/bar');
+    expect(resolveUnderTest('/../foo/../bar')).to.equal('https://example.com/bar');
+  });
+
+  it('should parse absolute fetch-scheme URLs', () => {
+    expect(resolveUnderTest('about:good')).to.equal('about:good');
+    expect(resolveUnderTest('https://example.net')).to.equal('https://example.net/');
+    expect(resolveUnderTest('https://ex%41mple.com/')).to.equal('https://example.com/');
+    expect(resolveUnderTest('https:example.org')).to.equal('https://example.org/');
+    expect(resolveUnderTest('https://///example.com///')).to.equal('https://example.com///');
+  });
+
+  it('should fail for absolute non-fetch-scheme URLs', () => {
+    expect(() => resolveUnderTest('mailto:bad')).to.throw(TypeError);
+    expect(() => resolveUnderTest('import:bad')).to.throw(TypeError);
+    // eslint-disable-next-line no-script-url
+    expect(() => resolveUnderTest('javascript:bad')).to.throw(TypeError);
+    expect(() => resolveUnderTest('wss:bad')).to.throw(TypeError);
+  });
+
+  it('should fail for strings not parseable as absolute URLs and not starting with ./ ../ or /', () => {
+    expect(() => resolveUnderTest('foo')).to.throw(TypeError);
+    expect(() => resolveUnderTest('\\foo')).to.throw(TypeError);
+    expect(() => resolveUnderTest(':foo')).to.throw(TypeError);
+    expect(() => resolveUnderTest('@foo')).to.throw(TypeError);
+    expect(() => resolveUnderTest('%2E/foo')).to.throw(TypeError);
+    expect(() => resolveUnderTest('%2E%2E/foo')).to.throw(TypeError);
+    expect(() => resolveUnderTest('.%2Ffoo')).to.throw(TypeError);
+    expect(() => resolveUnderTest('https://ex ample.org/')).to.throw(TypeError);
+    expect(() => resolveUnderTest('https://example.com:demo')).to.throw(TypeError);
+    expect(() => resolveUnderTest('http://[www.example.com]/')).to.throw(TypeError);
+  });
+});
+
+describe('Mapped using the "imports" key only (no scopes)', () => {
+  it('should fail when the mapping is to an empty array', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "moment": null,
+        "lodash": []
+      }
+    }`);
+
+    expect(() => resolveUnderTest('moment')).to.throw(TypeError);
+    expect(() => resolveUnderTest('lodash')).to.throw(TypeError);
+  });
+
+  describe('Package-like scenarios', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "moment": "/node_modules/moment/src/moment.js",
+        "moment/": "/node_modules/moment/src/",
+        "lodash-dot": "./node_modules/lodash-es/lodash.js",
+        "lodash-dot/": "./node_modules/lodash-es/",
+        "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+        "lodash-dotdot/": "../node_modules/lodash-es/",
+        "nowhere/": []
+      }
+    }`);
+
+    it('should work for package main modules', () => {
+      expect(resolveUnderTest('moment')).to.equal(
+        'https://example.com/node_modules/moment/src/moment.js',
+      );
+      expect(resolveUnderTest('lodash-dot')).to.equal(
+        'https://example.com/app/node_modules/lodash-es/lodash.js',
+      );
+      expect(resolveUnderTest('lodash-dotdot')).to.equal(
+        'https://example.com/node_modules/lodash-es/lodash.js',
+      );
+    });
+
+    it('should work for package submodules', () => {
+      expect(resolveUnderTest('moment/foo')).to.equal(
+        'https://example.com/node_modules/moment/src/foo',
+      );
+      expect(resolveUnderTest('lodash-dot/foo')).to.equal(
+        'https://example.com/app/node_modules/lodash-es/foo',
+      );
+      expect(resolveUnderTest('lodash-dotdot/foo')).to.equal(
+        'https://example.com/node_modules/lodash-es/foo',
+      );
+    });
+
+    it('should work for package names that end in a slash by just passing through', () => {
+      // TODO: is this the right behavior, or should we throw?
+      expect(resolveUnderTest('moment/')).to.equal('https://example.com/node_modules/moment/src/');
+    });
+
+    it('should still fail for package modules that are not declared', () => {
+      expect(() => resolveUnderTest('underscore/')).to.throw(TypeError);
+      expect(() => resolveUnderTest('underscore/foo')).to.throw(TypeError);
+    });
+
+    it('should fail for package submodules that map to nowhere', () => {
+      expect(() => resolveUnderTest('nowhere/foo')).to.throw(TypeError);
+    });
+  });
+
+  describe('Tricky specifiers', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "package/withslash": "/node_modules/package-with-slash/index.mjs",
+        "not-a-package": "/lib/not-a-package.mjs",
+        ".": "/lib/dot.mjs",
+        "..": "/lib/dotdot.mjs",
+        "..\\\\": "/lib/dotdotbackslash.mjs",
+        "%2E": "/lib/percent2e.mjs",
+        "%2F": "/lib/percent2f.mjs"
+      }
+    }`);
+
+    it('should work for explicitly-mapped specifiers that happen to have a slash', () => {
+      expect(resolveUnderTest('package/withslash')).to.equal(
+        'https://example.com/node_modules/package-with-slash/index.mjs',
+      );
+    });
+
+    it('should work when the specifier has punctuation', () => {
+      expect(resolveUnderTest('.')).to.equal('https://example.com/lib/dot.mjs');
+      expect(resolveUnderTest('..')).to.equal('https://example.com/lib/dotdot.mjs');
+      expect(resolveUnderTest('..\\')).to.equal('https://example.com/lib/dotdotbackslash.mjs');
+      expect(resolveUnderTest('%2E')).to.equal('https://example.com/lib/percent2e.mjs');
+      expect(resolveUnderTest('%2F')).to.equal('https://example.com/lib/percent2f.mjs');
+    });
+
+    it('should fail for attempting to get a submodule of something not declared with a trailing slash', () => {
+      expect(() => resolveUnderTest('not-a-package/foo')).to.throw(TypeError);
+    });
+  });
+
+  describe('URL-like specifiers', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "/node_modules/als-polyfill/index.mjs": "std:kv-storage",
+
+        "/lib/foo.mjs": "./more/bar.mjs",
+        "./dotrelative/foo.mjs": "/lib/dot.mjs",
+        "../dotdotrelative/foo.mjs": "/lib/dotdot.mjs",
+
+        "/lib/no.mjs": null,
+        "./dotrelative/no.mjs": [],
+
+        "/": "/lib/slash-only/",
+        "./": "/lib/dotslash-only/",
+
+        "/test/": "/lib/url-trailing-slash/",
+        "./test/": "/lib/url-trailing-slash-dot/",
+
+        "/test": "/lib/test1.mjs",
+        "../test": "/lib/test2.mjs"
+      }
+    }`);
+
+    it('should remap to other URLs', () => {
+      expect(resolveUnderTest('https://example.com/lib/foo.mjs')).to.equal(
+        'https://example.com/app/more/bar.mjs',
+      );
+      expect(resolveUnderTest('https://///example.com/lib/foo.mjs')).to.equal(
+        'https://example.com/app/more/bar.mjs',
+      );
+      expect(resolveUnderTest('/lib/foo.mjs')).to.equal('https://example.com/app/more/bar.mjs');
+
+      expect(resolveUnderTest('https://example.com/app/dotrelative/foo.mjs')).to.equal(
+        'https://example.com/lib/dot.mjs',
+      );
+      expect(resolveUnderTest('../app/dotrelative/foo.mjs')).to.equal(
+        'https://example.com/lib/dot.mjs',
+      );
+
+      expect(resolveUnderTest('https://example.com/dotdotrelative/foo.mjs')).to.equal(
+        'https://example.com/lib/dotdot.mjs',
+      );
+      expect(resolveUnderTest('../dotdotrelative/foo.mjs')).to.equal(
+        'https://example.com/lib/dotdot.mjs',
+      );
+    });
+
+    it('should fail for URLs that remap to empty arrays', () => {
+      expect(() => resolveUnderTest('https://example.com/lib/no.mjs')).to.throw(TypeError);
+      expect(() => resolveUnderTest('/lib/no.mjs')).to.throw(TypeError);
+      expect(() => resolveUnderTest('../lib/no.mjs')).to.throw(TypeError);
+
+      expect(() => resolveUnderTest('https://example.com/app/dotrelative/no.mjs')).to.throw(
+        TypeError,
+      );
+      expect(() => resolveUnderTest('/app/dotrelative/no.mjs')).to.throw(TypeError);
+      expect(() => resolveUnderTest('../app/dotrelative/no.mjs')).to.throw(TypeError);
+    });
+
+    it('should remap URLs that are just composed from / and .', () => {
+      expect(resolveUnderTest('https://example.com/')).to.equal(
+        'https://example.com/lib/slash-only/',
+      );
+      expect(resolveUnderTest('/')).to.equal('https://example.com/lib/slash-only/');
+      expect(resolveUnderTest('../')).to.equal('https://example.com/lib/slash-only/');
+
+      expect(resolveUnderTest('https://example.com/app/')).to.equal(
+        'https://example.com/lib/dotslash-only/',
+      );
+      expect(resolveUnderTest('/app/')).to.equal('https://example.com/lib/dotslash-only/');
+      expect(resolveUnderTest('../app/')).to.equal('https://example.com/lib/dotslash-only/');
+    });
+
+    it('should remap URLs that are prefix-matched by keys with trailing slashes', () => {
+      expect(resolveUnderTest('/test/foo.mjs')).to.equal(
+        'https://example.com/lib/url-trailing-slash/foo.mjs',
+      );
+      expect(resolveUnderTest('https://example.com/app/test/foo.mjs')).to.equal(
+        'https://example.com/lib/url-trailing-slash-dot/foo.mjs',
+      );
+    });
+
+    it("should use the last entry's address when URL-like specifiers parse to the same absolute URL", () => {
+      expect(resolveUnderTest('/test')).to.equal('https://example.com/lib/test2.mjs');
+    });
+  });
+
+  describe('Overlapping entries with trailing slashes', () => {
+    it('should favor the most-specific key (no empty arrays)', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "imports": {
+          "a": "/1",
+          "a/": "/2/",
+          "a/b": "/3",
+          "a/b/": "/4/"
+        }
+      }`);
+
+      expect(resolveUnderTest('a')).to.equal('https://example.com/1');
+      expect(resolveUnderTest('a/')).to.equal('https://example.com/2/');
+      expect(resolveUnderTest('a/b')).to.equal('https://example.com/3');
+      expect(resolveUnderTest('a/b/')).to.equal('https://example.com/4/');
+      expect(resolveUnderTest('a/b/c')).to.equal('https://example.com/4/c');
+    });
+
+    it('should favor the most-specific key when empty arrays are involved for less-specific keys', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "imports": {
+          "a": [],
+          "a/": [],
+          "a/b": "/3",
+          "a/b/": "/4/"
+        }
+      }`);
+
+      expect(() => resolveUnderTest('a')).to.throw(TypeError);
+      expect(() => resolveUnderTest('a/')).to.throw(TypeError);
+      expect(() => resolveUnderTest('a/x')).to.throw(TypeError);
+      expect(resolveUnderTest('a/b')).to.equal('https://example.com/3');
+      expect(resolveUnderTest('a/b/')).to.equal('https://example.com/4/');
+      expect(resolveUnderTest('a/b/c')).to.equal('https://example.com/4/c');
+      expect(() => resolveUnderTest('a/x/c')).to.throw(TypeError);
+    });
+
+    it('should favor the most-specific key when empty arrays are involved for more-specific keys', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "imports": {
+          "a": "/1",
+          "a/": "/2/",
+          "a/b": [],
+          "a/b/": []
+        }
+      }`);
+
+      expect(resolveUnderTest('a')).to.equal('https://example.com/1');
+      expect(resolveUnderTest('a/')).to.equal('https://example.com/2/');
+      expect(resolveUnderTest('a/x')).to.equal('https://example.com/2/x');
+      expect(() => resolveUnderTest('a/b')).to.throw(TypeError);
+      expect(() => resolveUnderTest('a/b/')).to.throw(TypeError);
+      expect(() => resolveUnderTest('a/b/c')).to.throw(TypeError);
+      expect(resolveUnderTest('a/x/c')).to.equal('https://example.com/2/x/c');
+    });
+  });
+});


### PR DESCRIPTION
code is a copy of the reference implementation with some adoption
- parse to string instead of javascript new URL (anticipate support for node paths)
- use es modules, mocha, chai instead of require, jest, jasmine

still todo:
- [x] actually, support paths (for build tools) besides URLs
- [x] documentation
- [x] add thanks to reference implemenation
- [x] clean up history
- [x] final name? `@import-maps/process`? => renamed to `@import-maps/resolve`