### PR TITLE
increase browserstack CI timeouts

### DIFF
--- a/karma.bs.conf.js
+++ b/karma.bs.conf.js
@@ -9,6 +9,13 @@ module.exports = config => {
       browserStack: {
         project: 'open-wc',
       },
+
+      // How long does Karma wait for a browser to reconnect
+      browserDisconnectTimeout: 60000,
+      // How long will Karma wait for a message from a browser before disconnecting from it
+      browserNoActivityTimeout: 60000,
+      // The number of disconnections tolerated
+      browserDisconnectTolerance: 3,
     }),
   );
 


### PR DESCRIPTION
Browserstack connection is a bit flaky, increasing the timeout and adding retries seems to stabilize it quite a bit.