### PR TITLE
feat(testing): upgrade testing-karma to latest version

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -39,7 +39,7 @@
     "mocha": "^5.0.0"
   },
   "devDependencies": {
-    "@open-wc/testing-karma": "^2.0.16",
+    "@open-wc/testing-karma": "^3.0.0",
     "@open-wc/testing-karma-bs": "^1.1.17",
     "@open-wc/testing-wallaby": "^0.1.12",
     "webpack-merge": "^4.1.5"


### PR DESCRIPTION
BREAKING CHANGE: Removed the legacy flag which used webpack on older
browsers. We now use karma-esm everywhere which supports older
browsers with a compatibility option. For more details please see
the changelog of testing-karma and karma-esm.