### PR TITLE
fix(create): set custom element in root of the package as entrypoint

### DIFF
--- a/packages/create/src/generators/app-lit-element/index.js
+++ b/packages/create/src/generators/app-lit-element/index.js
@@ -13,10 +13,7 @@ const AppLitElementMixin = subclass =>
       );
 
       // write & rename el registration template
-      this.copyTemplate(
-        `${__dirname}/templates/_my-app.js`,
-        this.destinationPath(`src/${tagName}.js`),
-      );
+      this.copyTemplate(`${__dirname}/templates/_my-app.js`, this.destinationPath(`${tagName}.js`));
 
       this.copyTemplateJsonInto(
         `${__dirname}/templates/_package.json`,

--- a/packages/create/src/generators/app-lit-element/templates/_my-app.js
+++ b/packages/create/src/generators/app-lit-element/templates/_my-app.js
@@ -1,3 +1,3 @@
-import { <%= className %> } from './<%= className %>.js';
+import { <%= className %> } from './src/<%= className %>.js';
 
 window.customElements.define('<%= tagName %>', <%= className %>);

--- a/packages/create/src/generators/app-lit-element/templates/static/index.html
+++ b/packages/create/src/generators/app-lit-element/templates/static/index.html
@@ -19,7 +19,7 @@
 <body>
   <<%= tagName %> title="Hello owc world!"></<%= tagName %>>
 
-  <script type="module" src="./src/<%= tagName %>.js"></script>
+  <script type="module" src="./<%= tagName %>.js"></script>
 </body>
 
 </html>

--- a/packages/create/src/generators/building-webpack/templates/static/index.html
+++ b/packages/create/src/generators/building-webpack/templates/static/index.html
@@ -18,7 +18,7 @@
 <body>
   <<%= tagName %> heading="Hello world!"></<%= tagName %>>
 
-  <script type="module" src="./src/<%= tagName %>.js"></script>
+  <script type="module" src="./<%= tagName %>.js"></script>
 </body>
 
 </html>

--- a/packages/create/src/generators/demoing-storybook/templates/static-scaffold/stories/index.stories.js
+++ b/packages/create/src/generators/demoing-storybook/templates/static-scaffold/stories/index.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf, html, withKnobs, withClassPropertiesKnobs } from '@open-wc/demoing-storybook';
 
 import { <%= className %> } from '../src/<%= className %>.js';
-import '../src/<%= tagName %>.js';
+import '../<%= tagName %>.js';
 
 storiesOf('<%= tagName %>', module)
   .addDecorator(withKnobs)

--- a/packages/create/src/generators/testing/templates/_my-el.test.js
+++ b/packages/create/src/generators/testing/templates/_my-el.test.js
@@ -1,6 +1,6 @@
 import { html, fixture, expect } from '@open-wc/testing';
 
-import '../src/<%= tagName %>.js';
+import '../<%= tagName %>.js';
 
 describe('<<%= tagName %>>', () => {
   it('has a default property title', async () => {

--- a/packages/create/src/generators/wc-lit-element/index.js
+++ b/packages/create/src/generators/wc-lit-element/index.js
@@ -12,10 +12,7 @@ const WcLitElementMixin = subclass =>
       );
 
       // write & rename el registration template
-      this.copyTemplate(
-        `${__dirname}/templates/_my-el.js`,
-        this.destinationPath(`src/${tagName}.js`),
-      );
+      this.copyTemplate(`${__dirname}/templates/_my-el.js`, this.destinationPath(`${tagName}.js`));
 
       this.copyTemplate(`${__dirname}/templates/_gitignore`, this.destinationPath(`.gitignore`));
 

--- a/packages/create/src/generators/wc-lit-element/templates/_my-el.js
+++ b/packages/create/src/generators/wc-lit-element/templates/_my-el.js
@@ -1,3 +1,3 @@
-import { <%= className %> } from './<%= className %>.js';
+import { <%= className %> } from './src/<%= className %>.js';
 
 window.customElements.define('<%= tagName %>', <%= className %>);

--- a/packages/create/src/generators/wc-lit-element/templates/static/demo/index.html
+++ b/packages/create/src/generators/wc-lit-element/templates/static/demo/index.html
@@ -13,7 +13,7 @@
 
   <script type="module">
     import { html, render } from 'lit-html';
-    import '../src/<%= tagName %>.js';
+    import '../<%= tagName %>.js';
 
     const title = 'Hello owc World!';
     render(


### PR DESCRIPTION
The entrypoint for the custom-element should be in the root of the package. I think I changed it everywhere correctly but WIP to confirm that nothing broke.