### PR TITLE
chore(create): change editorconfig to support md block comments

### DIFF
--- a/packages/create/src/generators/wc-lit-element/templates/static/.editorconfig
+++ b/packages/create/src/generators/wc-lit-element/templates/static/.editorconfig
@@ -23,7 +23,7 @@ trim_trailing_whitespace = false
 [*.json]
 indent_size = 2
 
-[*.{html,js}]
+[*.{html,js,md}]
 block_comment_start = /**
 block_comment = *
 block_comment_end = */


### PR DESCRIPTION
Use case:


### Hello this is my markdown
Now I show you some code
```js
/**
 * Block comment in my code example in my markdown
 */
function someFunc(foo) {
  return `${foo}bar`; 
}
```
Basically without the EC rule, eclint would complain about the 2nd line ` * Block comment...` as well as the 3rd line ` */` because they only have 1 indent instead of 2 (according to indent-size)