### PR TITLE
feat(rollup-plugin-index-html): support import maps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
             - node_modules
           key: v2-dependencies-{{ checksum "package.json" }}
 
+      # build what needs to be build so we can use it in the next steps
+      - run: npm run build
+
       # run lint
       - run: npm run lint
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "publish": "lerna publish --message 'chore: release new versions'",
     "site:build": "npm run vuepress:build",
     "site:start": "npm run vuepress:start",
+    "build": "lerna run build",
     "test": "karma start --coverage",
     "test:watch": "karma start --auto-watch=true --single-run=false",
     "test:update-snapshots": "karma start --update-snapshots",

--- a/packages/building-utils/index-html/extract-resources.js
+++ b/packages/building-utils/index-html/extract-resources.js
@@ -5,6 +5,8 @@ const { queryAll, predicates, getAttribute, remove } = require('../dom5-fork');
  * @typedef {object} ExtractResult
  * @property {import('parse5').ASTNode} indexHTML the index file, with resources removed
  * @property {string[]} jsModules paths to js modules that were found
+ * @property {string[]} inlineImportMaps content of inline import maps that were found
+ * @property {string[]} importMapPaths paths to import map json files that were found
  */
 
 /**
@@ -21,7 +23,11 @@ function extractResources(htmlString) {
 
   const scripts = queryAll(indexHTML, predicates.hasTagName('script'));
   const moduleScripts = scripts.filter(script => getAttribute(script, 'type') === 'module');
+  const importMapScripts = scripts.filter(script => getAttribute(script, 'type') === 'importmap');
+
   const jsModules = [];
+  const inlineImportMaps = [];
+  const importMapPaths = [];
 
   moduleScripts.forEach(moduleScript => {
     const src = getAttribute(moduleScript, 'src');
@@ -31,8 +37,18 @@ function extractResources(htmlString) {
     }
   });
 
+  importMapScripts.forEach(importMapScript => {
+    const src = getAttribute(importMapScript, 'src');
+    if (!src) {
+      inlineImportMaps.push(importMapScript.childNodes[0].value);
+    } else {
+      importMapPaths.push(src);
+    }
+    remove(importMapScript);
+  });
+
   // TODO: Also extract other kinds of resources
-  return { indexHTML, jsModules };
+  return { indexHTML, jsModules, inlineImportMaps, importMapPaths };
 }
 
 module.exports.extractResources = extractResources;

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@open-wc/building-utils": "^2.1.1",
+    "@import-maps/resolve": "^0.1.0",
     "deepmerge": "^3.2.0",
     "mkdirp": "^0.5.1",
     "parse5": "^5.1.0"

--- a/packages/rollup-plugin-index-html/src/process-entry-html.js
+++ b/packages/rollup-plugin-index-html/src/process-entry-html.js
@@ -9,7 +9,7 @@ const { createError } = require('./utils');
  *
  * Returns the index html so that it can be used for output processing.
  */
-function createEntrypoints(inputConfig) {
+function processEntryHtml(inputConfig) {
   if (typeof inputConfig.input !== 'string' || !inputConfig.input.endsWith('index.html')) {
     throw createError('Input must be an index.html file, or an indexHTML option must be provided.');
   }
@@ -21,6 +21,7 @@ function createEntrypoints(inputConfig) {
 
   return {
     outputIndexHTML: resources.indexHTML,
+    inlineImportMaps: resources.inlineImportMaps,
     rollupOptions: {
       ...inputConfig,
       input: modules,
@@ -28,4 +29,4 @@ function createEntrypoints(inputConfig) {
   };
 }
 
-module.exports.createEntrypoints = createEntrypoints;
+module.exports.processEntryHtml = processEntryHtml;

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/.gitignore
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/app.js
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/app.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
+import './shared.js';
+
+import 'foo';
+import 'foo/foo.js';
+import 'bar';
+
+console.log('my app');
+
+import('lazy');

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/bar-fork/bar.js
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/bar-fork/bar.js
@@ -1,0 +1,3 @@
+import '../shared.js';
+
+console.log('Loaded: /bar-fork/bar.js');

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/index.html
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/index.html
@@ -1,0 +1,41 @@
+<html lang="en-GB">
+
+<head>
+  <script type="importmap">
+    {
+      "imports": {
+        "foo": "./node_modules/foo/index.js",
+        "foo/": "./node_modules/foo/",
+        "bar": "./bar-fork/bar.js",
+        "lazy": "./node_modules/lazy/index.js"
+      }
+    }
+  </script>
+
+  <title>My app</title>
+  <style>
+    my-app {
+      display: block;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>
+    <span>
+      Hello world!
+    </span>
+  </h1>
+  <my-app></my-app>
+  <script>
+    /* eslint-disable */
+    (function () {
+      const message = 'hello inline script';
+      console.log(message);
+    })();
+  </script>
+
+  <script type="module" src="./app.js"></script>
+</body>
+
+</html>

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/node_modules/foo/foo.js
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/node_modules/foo/foo.js
@@ -1,0 +1,1 @@
+console.log('Loaded: /node_modules/foo/foo.js');

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/node_modules/foo/index.js
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+console.log('Loaded: /node_modules/foo/index.js');

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/node_modules/lazy/index.js
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/node_modules/lazy/index.js
@@ -1,0 +1,1 @@
+console.log('Loaded: /node_modules/lazy/index.js');

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/rollup.config.js
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/rollup.config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const indexHTML = require('../../../rollup-plugin-index-html');
+
+module.exports = config => ({
+  input: path.resolve(__dirname, './index.html'),
+  output: {
+    dir: '',
+    format: 'esm',
+  },
+  plugins: [indexHTML({ ...config, rootDir: __dirname })],
+});

--- a/packages/rollup-plugin-index-html/test/fixtures/import-map/shared.js
+++ b/packages/rollup-plugin-index-html/test/fixtures/import-map/shared.js
@@ -1,0 +1,1 @@
+console.log('Loaded: ./shared.js');

--- a/packages/rollup-plugin-index-html/test/snapshots/import-map/app.js
+++ b/packages/rollup-plugin-index-html/test/snapshots/import-map/app.js
@@ -1,0 +1,13 @@
+console.log('Loaded: ./shared.js');
+
+console.log('Loaded: /node_modules/foo/index.js');
+
+console.log('Loaded: /node_modules/foo/foo.js');
+
+console.log('Loaded: /bar-fork/bar.js');
+
+/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
+
+console.log('my app');
+
+import('./index-bcce6317.js');

--- a/packages/rollup-plugin-index-html/test/snapshots/import-map/index-bcce6317.js
+++ b/packages/rollup-plugin-index-html/test/snapshots/import-map/index-bcce6317.js
@@ -1,0 +1,1 @@
+console.log('Loaded: /node_modules/lazy/index.js');

--- a/packages/rollup-plugin-index-html/test/snapshots/import-map/index.html
+++ b/packages/rollup-plugin-index-html/test/snapshots/import-map/index.html
@@ -1,0 +1,1 @@
+<html lang="en-GB"><head><title>My app</title><style>my-app{display:block}</style></head><body><h1><span>Hello world!</span></h1><my-app></my-app><script>console.log("hello inline script");</script><script src="./app.js" type="module"></script></body></html>


### PR DESCRIPTION
- fixes some missing feature in import-maps/resolve

ToDo:
- [x] Read import map from index.html (currently hard coded in test)
- [x] Remove import map from html output?
- [x] Fix failing test in import-maps/resolve
- [x] Cleanup code (console, lint, ...)
- [x] Cleanup history and make nice commits
