### PR TITLE
fix(rollup-config): avoid default indexHTML options override

### DIFF
--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -37,6 +37,7 @@ function createConfig(_options, legacy) {
     },
     plugins: [
       indexHTML({
+        ...(options.indexHTMLPlugin || {}),
         // tell index-html-plugin that we are creating two builds
         multiBuild: true,
         // tell index-html-plugin whether this is the legacy config
@@ -50,7 +51,6 @@ function createConfig(_options, legacy) {
           systemJs: true,
           fetch: true,
         },
-        ...(options.indexHTMLPlugin || {}),
       }),
 
       // resolve bare import specifiers

--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -36,12 +36,12 @@ module.exports = function createBasicConfig(_options) {
     plugins: [
       // parse input index.html as input and feed any modules found to rollup
       indexHTML({
+        ...(options.indexHTMLPlugin || {}),
         polyfills: {
           ...((options.indexHTMLPlugin && options.indexHTMLPlugin.polyfills) || {}),
           dynamicImport: true,
           webcomponents: true,
         },
-        ...(options.indexHTMLPlugin || {}),
       }),
 
       // resolve bare import specifiers


### PR DESCRIPTION
This PR tries to fix the override of default indexHTML options when you add new configuration through indexHTMLPlugin when you use modern and legacy rollup configuration.

Close #669 