### PR TITLE
feat(es-dev-server): improve babel error logging

### DIFF
--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -68,7 +68,8 @@
     "koa-static": "^5.0.0",
     "lru-cache": "^5.1.1",
     "minimatch": "^3.0.4",
-    "opn": "^5.4.0"
+    "opn": "^5.4.0",
+    "strip-ansi": "^5.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/packages/es-dev-server/src/command-line-args.js
+++ b/packages/es-dev-server/src/command-line-args.js
@@ -189,5 +189,8 @@ export function readCommandLineArgs(argv = process.argv) {
     ...options,
     open,
     logStartup: true,
+    // when used from the command line we log babel errors to the browser,
+    // not to the terminal for a better UX
+    logBabelErrors: false,
   };
 }

--- a/packages/es-dev-server/src/config.js
+++ b/packages/es-dev-server/src/config.js
@@ -40,6 +40,7 @@ import { compatibilityModes } from './constants.js';
  * @property {string[]} [babelModernExclude] files excluded from babel on modern browser
  * @property {object} [babelConfig] babel config to use, this is useful when you want to provide a
  *   babel config from a tool, and don't want to require all users to use the same babel config
+ * @property {boolean} [logBabelErrors] whether to log errors thrown by babel, true by default
  */
 
 /**
@@ -75,6 +76,7 @@ import { compatibilityModes } from './constants.js';
  * @property {string[]} extraFileExtensions
  * @property {string[]} babelExclude
  * @property {string[]} babelModernExclude
+ * @property {boolean} logBabelErrors whether to log errors thrown by babel, true by default
  */
 
 /**
@@ -100,6 +102,7 @@ export function createConfig(config) {
     babelExclude = [],
     babelModernExclude = [],
     babelConfig,
+    logBabelErrors = true,
     logStartup,
   } = config;
 
@@ -163,5 +166,6 @@ export function createConfig(config) {
     watchExcludes,
     watchDebounce: 1000,
     customMiddlewares: middlewares,
+    logBabelErrors,
   };
 }

--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -36,6 +36,7 @@ export function createMiddlewares(config, fileWatcher) {
     watchExcludes,
     watchDebounce,
     customMiddlewares,
+    logBabelErrors,
   } = config;
 
   /** @type {import('koa').Middleware[]} */
@@ -110,6 +111,7 @@ export function createMiddlewares(config, fileWatcher) {
         customBabelConfig,
         babelExclude,
         babelModernExclude,
+        logBabelErrors,
       }),
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15779,7 +15779,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==


### PR DESCRIPTION
Fixes https://github.com/open-wc/open-wc/issues/655

I opted for removing logging in the terminal entirely, and just leaving it to the browser. In the browser we see all the other kinds of errors already anyway, and it clears on reload so it's easy to keep of track of. 

Added some additional cleanup of the error messages. 