### PR TITLE
docs(testing-karma): Fix incorrect code snippet in README

### DIFF
--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -55,13 +55,13 @@ module.exports = config => {
         // npm run test -- --grep test/bar/*
         { pattern: config.grep ? config.grep : 'test/**/*.test.js', type: 'module' }
       ],
-    }),
 
-    // see the karma-esm docs for all options
-    esm: {
-      // if you are using 'bare module imports' you will need this option
-      nodeResolve: true
-    }
+      // see the karma-esm docs for all options
+      esm: {
+        // if you are using 'bare module imports' you will need this option
+        nodeResolve: true
+      }
+    })
   );
   return config;
 };


### PR DESCRIPTION
The code snippet under "Create a `karma.conf.js`" in the testing-karma README contained a [syntax error]. The `esm` option was not correctly nested in the second parameter given to the `merge` function. This PR fixes it by moving the `esm` option to the correct place.

[syntax error]: https://prettier.io/playground/#N4Igxg9gdgLgprEAuc0DOMAExNgE5wCG8AInAGaECuANjAMLTkCWA5pgL6YC8mBAjlWYEAFAHIAAhAAOCALQB3MAHp4GZlFZyA1oTwBbQmICUAbgA6USFAyZ9cPKzg8+cQcLjiAJnDjT7jnAmFlCW+hBetHAAdHAAHtIQeDBoLtYs7NwAfNiWmLhMbNFocDAiefl2Dk4i+ESkFNR0jFAZtYWsxgA0uVCVlSw0cGhImADaFf35ysp8VDaYhDQ0mIPDmAheGuwKzDAAFpjRalgamAfOJ6sQND54XZNTM7iEfQBGzhAAbg4KeHvwd4AT0w0kIaDQ20WmDkclYBGkqxohFY0Q2cUI+mkQxGj36MzxlWeUH8cz6V1hMLhCPOwxgynIEAgyjeemOdOiACs0ITprMSfoybTbJTYfC-ML6ay8MoAFS87Cg4jwPBQUbpIrixEAfgKrU1NNGYhOctlcvZGC5aDEPRgQNkRvCkSGYk4hIAug8+pUON1LI9niVLvtnLoDIQ5MNBV4IGBUoy8ItlpgZDBmOhHlHRsBCc9mORMECIFRFgRMFRIZpMGJpc4nVFMMwsUkUq6iyXdsmoL4vOd9sxUqn06Fvf0oBE4AAlYY3H6jGB4KhwR4cCpmCoEGBUVV6jIhDimEBdEBD9DIUB6PAQBQABT0CDQyBAhC+EGYXiPIDeeEIYG0pQAZTBMBtmQBcl2PfYYH0GgAHV+zUYC4AAh89mYL49iBJ840fY8NBKZIbx-VhDGQSgaBKY9uTiAAhH8-0AzE4AAGQ0OAyKWSiQGogDtiGABFKgIHgDiKLgY8wTwAin1ZN4gRoaBP2kf5YFg98DmQAAOAAGCSrxKWCf2kJ9lOGBwfk-QRhLgIiZEfFBwTkbs4B8D9jwEIQCCIlFSKQciuJKfRmDAxdxJAStWAEoSRL8ziwpgQg3jUrwNKQAAmY8F0IZgaG2Rh9F8kBx27T8KzgAAVRL7P8uAOA4IA