### PR TITLE
fix: subproperty bug

### DIFF
--- a/packages/import-maps-generate/src/generate.js
+++ b/packages/import-maps-generate/src/generate.js
@@ -15,7 +15,6 @@ export async function generate(targetPath = process.cwd()) {
   const packageJson = JSON.parse(packageJsonString);
 
   const result = await generateFromYarnLock(yarnLockString, packageJson, targetPath);
-
   fs.writeFileSync('./import-map.json', JSON.stringify(result, null, 2));
 
   if (options['inject-to']) {

--- a/packages/import-maps-generate/src/generateFromYarnLock.js
+++ b/packages/import-maps-generate/src/generateFromYarnLock.js
@@ -53,13 +53,15 @@ async function addWorkspaceDeps(flatResolvedDeps, packageJson, targetPath = proc
 }
 
 export function flatResolvedDepsToImports(deps) {
-  const imports = {};
+  const importMap = {};
+  importMap.imports = {};
+
   Object.keys(deps).forEach(depName => {
     const depPath = deps[depName];
-    imports[depName] = depPath;
-    imports[`${depName}/`] = `${path.dirname(depPath)}/`;
+    importMap.imports[depName] = depPath;
+    importMap.imports[`${depName}/`] = `${path.dirname(depPath)}/`;
   });
-  return imports;
+  return importMap;
 }
 
 function updatePackageJsonResolutions(depName, selectedVersion, packageJson, targetPath) {
@@ -151,5 +153,5 @@ export async function generateFromYarnLock(
   let imports = flatResolvedDepsToImports(flatResolvedDepsWithWorkspaceDeps);
   imports = postProcessImportMap(imports, packageJson);
 
-  return { imports };
+  return imports;
 }

--- a/packages/import-maps-generate/src/postProcessImportMap.js
+++ b/packages/import-maps-generate/src/postProcessImportMap.js
@@ -1,6 +1,5 @@
 export function postProcessImportMap(imports, packageJson) {
   const importMap = imports;
-
   if (typeof packageJson.importMap !== 'undefined') {
     if (typeof packageJson.importMap.overrides !== 'undefined') {
       // override imports

--- a/packages/import-maps-generate/test/generateFromYarnLock.test.js
+++ b/packages/import-maps-generate/test/generateFromYarnLock.test.js
@@ -53,10 +53,12 @@ describe('flatResolvedDepsToImports', () => {
     const importMap = flatResolvedDepsToImports(flatResolvedDeps);
 
     expect(importMap).to.deep.equal({
-      'lit-element': '/node_modules/lit-element/lit-element.js',
-      'lit-element/': '/node_modules/lit-element/',
-      'lit-html': '/node_modules/lit-element/node_modules/lit-html/lit-html.js',
-      'lit-html/': '/node_modules/lit-element/node_modules/lit-html/',
+      imports: {
+        'lit-element': '/node_modules/lit-element/lit-element.js',
+        'lit-element/': '/node_modules/lit-element/',
+        'lit-html': '/node_modules/lit-element/node_modules/lit-html/lit-html.js',
+        'lit-html/': '/node_modules/lit-element/node_modules/lit-html/',
+      },
     });
   });
 });


### PR DESCRIPTION
When applying an override, it adds an extra/unnecessary `.imports` property to the import map

<img width="509" alt="Screen Shot 2019-07-05 at 16 41 40" src="https://user-images.githubusercontent.com/17054057/60731455-e1b8f480-9f47-11e9-89e7-aa6645393006.png">

After applying this fix:

<img width="508" alt="Screen Shot 2019-07-05 at 17 16 53" src="https://user-images.githubusercontent.com/17054057/60731779-baaef280-9f48-11e9-8cba-3e31b0e81b65.png">
