### PR TITLE
feat(es-dev-server): add option to set a base path

### DIFF
--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -175,32 +175,33 @@ Click read more to view different strategies for setting up your project's folde
 
 ## Command line flags and Configuration
 ### Server configuration
-| name                 |  type          | description                                                              |
-| -------------------- | -------------- | ------------------------------------------------------------------------ |
-| port                 | number         | The port to use. Default: 8080                                           |
-| hostname             | string         | The hostname to use. Default: localhost                                  |
-| open                 | boolean/string | Opens the browser on app-index, root dir or a custom path                |
-| app-index            | string         | The app's index.html file, sets up history API fallback for SPA routing  |
-| root-dir             | string         | The root directory to serve files from. Default: working directory       |
-| config               | string         | The file to read configuration from (js or json)                         |
-| help                 | none           | See all options                                                          |
+| name                 |  type          | description                                                                |
+| -------------------- | -------------- | -------------------------------------------------------------------------- |
+| port                 | number         | The port to use. Default: 8080                                             |
+| hostname             | string         | The hostname to use. Default: localhost                                    |
+| open                 | boolean/string | Opens the browser on app-index, root dir or a custom path                  |
+| app-index            | string         | The app's index.html file, sets up history API fallback for SPA routing    |
+| root-dir             | string         | The root directory to serve files from. Default: working directory         |
+| base-path            | string         | Base path the app is served on. Example: /my-app  |
+| config               | string         | The file to read configuration from (js or json)                           |
+| help                 | none           | See all options                                                            |
 
 ### Development help
-| name                 |  type          | description                                                              |
-| -------------------- | -------------- | ------------------------------------------------------------------------ |
-| watch                | boolean        | Reload the browser when files are edited                                 |
-| http2                | number         | Serve files over HTTP2. Sets up HTTPS with self-signed certificates      |
+| name                 |  type          | description                                                                |
+| -------------------- | -------------- | -------------------------------------------------------------------------- |
+| watch                | boolean        | Reload the browser when files are edited                                   |
+| http2                | number         | Serve files over HTTP2. Sets up HTTPS with self-signed certificates        |
 
 ### Code transformation
-| name                 |  type          | description                                                              |
-| -------------------- | -------------- | ------------------------------------------------------------------------ |
-| compatibility        | string         | Compatibility mode for older browsers. Can be: `esm`, `modern` or `all`  |
-| node-resolve         | number         | Resolve bare import imports using node resolve                           |
-| module-dirs          | string/array   | Directories to resolve modules from. Used by node-resolve                |
-| babel                | number         | Transform served code through babel. Requires .babelrc                   |
-| file-extensions      | number/array   | Extra file extentions to use when transforming code.                     |
-| babel-exclude        | number/array   | Patterns of files to exclude from babel compilation.                     |
-| babel-modern-exclude | number/array   | Patterns of files to exclude from babel compilation on modern browsers.  |
+| name                 |  type          | description                                                                |
+| -------------------- | -------------- | -------------------------------------------------------------------------- |
+| compatibility        | string         | Compatibility mode for older browsers. Can be: `esm`, `modern` or `all`    |
+| node-resolve         | number         | Resolve bare import imports using node resolve                             |
+| module-dirs          | string/array   | Directories to resolve modules from. Used by node-resolve                  |
+| babel                | number         | Transform served code through babel. Requires .babelrc                     |
+| file-extensions      | number/array   | Extra file extentions to use when transforming code.                       |
+| babel-exclude        | number/array   | Patterns of files to exclude from babel compilation.                       |
+| babel-modern-exclude | number/array   | Patterns of files to exclude from babel compilation on modern browsers.    |
 
 Most commands have an alias/shorthand. You can view them by using `--help`.
 

--- a/packages/es-dev-server/demo/base-path/index.html
+++ b/packages/es-dev-server/demo/base-path/index.html
@@ -1,0 +1,46 @@
+<html>
+
+<head>
+  <base href="/my-base-path/demo/node-resolve/">
+</head>
+
+<body>
+  <img width="100" src="../logo.png">
+
+  <h1>Demo app</h1>
+
+  <p>
+    <a href="foo/">Foo</a>
+  </p>
+
+  <p>
+    <a href="bar/">Bar</a>
+  </p>
+
+  <div id="app"></div>
+  <div id="inlineApp"></div>
+</body>
+
+<script type="module">
+  /* eslint-disable */
+  import { html, render } from 'lit-html';
+  import { foo } from './module-b.js';
+
+  console.log('inline module 0', foo());
+
+  render(
+    html`
+      <strong>inline module 0 loaded correctlyX</strong>
+    `,
+    document.getElementById('inlineApp'),
+  );
+</script>
+
+<script type="module" src="./module-a.js"></script>
+
+<script type="module">
+  /* eslint-disable */
+  console.log('inline module 1');
+</script>
+
+</html>

--- a/packages/es-dev-server/demo/base-path/module-a.js
+++ b/packages/es-dev-server/demo/base-path/module-a.js
@@ -1,0 +1,5 @@
+/* eslint-disable */
+import { foo } from './module-b.js';
+
+console.log('module a');
+console.log(foo());

--- a/packages/es-dev-server/demo/base-path/module-b.js
+++ b/packages/es-dev-server/demo/base-path/module-b.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+import { html, render } from 'lit-html';
+
+export const foo = () => 'module b foo';
+
+console.log('module b');
+console.log('lit-html', html);
+
+render(
+  html`
+    <strong>module b loaded correctlyX</strong>
+  `,
+  document.getElementById('app'),
+);

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -38,6 +38,8 @@
     "start:no-babel": "yarn build && node dist/cli.js --app-index demo/babel/index.html --open --http2 --watch",
     "start:typescript": "yarn build && node dist/cli.js --app-index demo/typescript/index.html --file-extensions .ts --node-resolve --open --watch --http2 --babel",
     "start:index-rewrite": "yarn build && node dist/cli.js --app-index demo/index-rewrite/index.html --config demo/index-rewrite/es-dev-server.config.js --node-resolve --open /",
+    "start:base-path": "yarn build && node dist/cli.js --app-index demo/base-path/index.html --base-path /my-base-path --node-resolve --http2 --watch --open",
+    "start:base-path-compat": "yarn build && node dist/cli.js --app-index demo/base-path/index.html --base-path /my-base-path --node-resolve --compatibility all --http2 --watch --open",
     "generate-certificates": "node scripts/generate-certificates.js",
     "prepublishOnly": "npm run build && ../../scripts/insert-header.js"
   },

--- a/packages/es-dev-server/src/command-line-args.js
+++ b/packages/es-dev-server/src/command-line-args.js
@@ -54,6 +54,13 @@ export function readCommandLineArgs(argv = process.argv) {
         'The root directory to serve files from. Defaults to the current working directory.',
     },
     {
+      name: 'base-path',
+      type: String,
+      description:
+        'Base path the app is served on. This path is only visible in the browser, it is stripped from the request url before resolving files. ' +
+        'Starts with a / and ends with no/. For example: /my-app, /foo, /foo/bar',
+    },
+    {
       name: 'module-dirs',
       alias: 'm',
       type: String,

--- a/packages/es-dev-server/src/config.js
+++ b/packages/es-dev-server/src/config.js
@@ -17,6 +17,9 @@ import { compatibilityModes } from './constants.js';
  *   can be an absolute file path, or a path relative to the root dir
  * @property {string} [rootDir] root directory to set up the web server, any served files must
  *   be within the scope of this folder
+ * @property {string} [basePath] Base path the app is served on. This path is only visible in
+ *   the browser, it is stripped from the request url before resolving files. Starts with a /
+ *   and ends with no/. For example: /my-app, /foo, /foo/bar
  * @property {import('koa').Middleware[]} [middlewares]
  * @property {boolean} logStartup whether to log server startup
  *
@@ -52,6 +55,7 @@ import { compatibilityModes } from './constants.js';
  *   appIndex file path
  * @property {string} [appIndexDir] app index browser directory, generated from
  *   appIndex file path and root dir
+ * @property {string} basePath
  * @property {string} rootDir
  * @property {boolean} logStartup whether to log a startup message
  * @property {import('koa').Middleware[]} customMiddlewares
@@ -84,6 +88,7 @@ export function createConfig(config) {
     hostname = '127.0.0.1',
     open = false,
     rootDir = process.cwd(),
+    basePath,
     watch = false,
     watchExcludes = [],
     http2 = false,
@@ -125,10 +130,9 @@ export function createConfig(config) {
     openPath = path.normalize(open);
   } else if (appIndex) {
     // if an appIndex was provided, use it's directory as open path
-    openPath = `${appIndexDir}/`;
+    openPath = `${basePath || ''}${appIndexDir}/`;
   } else {
-    // default to working directory root
-    openPath = '/';
+    openPath = basePath ? `${basePath}/` : '/';
   }
 
   // make sure path properly starts a /
@@ -142,6 +146,7 @@ export function createConfig(config) {
     rootDir,
     appIndexDir,
     appIndex,
+    basePath,
     moduleDirectories: moduleDirs,
     nodeResolve,
     readUserBabelConfig: babel,

--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -1,5 +1,6 @@
 import koaStatic from 'koa-static';
 import koaEtag from 'koa-etag';
+import { createBasePathMiddleware } from './middleware/base-path.js';
 import { createHistoryAPIFallbackMiddleware } from './middleware/history-api-fallback.js';
 import { createBabelMiddleware } from './middleware/babel.js';
 import { createReloadBrowserMiddleware } from './middleware/reload-browser.js';
@@ -22,6 +23,7 @@ export function createMiddlewares(config, fileWatcher) {
     rootDir,
     appIndex,
     appIndexDir,
+    basePath,
     moduleDirectories,
     nodeResolve,
     readUserBabelConfig,
@@ -60,6 +62,11 @@ export function createMiddlewares(config, fileWatcher) {
   const setupTransformIndexHTML = setupBabel || setupCompatibility;
   const setupHistoryFallback = appIndex;
   const setupMessageChanel = watch || setupBabel;
+
+  // strip application base path from requests
+  if (config.basePath) {
+    middlewares.push(createBasePathMiddleware({ basePath }));
+  }
 
   // add custom user's middlewares
   if (customMiddlewares && customMiddlewares.length > 0) {

--- a/packages/es-dev-server/src/middleware/base-path.js
+++ b/packages/es-dev-server/src/middleware/base-path.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {object} BasePathMiddlewareConfig
+ * @property {string} basePath
+ */
+
+/**
+ * Creates middleware which strips a base path from each request
+ *
+ * @param {BasePathMiddlewareConfig} cfg
+ */
+export function createBasePathMiddleware(cfg) {
+  /** @type {import('koa').Middleware} */
+  function basePathMiddleware(ctx, next) {
+    if (ctx.url.startsWith(cfg.basePath)) {
+      ctx.url = ctx.url.replace(cfg.basePath, '');
+    }
+
+    return next();
+  }
+
+  return basePathMiddleware;
+}

--- a/packages/es-dev-server/test/middleware/base-path.test.js
+++ b/packages/es-dev-server/test/middleware/base-path.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import fetch from 'node-fetch';
+import path from 'path';
+import { startServer, createConfig } from '../../src/es-dev-server.js';
+
+const host = 'http://localhost:8080/';
+
+describe('base path middleware', () => {
+  let server;
+  beforeEach(() => {
+    ({ server } = startServer(
+      createConfig({
+        rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+        appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
+        basePath: '/foo',
+      }),
+    ));
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('strips the base path from requests', async () => {
+    const response = await fetch(`${host}foo/index.html`);
+    const responseText = await response.text();
+
+    expect(response.status).to.equal(200);
+    expect(responseText).to.include('<title>My app</title>');
+  });
+
+  it('can request without base path', async () => {
+    const response = await fetch(`${host}index.html`);
+    const responseText = await response.text();
+
+    expect(response.status).to.equal(200);
+    expect(responseText).to.include('<title>My app</title>');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,7 +26,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.5", "@babel/core@^7.3.3":
+"@babel/core@^7.0.0", "@babel/core@^7.3.3":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
   integrity sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==
@@ -973,11 +973,6 @@
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@bundled-es-modules/chai/-/chai-4.2.1.tgz#124e9cc71584cb576c90b3e4e455abf525bbd3aa"
   integrity sha512-8tZO0prhIK8viNBAIo29lSXDJtTs/FrLwfNKsZiD0LzlTSGq6Ld2u7Bh73pUP2DvxMFqNbEWsRoUifOIvjDH8w==
-
-"@bundled-es-modules/url-polyfill@^1.1.3":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@bundled-es-modules/url-polyfill/-/url-polyfill-1.1.4.tgz#025155648b6d8e3db723cee3b9403a8684f60e26"
-  integrity sha512-sq6SN6XpHzBPE5B6Up5UFxCDr3iuREmBd8gXast9h3JUgA0tKxta6VxIA0dnkOpyT34VyIxDiIwWpsrp382cnw==
 
 "@commitlint/cli@7.2.1":
   version "7.2.1"
@@ -1961,6 +1956,14 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
+"@open-wc/chai-dom-equals@^0.12.36":
+  version "0.12.36"
+  resolved "https://registry.yarnpkg.com/@open-wc/chai-dom-equals/-/chai-dom-equals-0.12.36.tgz#ed0eb56b9e98c4d7f7280facce6215654aae9f4c"
+  integrity sha512-Gt1fa37h4rtWPQGETSU4n1L678NmMi9KwHM1sH+JCGcz45rs8DBPx7MUVeGZ+HxRlbEI5t9LU2RGGv6xT2OlyA==
+  dependencies:
+    "@open-wc/semantic-dom-diff" "^0.13.16"
+    "@types/chai" "^4.1.7"
+
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
   version "1.1.31"
   dependencies:
@@ -2575,11 +2578,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
   integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
 
-"@types/lru-cache@^4.1.1":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.2.tgz#528ba392658055dba78fc3be906ca338a1a2d1c5"
-  integrity sha512-ve2IoUJClE+4S/sG2zoLGEHP6DCvqgyz7UkHZdiICdQaAYRaCXsRWfJlbL8B0KvUyo9lgzD+oR0YSy4YikFyFQ==
-
 "@types/lru-cache@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
@@ -3088,31 +3086,6 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webcomponents/custom-elements@^1.2.1":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.2.4.tgz#7074543155396114617722724d6f6cb7b3800a14"
-  integrity sha512-WiTlgz6/kuwajYIcgyq64rSlCtb2AvbxwwrExP3wr6rKbJ72I3hi/sb4KdGUumfC+isDn2F0btZGk4MnWpyO1Q==
-
-"@webcomponents/shadycss@^1.8.0":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.9.1.tgz#d769fbadfa504f11b84caeef26701f89070ec49a"
-  integrity sha512-IaZOnWOKXHghqk/WfPNDRIgDBi3RsVPY2IFAw6tYiL9UBGvQRy5R6uC+Fk7qTZsReTJ0xh5MTT8yAcb3MUR4mQ==
-
-"@webcomponents/shadydom@^1.4.2":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@webcomponents/shadydom/-/shadydom-1.6.0.tgz#5918eccd07ff506a3a258fa0a7339bd7434bcf0a"
-  integrity sha512-2r9SGHv13MS488ZwYXd2W123bXn/ZjWo5/pO4s9FOZmpEYv8ALWRc4VazmiFNl+3n4Cdu0uvCwju4V6ivgZKXA==
-
-"@webcomponents/template@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@webcomponents/template/-/template-1.4.0.tgz#2ffd4574a5a2b662f0330dbeb40b231244a41c52"
-  integrity sha512-HJfhAxCD+DZmtm8oCALtvyOL9JlisSDqwE/4FWfaxq4SK3gUIp/2eUjLE6zqt9n6VHeo1zQjMTOA4fKKF6qSQg==
-
-"@webcomponents/webcomponents-platform@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponents-platform/-/webcomponents-platform-1.0.1.tgz#4e7ae8b40bcade06f5fdfa73fdb0211d90908866"
-  integrity sha512-7Ua2c3FvqAuiC2++gIoStG9r0B5sxleq8B7o0XKuIM052amWPTaCka0UMvnQRRJEsdGgRGIUv6sLkOyfhcr1dw==
-
 "@webcomponents/webcomponentsjs@^1.2.0":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz#5bb82a0d3210c836bd4623e13a4a93145cb9dc27"
@@ -3583,7 +3556,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-arrify@^2.0.0, arrify@^2.0.1:
+arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
@@ -3937,18 +3910,6 @@ babel-plugin-add-react-displayname@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
-
-babel-plugin-bare-import-rewrite@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-bare-import-rewrite/-/babel-plugin-bare-import-rewrite-1.5.0.tgz#c34a718278490f95f73fc8adb55d6a7ec3f98b3f"
-  integrity sha512-jwNgxGSddasxT4tJIzReCYmW9nk9iNyJpZGon7zZwVSEG9qplpIzK28o0wMaInh0QHC8DCTa+tqGHkGPTkijgQ==
-  dependencies:
-    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
-    arrify "^2.0.0"
-    minimatch "^3.0.4"
-    path-is-inside "^1.0.2"
-    resolve "^1.8.1"
-    whatwg-url "^7.0.0"
 
 babel-plugin-bare-import-rewrite@^1.5.1:
   version "1.5.1"
@@ -7676,16 +7637,6 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   dependencies:
     homedir-polyfill "^1.0.1"
-
-express-transform-bare-module-specifiers@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/express-transform-bare-module-specifiers/-/express-transform-bare-module-specifiers-1.0.2.tgz#62bc54a7d146cd96345ef5df8bc3ed975075ab88"
-  integrity sha512-fgLGLiTXJFusnSvNOFkcgWyx+JuWpRBDP6ZdZGwugOJvaBFV32Xudn7UjqYpQusViHE+VjFDf/7Nls3gXZGd1Q==
-  dependencies:
-    "@babel/core" "^7.1.5"
-    babel-plugin-bare-import-rewrite "^1.0.0"
-    content-type "^1.0.4"
-    lru-cache "^4.1.3"
 
 express@^4.16.3, express@^4.16.4:
   version "4.16.4"


### PR DESCRIPTION
Some web apps are deployed on some base path, for example `/my-app/`. You want to be able to mimic this locally without needing to create a dummy folder called `my-app`. 

The `basePath` option allows you to configure this, it's basically a small middleware that strips that specific path from each requests before it's handled by the rest of the server.