### PR TITLE
fix(es-dev-server): don't require app-index for reload

### DIFF
--- a/packages/es-dev-server/src/server.js
+++ b/packages/es-dev-server/src/server.js
@@ -86,7 +86,6 @@ export function startServer(config) {
     );
   }
 
-  const setupWatch = appIndex && watch;
   const setupBabel =
     customBabelConfig ||
     nodeResolve ||
@@ -95,11 +94,11 @@ export function startServer(config) {
   const setupCompatibility = compatibilityMode && compatibilityMode !== compatibilityModes.NONE;
   const setupTransformIndexHTML = setupBabel || setupCompatibility;
   const setupHistoryFallback = appIndex;
-  const setupMessageChanel = setupWatch || setupBabel;
+  const setupMessageChanel = watch || setupBabel;
 
   const app = new Koa();
   /** @type {import('chokidar').FSWatcher | null} */
-  const fileWatcher = setupWatch ? chokidar.watch([]) : null;
+  const fileWatcher = watch ? chokidar.watch([]) : null;
 
   // add custom user's middlewares
   if (customMiddlewares && customMiddlewares.length > 0) {
@@ -119,7 +118,7 @@ export function startServer(config) {
   }
 
   // watch files and reload browser
-  if (setupWatch) {
+  if (watch) {
     app.use(
       createReloadBrowserMiddleware({
         rootDir,


### PR DESCRIPTION
test reloading is broken because it doesn't set an app-index, which was still requires for browser reloading in the es-dev-server. We removed this requirement in the middleware, but we didn't remove the check when setting up the server.