### PR TITLE
feat(es-dev-server): add option to prevent compiling files with babel

### DIFF
--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -94,30 +94,32 @@ Note that "latest javascript features and syntax" is a general term, not everyth
 
 ## Command line flags overview
 ### Server configuration
-| name            |  type          | description                                                              |
-| --------------- | -------------- | ------------------------------------------------------------------------ |
-| port            | number         | The port to use. Default: 8080                                           |
-| hostname        | string         | The hostname to use. Default: localhost                                  |
-| open            | boolean/string | Opens the browser on app-index, root dir or a custom path                |
-| app-index       | string         | The app's index.html file, sets up history API fallback for SPA routing  |
-| root-dir        | string         | The root directory to serve files from. Default: working directory       |
-| config          | string         | The file to read configuration from (js or json)                         |
-| help            | none           | See all options                                                          |
+| name                 |  type          | description                                                              |
+| -------------------- | -------------- | ------------------------------------------------------------------------ |
+| port                 | number         | The port to use. Default: 8080                                           |
+| hostname             | string         | The hostname to use. Default: localhost                                  |
+| open                 | boolean/string | Opens the browser on app-index, root dir or a custom path                |
+| app-index            | string         | The app's index.html file, sets up history API fallback for SPA routing  |
+| root-dir             | string         | The root directory to serve files from. Default: working directory       |
+| config               | string         | The file to read configuration from (js or json)                         |
+| help                 | none           | See all options                                                          |
 
 ### Development help
-| name            |  type          | description                                                              |
-| --------------- | -------------- | ------------------------------------------------------------------------ |
-| watch           | boolean        | Reload the browser when files are edited                                 |
-| http2           | number         | Serve files over HTTP2. Sets up HTTPS with self-signed certificates      |
+| name                 |  type          | description                                                              |
+| -------------------- | -------------- | ------------------------------------------------------------------------ |
+| watch                | boolean        | Reload the browser when files are edited                                 |
+| http2                | number         | Serve files over HTTP2. Sets up HTTPS with self-signed certificates      |
 
 ### Code transformation
-| name            |  type          | description                                                              |
-| --------------- | -------------- | ------------------------------------------------------------------------ |
-| compatibility   | string         | Compatibility mode for older browsers. Can be: `esm`, `modern` or `all`  |
-| node-resolve    | number         | Resolve bare import imports using node resolve                           |
-| module-dirs     | string/array   | Directories to resolve modules from. Used by node-resolve                |
-| babel           | number         | Transform served code through babel. Requires .babelrc                   |
-| file-extensions | number/array   | Extra file extentions to use when transforming code.                     |
+| name                 |  type          | description                                                              |
+| -------------------- | -------------- | ------------------------------------------------------------------------ |
+| node-resolve         | number         | Resolve bare import imports using node resolve                           |
+| compatibility        | string         | Compatibility mode for older browsers. Can be: `esm`, `modern` or `all`  |
+| module-dirs          | string/array   | Directories to resolve modules from. Used by node-resolve                |
+| babel                | number         | Transform served code through babel. Requires .babelrc                   |
+| file-extensions      | number/array   | Extra file extentions to use when transforming code.                     |
+| babel-exclude        | number/array   | Patterns of files to exclude from babel compilation.                     |
+| babel-modern-exclude | number/array   | Patterns of files to exclude from babel compilation on modern browsers.  |
 
 Most commands have an alias/shorthand. You can view them by using `--help`.
 

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -48,6 +48,7 @@
     "@babel/plugin-syntax-import-meta": "^7.2.0",
     "@babel/preset-env": "^7.4.5",
     "@open-wc/building-utils": "^2.4.0",
+    "@types/minimatch": "^3.0.3",
     "babel-plugin-bare-import-rewrite": "^1.5.1",
     "camelcase": "^5.3.1",
     "chokidar": "^3.0.0",

--- a/packages/es-dev-server/src/command-line-args.js
+++ b/packages/es-dev-server/src/command-line-args.js
@@ -90,6 +90,18 @@ export default function readCommandLineArgs(argv = process.argv) {
       description: 'Extra file extentions to use when transforming code.',
     },
     {
+      name: 'babel-exclude',
+      type: String,
+      multiple: true,
+      description: 'Patterns of files to exclude from babel compilation.',
+    },
+    {
+      name: 'babel-modern-exclude',
+      type: String,
+      multiple: true,
+      description: 'Patterns of files to exclude from babel compilation on modern browsers.',
+    },
+    {
       name: 'compatibility',
       type: String,
       description: 'Compatibility mode for older browsers. Can be: "esm", modern" or "all"',
@@ -184,6 +196,8 @@ export default function readCommandLineArgs(argv = process.argv) {
     customMiddlewares: options.customMiddlewares,
     extraFileExtensions: options.fileExtensions,
     moduleDirectories: options.moduleDirs,
+    babelExclude: options.babelExclude,
+    babelModernExclude: options.babelModernExclude,
     logStartup: true,
   };
 }

--- a/packages/es-dev-server/src/server.js
+++ b/packages/es-dev-server/src/server.js
@@ -32,6 +32,8 @@ import { createHTTPServer } from './create-http-server.js';
  * @property {number} [watchDebounce]
  * @property {object} [customBabelConfig]
  * @property {string[]} [extraFileExtensions]
+ * @property {string[]} [babelExclude]
+ * @property {string[]} [babelModernExclude]
  * @property {import('koa').Middleware[]} [customMiddlewares]
  */
 
@@ -52,6 +54,8 @@ export function startServer(config) {
     http2 = false,
     extraFileExtensions = [],
     compatibilityMode = compatibilityModes.NONE,
+    babelExclude = [],
+    babelModernExclude = [],
     watchExcludes = ['node_modules/**'],
     watchDebounce = 1000,
     customMiddlewares,
@@ -130,6 +134,8 @@ export function startServer(config) {
         compatibilityMode,
         extraFileExtensions,
         customBabelConfig,
+        babelExclude,
+        babelModernExclude,
       }),
     );
   }

--- a/packages/es-dev-server/test/fixtures/simple/src/excluded-legacy.js
+++ b/packages/es-dev-server/test/fixtures/simple/src/excluded-legacy.js
@@ -1,0 +1,3 @@
+class Foo {
+
+}

--- a/packages/es-dev-server/test/fixtures/simple/src/excluded-modern.js
+++ b/packages/es-dev-server/test/fixtures/simple/src/excluded-modern.js
@@ -1,0 +1,8 @@
+import { message } from 'my-module';
+
+async function* asyncGenerator() {
+  await Promise.resolve();
+  yield 0;
+  await Promise.resolve();
+  yield 1;
+}

--- a/packages/es-dev-server/test/middleware/babel.test.js
+++ b/packages/es-dev-server/test/middleware/babel.test.js
@@ -36,6 +36,7 @@ describe('babel middleware', () => {
       ({ server } = startServer({
         rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
         nodeResolve: true,
+        babelModernExclude: ['**/src/excluded-modern.js'],
       }));
     });
 
@@ -91,6 +92,14 @@ describe('babel middleware', () => {
       expect(responseText).to.include("const foo = require('bar');");
       expect(responseText).to.include('module.exports = loremIpsum;');
     });
+
+    it('does not transform excluded files', async () => {
+      const response = await fetch(`${host}src/excluded-modern.js`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.include("import { message } from 'my-module';");
+    });
   });
 
   describe('readUserBabelConfig flag', () => {
@@ -141,6 +150,7 @@ describe('babel middleware', () => {
         rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
         appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
         compatibilityMode: compatibilityModes.MODERN,
+        babelModernExclude: ['**/src/excluded-modern.js'],
       }));
     });
 
@@ -176,6 +186,14 @@ describe('babel middleware', () => {
       expect(responseText).to.include("const foo = require('bar');");
       expect(responseText).to.include('module.exports = loremIpsum;');
     });
+
+    it('does not transform excluded files', async () => {
+      const response = await fetch(`${host}src/excluded-modern.js`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.include('async function* asyncGenerator() {');
+    });
   });
 
   describe('compatibilityMode all', () => {
@@ -185,6 +203,8 @@ describe('babel middleware', () => {
         rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
         appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
         compatibilityMode: compatibilityModes.ALL,
+        babelModernExclude: ['**/src/excluded-modern.js'],
+        babelExclude: ['**/src/excluded-legacy.js'],
       }));
     });
 
@@ -221,6 +241,14 @@ describe('babel middleware', () => {
         expect(responseText).to.include("const foo = require('bar');");
         expect(responseText).to.include('module.exports = loremIpsum;');
       });
+
+      it('does not transform excluded files', async () => {
+        const response = await fetch(`${host}src/excluded-modern.js`);
+        const responseText = await response.text();
+
+        expect(response.status).to.equal(200);
+        expect(responseText).to.include('async function* asyncGenerator() {');
+      });
     });
 
     describe('requests with ?legacy=true suffixed', () => {
@@ -253,6 +281,15 @@ describe('babel middleware', () => {
         expect(responseText).to.include(
           'System.register(["my-module", "./src/local-module.js"], function',
         );
+      });
+
+      it('does not transform excluded files', async () => {
+        const response = await fetch(`${host}src/excluded-legacy.js`);
+        const responseText = await response.text();
+
+        expect(response.status).to.equal(200);
+        expect(responseText).to.include('class Foo');
+        expect(responseText).to.not.include('System.register');
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,21 +1930,21 @@
     url-template "^2.0.8"
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.1.13"
+  version "1.1.15"
   dependencies:
-    "@open-wc/testing-karma" "^2.0.13"
+    "@open-wc/testing-karma" "^2.0.15"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "2.0.13"
+  version "2.0.15"
   dependencies:
     "@babel/core" "^7.3.3"
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
     "@babel/plugin-syntax-import-meta" "^7.2.0"
     "@babel/polyfill" "^7.0.0"
     "@babel/preset-env" "^7.0.0"
-    "@open-wc/karma-esm" "^1.1.3"
+    "@open-wc/karma-esm" "^1.1.4"
     "@types/node" "^11.13.0"
     "@webcomponents/webcomponentsjs" "^2.2.0"
     babel-loader "^8.0.0"
@@ -2545,7 +2545,7 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
   integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -5242,6 +5242,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -5715,6 +5720,11 @@ config-chain@^1.1.11, config-chain@^1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+confusing-browser-globals@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz#5ae852bd541a910e7ffb2dbb864a2d21a36ad29b"
+  integrity sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==
+
 connect-history-api-fallback@^1.5.0, connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
@@ -6163,6 +6173,11 @@ cross-spawn@^5.0.1:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -7278,14 +7293,14 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-airbnb-base@^13.0.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz#b5a1b480b80dfad16433d6c4ad84e6605052c05c"
-  integrity sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==
+eslint-config-airbnb-base@^13.2.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz#f6ea81459ff4dec2dda200c35f1d8f7419d57943"
+  integrity sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==
   dependencies:
-    eslint-restricted-globals "^0.1.1"
+    confusing-browser-globals "^1.0.5"
     object.assign "^4.1.0"
-    object.entries "^1.0.4"
+    object.entries "^1.1.0"
 
 eslint-config-prettier@^3.3.0:
   version "3.6.0"
@@ -7341,11 +7356,6 @@ eslint-plugin-wc@^1.0.0:
   dependencies:
     js-levenshtein-esm "^1.2.0"
     validate-element-name "^2.1.1"
-
-eslint-restricted-globals@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
-  integrity sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=
 
 eslint-scope@3.7.1:
   version "3.7.1"
@@ -9462,7 +9472,7 @@ is-binary-path@^2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.4, is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -10627,6 +10637,13 @@ lit-element@^2.0.1:
   dependencies:
     lit-html "^1.0.0"
 
+lit-element@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.2.0.tgz#e853be38021f0c7743a10180affdf84b8a02400c"
+  integrity sha512-Mzs3H7IO4wAnpzqreHw6dQqp9IG+h/oN8X9pgNbMZbE7x6B0aNOwP5Nveox/5HE+65ZfW2PeULEjoHkrwpTnuQ==
+  dependencies:
+    lit-html "^1.0.0"
+
 lit-html@0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-0.14.0.tgz#d6830e8f55fb923b0f5824decf7da082a1d22997"
@@ -10638,6 +10655,11 @@ lit-html@^1.0.0:
   integrity sha512-oeWlpLmBW3gFl7979Wol2LKITpmKTUFNn7PnFbh6YNynF61W74l6x5WhwItAwPRSATpexaX1egNnRzlN4GOtfQ==
 
 lit-html@^1.0.0-rc.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.1.1.tgz#186ed6abcc70c0d24e1132b37411c3b2645ed1aa"
+  integrity sha512-1WqhkPpj+CKwLRXCCbyRGnWkcFKE4ft2+j8C2zaXwFUK9I2vYDzTuDGPh0H9hZcDBEwoe6YpPC8AO5734EPORQ==
+
+lit-html@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.1.0.tgz#6951fb717fb48fe34d915ae163448a04da321562"
   integrity sha512-ZDJHpJi09yknMpjwPI8fuSl5sUG7+pF+eE5WciFtgyX7zebvgMDBgSLq4knXa7grxM00RkQ7PBd7UZQiruA78Q==
@@ -11116,6 +11138,15 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 mdn-data@~1.1.0:
   version "1.1.4"
@@ -12028,7 +12059,7 @@ object.assign@4.1.0, object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.0.4, object.entries@^1.1.0:
+object.entries@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
   integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==


### PR DESCRIPTION
This is needed for tests, as mocha, chai and sinon are large libraries and should not be compiled with babel.