### PR TITLE
fix: allows symlinks in node_modules

### DIFF
--- a/packages/building-utils/forked-babel-plugin-bare-import-rewrite.js
+++ b/packages/building-utils/forked-babel-plugin-bare-import-rewrite.js
@@ -64,19 +64,16 @@ function absResolve(importPath, sourceFileName, pluginOptions = {}) {
     return importPath;
   }
 
-  const result = resolve.sync(importPath, {
+  return resolve.sync(importPath, {
     basedir: basedirResolve(importPath, sourceFileName, pluginOptions),
     extensions: pluginOptions.extensions || ['.mjs', '.js', 'json'],
     moduleDirectory: pluginOptions.resolveDirectories || 'node_modules',
-    preserveSymlinks: false,
+    preserveSymlinks: true,
     packageFilter(packageJson) {
       packageJson.main = packageJson.module || packageJson['jsnext:main'] || packageJson.main;
       return packageJson;
     },
   });
-
-  // use node's resolve to convert symlinks to real paths
-  return require.resolve(result);
 }
 
 function tryResolve(babelPath, importPath, sourceFileName, pluginOptions) {

--- a/packages/demoing-storybook/default-storybook-webpack-config.js
+++ b/packages/demoing-storybook/default-storybook-webpack-config.js
@@ -1,4 +1,7 @@
 module.exports = ({ config, transpilePackages = ['lit-html', 'lit-element', '@open-wc'] }) => {
+  // eslint-disable-next-line no-param-reassign
+  config.resolve.symlinks = false;
+
   config.module.rules.push({
     test: [/\.stories\.js$/, /index\.js$/],
     loaders: [require.resolve('@storybook/addon-storysource/loader')],

--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -1,4 +1,13 @@
-let defineCECounter = 0;
+function getAvailableCustomElementTag() {
+  const randomNumber = Math.floor(Math.random() * Math.floor(1000000));
+  const tag = `test-${randomNumber}`;
+
+  if (customElements.get(tag) !== undefined) {
+    return getAvailableCustomElementTag();
+  }
+
+  return tag;
+}
 
 /**
  * Registers a new element with an automatically generated unique name.
@@ -15,9 +24,8 @@ let defineCECounter = 0;
  * @returns {string} Tag name of the registered element
  */
 export function defineCE(klass) {
-  const tag = `test-${defineCECounter}`;
+  const tag = getAvailableCustomElementTag();
   customElements.define(tag, klass);
-  defineCECounter += 1;
   return tag;
 }
 
@@ -127,6 +135,7 @@ export function oneEvent(element, eventName) {
       resolve(ev);
       element.removeEventListener(eventName, listener);
     }
+
     element.addEventListener(eventName, listener);
   });
 }

--- a/packages/testing-karma/legacy-config.js
+++ b/packages/testing-karma/legacy-config.js
@@ -54,6 +54,7 @@ module.exports = function createLegacyConfig(config) {
       devtool: 'inline-cheap-module-source-map',
 
       resolve: {
+        symlinks: false,
         mainFields: [
           // current leading de-facto standard - see https://github.com/rollup/rollup/wiki/pkg.module
           'module',


### PR DESCRIPTION
Having dependencies as symlinks (because of Lerna or npm link for example) in a monorepo causes some fails in unit tests and Storybook because those dependencies are not detected as external dependencies because the absolute path is outside the node_modules and then they are not properly processed (as for example transpiling them).

Enabling the symlinks those problems are fixed and sibling projects are detected as external dependencies.

On the other hand, the function `defineCE` has been refactored because the counter only works when we had just one file in the same location. With symlinks we have several locations and that caused some tag name collisions, so I refactored it to obtain a random number instead a counter and also checks if the random number is available before defining the component.