### PR TITLE
feat(eslint-config): add import extensions linting rule

### DIFF
--- a/packages/create/src/generators/app/index.js
+++ b/packages/create/src/generators/app/index.js
@@ -2,7 +2,7 @@
 import prompts from 'prompts';
 import commandLineArgs from 'command-line-args';
 import { executeMixinGenerator } from '../../core.js';
-import LintingMixin from '../linting';
+import LintingMixin from '../linting/index.js';
 import TestingMixin from '../testing/index.js';
 import DemoingStorybookMixin from '../demoing-storybook/index.js';
 import BuildingRollupMixin from '../building-rollup/index.js';

--- a/packages/es-dev-server/src/cli.js
+++ b/packages/es-dev-server/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { startServer } from './server.js';
-import readCommandLineArgs from './command-line-args';
+import readCommandLineArgs from './command-line-args.js';
 
 const config = readCommandLineArgs();
 

--- a/packages/es-dev-server/src/middleware/compatibility.js
+++ b/packages/es-dev-server/src/middleware/compatibility.js
@@ -1,6 +1,6 @@
-import { extractResources, createIndexHTML } from '@open-wc/building-utils/index-html';
-import { getBodyAsString } from '../utils';
-import { compatibilityModes } from '../constants';
+import { extractResources, createIndexHTML } from '@open-wc/building-utils/index-html/index.js';
+import { getBodyAsString } from '../utils.js';
+import { compatibilityModes } from '../constants.js';
 import systemJsLegacyResolveScript from '../browser-scripts/system-js-legacy-resolve.js';
 
 /**

--- a/packages/es-dev-server/test/middleware/compatibility.test.js
+++ b/packages/es-dev-server/test/middleware/compatibility.test.js
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import path from 'path';
 import { startServer } from '../../src/server.js';
 import { compatibilityModes } from '../../src/constants.js';
-import systemJsLegacyResolveScript from '../../src/browser-scripts/system-js-legacy-resolve';
+import systemJsLegacyResolveScript from '../../src/browser-scripts/system-js-legacy-resolve.js';
 
 const REGEXP_ESM_SHIMS = /<script src="polyfills\/es-module-shims.*<\/script>/;
 const STRING_IMPORTMAP = '<script type="importmap">';

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ['html'],
   rules: {
     'no-underscore-dangle': 'off',
-    'import/extensions': 'off',
+    'import/extensions': ['error', 'always', { ignorePackages: true }],
     'import/prefer-default-export': 'off',
     'import/no-extraneous-dependencies': [
       'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "babel-eslint": "^10.0.0",
     "eslint": "^5.13.0",
-    "eslint-config-airbnb-base": "^13.0.0",
+    "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-html": "^4.0.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-wc": "^1.0.0"

--- a/packages/import-maps-generate/src/findPathToVersion.js
+++ b/packages/import-maps-generate/src/findPathToVersion.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import { findPackageJson } from './findPackageJson';
+import { findPackageJson } from './findPackageJson.js';
 
 async function findWorkspaceParentDeps(depName, packageJson, targetPath = process.cwd()) {
   const parents = [];

--- a/packages/import-maps-generate/src/findProductionDependencies.js
+++ b/packages/import-maps-generate/src/findProductionDependencies.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { findPackageJson } from './findPackageJson';
+import { findPackageJson } from './findPackageJson.js';
 
 export async function findWorkspaceProdutionDependenies(packageJson, root = process.cwd()) {
   let deps = packageJson.dependencies ? packageJson.dependencies : {};

--- a/packages/import-maps-generate/src/generate.js
+++ b/packages/import-maps-generate/src/generate.js
@@ -3,8 +3,8 @@
 import fs from 'fs';
 import path from 'path';
 import commandLineArgs from 'command-line-args';
-import { generateFromYarnLock } from './generateFromYarnLock';
-import injectToHtmlFile from './injectToHtmlFile';
+import { generateFromYarnLock } from './generateFromYarnLock.js';
+import injectToHtmlFile from './injectToHtmlFile.js';
 
 const optionDefinitions = [{ name: 'inject-to' }];
 const options = commandLineArgs(optionDefinitions);

--- a/packages/import-maps-generate/src/generateFromYarnLock.js
+++ b/packages/import-maps-generate/src/generateFromYarnLock.js
@@ -2,11 +2,11 @@ import * as lockfile from '@yarnpkg/lockfile';
 import path from 'path';
 import fs from 'fs';
 import prompts from 'prompts';
-import { findProductionDependencies } from './findProductionDependencies';
-import { flattenYarnLock } from './flattenYarnLock';
-import { findPathToVersion } from './findPathToVersion';
-import { findPackageJson } from './findPackageJson';
-import { postProcessImportMap } from './postProcessImportMap';
+import { findProductionDependencies } from './findProductionDependencies.js';
+import { flattenYarnLock } from './flattenYarnLock.js';
+import { findPathToVersion } from './findPathToVersion.js';
+import { findPackageJson } from './findPackageJson.js';
+import { postProcessImportMap } from './postProcessImportMap.js';
 
 async function askForVersionSelection(depName, versions) {
   const choices = [];

--- a/packages/import-maps-generate/test/findPackageJson.test.js
+++ b/packages/import-maps-generate/test/findPackageJson.test.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import { findPackageJson } from '../src/findPackageJson';
+import { findPackageJson } from '../src/findPackageJson.js';
 
 const { expect } = chai;
 

--- a/packages/import-maps-generate/test/findPathToVersion.test.js
+++ b/packages/import-maps-generate/test/findPathToVersion.test.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import fs from 'fs';
 import * as lockfile from '@yarnpkg/lockfile';
-import { findPathToVersion } from '../src/findPathToVersion';
+import { findPathToVersion } from '../src/findPathToVersion.js';
 
 const { expect } = chai;
 

--- a/packages/import-maps-generate/test/flattenYarnLock.test.js
+++ b/packages/import-maps-generate/test/flattenYarnLock.test.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import { flattenYarnLock } from '../src/flattenYarnLock';
+import { flattenYarnLock } from '../src/flattenYarnLock.js';
 
 const { expect } = chai;
 

--- a/packages/import-maps-generate/test/generateFromYarnLock.test.js
+++ b/packages/import-maps-generate/test/generateFromYarnLock.test.js
@@ -4,7 +4,7 @@ import {
   generateFromYarnLock,
   resolvePathsAndConflicts,
   flatResolvedDepsToImports,
-} from '../src/generateFromYarnLock';
+} from '../src/generateFromYarnLock.js';
 
 const { expect } = chai;
 

--- a/packages/import-maps-generate/test/injectToHtmlFile.test.js
+++ b/packages/import-maps-generate/test/injectToHtmlFile.test.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import fs from 'fs';
-import { indexHtml, indexHtmlWithImportMap } from './assets/injectToHtmlFile/utils';
-import injectToHtmlFile from '../src/injectToHtmlFile';
+import { indexHtml, indexHtmlWithImportMap } from './assets/injectToHtmlFile/utils.js';
+import injectToHtmlFile from '../src/injectToHtmlFile.js';
 
 const { expect } = chai;
 

--- a/packages/import-maps-resolve/test/mergeImportMaps.test.js
+++ b/packages/import-maps-resolve/test/mergeImportMaps.test.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import { mergeImportMaps } from '../src';
+import { mergeImportMaps } from '../src/index.js';
 
 const { expect } = chai;
 

--- a/packages/semantic-dom-diff/index.js
+++ b/packages/semantic-dom-diff/index.js
@@ -6,4 +6,4 @@ export {
   getDiffableHTML as getDiffableSemanticHTML,
 };
 
-export { chaiDomDiff } from './chai-dom-diff';
+export { chaiDomDiff } from './chai-dom-diff.js';

--- a/packages/testing-helpers/test/lit-html.test.js
+++ b/packages/testing-helpers/test/lit-html.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@bundled-es-modules/chai';
-import { html, litFixture, unsafeStatic } from '..';
+import { html, litFixture, unsafeStatic } from '../index.js';
 
 /**
  * @typedef {Object} ChildType

--- a/packages/testing-karma-bs/demo/test/example.test.js
+++ b/packages/testing-karma-bs/demo/test/example.test.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { expect } from 'chai';
-import { foo } from '../src/example';
+import { foo } from '../src/example.js';
 
 describe('foo()', () => {
   it('returns false when given true', () => {

--- a/packages/testing-karma/demo/test/example-a.test.js
+++ b/packages/testing-karma/demo/test/example-a.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@bundled-es-modules/chai';
-import { foo } from '../src/example';
+import { foo } from '../src/example.js';
 
 describe('a', () => {
   describe('foo()', () => {

--- a/packages/testing-karma/demo/test/example-b.test.js
+++ b/packages/testing-karma/demo/test/example-b.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@bundled-es-modules/chai';
-import { foo } from '../src/example';
+import { foo } from '../src/example.js';
 
 describe('b', () => {
   describe('foo()', () => {

--- a/packages/webpack-import-meta-loader/test/caseB/index.js
+++ b/packages/webpack-import-meta-loader/test/caseB/index.js
@@ -1,3 +1,3 @@
-import './caseBsub/caseBsub';
+import './caseBsub/caseBsub.js';
 
 export const foo = new URL('./', import.meta.url);

--- a/packages/webpack-import-meta-loader/test/webpack-import-meta-loader.test.js
+++ b/packages/webpack-import-meta-loader/test/webpack-import-meta-loader.test.js
@@ -39,7 +39,7 @@ describe('import-meta-url-loader', () => {
 
     expect(caseB).to.equal(
       `${'' +
-        "import './caseBsub/caseBsub';"}${newLine}${newLine}export const foo = new URL('./', ({ url: \`\${window.location.protocol}//\${window.location.host}/caseB/index.js\` }).url);${newLine}`,
+        "import './caseBsub/caseBsub.js';"}${newLine}${newLine}export const foo = new URL('./', ({ url: \`\${window.location.protocol}//\${window.location.host}/caseB/index.js\` }).url);${newLine}`,
     );
 
     expect(caseBsub).to.equal(


### PR DESCRIPTION
BREAKING CHANGE: imports other than bare module specifiers now require their extensions to be explicitly set in the import, eg: `import foo from './bar.js';`