### PR TITLE
fix(es-dev-server): serve polyfills correctly without app index

### DIFF
--- a/packages/es-dev-server/src/middleware/compatibility.js
+++ b/packages/es-dev-server/src/middleware/compatibility.js
@@ -1,4 +1,5 @@
 import { extractResources, createIndexHTML } from '@open-wc/building-utils/index-html/index.js';
+import path from 'path';
 import { getBodyAsString } from '../utils.js';
 import { compatibilityModes } from '../constants.js';
 import systemJsLegacyResolveScript from '../browser-scripts/system-js-legacy-resolve.js';
@@ -184,7 +185,8 @@ export function createCompatibilityMiddleware(cfg) {
 
     // cache polyfills for serving
     createResult.files.forEach(file => {
-      polyfills.set(`${cfg.appIndexDir}/${file.path}`, file.content);
+      const root = ctx.url.endsWith('/') ? ctx.url : `${path.posix.dirname(ctx.url)}/`;
+      polyfills.set(`${root}${file.path}`, file.content);
     });
   }
 


### PR DESCRIPTION
In https://github.com/open-wc/open-wc/pull/555 we changed compatibility to longer require an app index, but polyfills were still expecting it to be set. This fixes that.