### PR TITLE
Allow subclassers to pass custom generator names

### DIFF
--- a/packages/create/src/core.js
+++ b/packages/create/src/core.js
@@ -279,8 +279,8 @@ export async function writeFilesToDisk() {
   return answers.writeToDisk;
 }
 
-export function optionsToCommand(options) {
-  let command = 'npm init @open-wc ';
+export function optionsToCommand(options, generatorName = '@open-wc') {
+  let command = `npm init ${generatorName} `;
   Object.keys(options).forEach(key => {
     const value = options[key];
     if (typeof value === 'string') {


### PR DESCRIPTION
Before this change, a subclasser making their own scaffolder would see the "for the same scaffold, use the following command:" displaying `npm init @open-wc` without the ability to change it to the name he wants to register the scaffolder as. Allowing this means they don't have to fork the core stuff for making custom generators / scaffolder outside of open-wc domain :)