### PR TITLE
fix(building-webpack): always export an array of configs

### DIFF
--- a/packages/building-webpack/modern-and-legacy-config.js
+++ b/packages/building-webpack/modern-and-legacy-config.js
@@ -151,7 +151,7 @@ module.exports = userOptions => {
   };
 
   if (development) {
-    return createConfig(options, legacy);
+    return [createConfig(options, legacy)];
   }
 
   return [createConfig(options, true), createConfig(options, false)];

--- a/packages/webpack-index-html-plugin/src/create-entrypoints.js
+++ b/packages/webpack-index-html-plugin/src/create-entrypoints.js
@@ -29,7 +29,9 @@ function createEntrypoints(compiler, context, entry, config, createError) {
     );
   } else {
     if (!entry.endsWith('index.html')) {
-      throw createError('Entry must be a single index.html file');
+      throw createError(
+        'Entry must be a single index.html file. If you wish to use a javascript file as entrypoint you need to set a HTML template function.',
+      );
     }
     index = entry;
   }


### PR DESCRIPTION
Closes https://github.com/open-wc/open-wc/issues/527
Closes https://github.com/open-wc/open-wc/issues/529