### PR TITLE
fix(es-dev-server): resolve polyfill path on windows

### DIFF
--- a/packages/es-dev-server/src/middleware/compatibility.js
+++ b/packages/es-dev-server/src/middleware/compatibility.js
@@ -1,6 +1,6 @@
 import { extractResources, createIndexHTML } from '@open-wc/building-utils/index-html/index.js';
 import path from 'path';
-import { getBodyAsString } from '../utils.js';
+import { getBodyAsString, toBrowserPath } from '../utils.js';
 import { compatibilityModes, modernPolyfills, legacyPolyfills } from '../constants.js';
 import systemJsLegacyResolveScript from '../browser-scripts/system-js-legacy-resolve.js';
 
@@ -175,7 +175,7 @@ export function createCompatibilityMiddleware(cfg) {
       if (!root.endsWith('/')) {
         root = `${root}/`;
       }
-      polyfills.set(`${root}${file.path}`, file.content);
+      polyfills.set(`${root}${toBrowserPath(file.path)}`, file.content);
     });
   }
 


### PR DESCRIPTION
Polyfill paths refer to filepaths, which need to be transformed to browser path on windows.

Fixes https://github.com/open-wc/open-wc/issues/592