### PR TITLE
docs: fix Linting section link

### DIFF
--- a/docs/developing/ide.md
+++ b/docs/developing/ide.md
@@ -32,7 +32,7 @@ We recommend the following user settings:
 We recommend the following plugins:
 
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)  
-Get ESLint feedback directly in your IDE => more details under [Linting](./guide/linting)
+Get ESLint feedback directly in your IDE => more details under [Linting](/linting/)
 * [lit-html](https://marketplace.visualstudio.com/items?itemName=bierner.lit-html)  
 Highlights all your html tagged template literals
 * [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin)


### PR DESCRIPTION
Currently linting section link is pointing to https://open-wc.org/developing/guide/linting which returns 404. It should point to https://open-wc.org/linting/