### PR TITLE
fix(es-dev-server): remove unnecessary polyfills in esm mode

### DIFF
--- a/packages/building-utils/index-html/polyfills.js
+++ b/packages/building-utils/index-html/polyfills.js
@@ -145,21 +145,21 @@ function getPolyfills(config) {
         'configured to pollyfill webcomponentsjs, but no polyfills found. Install with "npm i -D @webcomponents/webcomponentsjs"',
       );
     }
+  }
 
-    if (config.polyfills.esModuleShims) {
-      try {
-        instructions.push({
-          name: 'es-module-shims',
-          test: "'noModule' in HTMLScriptElement.prototype",
-          path: require.resolve('es-module-shims/dist/es-module-shims.min.js'),
-          sourcemapPath: require.resolve('es-module-shims/dist/es-module-shims.min.js.map'),
-          module: true,
-        });
-      } catch (error) {
-        throw new Error(
-          'configured to pollyfill es-module-shims, but no polyfills found. Install with "npm i -D es-module-shims"',
-        );
-      }
+  if (config.polyfills.esModuleShims) {
+    try {
+      instructions.push({
+        name: 'es-module-shims',
+        test: "'noModule' in HTMLScriptElement.prototype",
+        path: require.resolve('es-module-shims/dist/es-module-shims.min.js'),
+        sourcemapPath: require.resolve('es-module-shims/dist/es-module-shims.min.js.map'),
+        module: true,
+      });
+    } catch (error) {
+      throw new Error(
+        'configured to pollyfill es-module-shims, but no polyfills found. Install with "npm i -D es-module-shims"',
+      );
     }
   }
 

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -23,6 +23,7 @@
     "test:update-snapshots": "mocha test/**/*.test.js test/*.test.js --require @babel/register --update-snapshots",
     "test:ci": "npm run test",
     "start": "yarn build && node dist/cli.js --app-index demo/import-map/index.html --open --watch --http2",
+    "start:compat-esm": "yarn build && node dist/cli.js --app-index demo/import-map/index.html --open --watch --http2 --compatibility esm",
     "start:compat-modern": "yarn build && node dist/cli.js --app-index demo/import-map/index.html --open --watch --http2 --compatibility modern",
     "start:compat-all": "yarn build && node dist/cli.js --app-index demo/import-map/index.html --open --watch --http2 --compatibility all",
     "start:node": "yarn build && node dist/cli.js --app-index demo/node-resolve/index.html --node-resolve --open --watch --http2",

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -69,7 +69,8 @@
     "koa-static": "^5.0.0",
     "lru-cache": "^5.1.1",
     "minimatch": "^3.0.4",
-    "opn": "^5.4.0"
+    "opn": "^5.4.0",
+    "strip-ansi": "^5.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/packages/es-dev-server/src/command-line-args.js
+++ b/packages/es-dev-server/src/command-line-args.js
@@ -189,5 +189,8 @@ export function readCommandLineArgs(argv = process.argv) {
     ...options,
     open,
     logStartup: true,
+    // when used from the command line we log babel errors to the browser,
+    // not to the terminal for a better UX
+    logBabelErrors: false,
   };
 }

--- a/packages/es-dev-server/src/config.js
+++ b/packages/es-dev-server/src/config.js
@@ -40,6 +40,7 @@ import { compatibilityModes } from './constants.js';
  * @property {string[]} [babelModernExclude] files excluded from babel on modern browser
  * @property {object} [babelConfig] babel config to use, this is useful when you want to provide a
  *   babel config from a tool, and don't want to require all users to use the same babel config
+ * @property {boolean} [logBabelErrors] whether to log errors thrown by babel, true by default
  */
 
 /**
@@ -75,6 +76,7 @@ import { compatibilityModes } from './constants.js';
  * @property {string[]} extraFileExtensions
  * @property {string[]} babelExclude
  * @property {string[]} babelModernExclude
+ * @property {boolean} logBabelErrors whether to log errors thrown by babel, true by default
  */
 
 /**
@@ -100,6 +102,7 @@ export function createConfig(config) {
     babelExclude = [],
     babelModernExclude = [],
     babelConfig,
+    logBabelErrors = true,
     logStartup,
   } = config;
 
@@ -163,5 +166,6 @@ export function createConfig(config) {
     watchExcludes,
     watchDebounce: 1000,
     customMiddlewares: middlewares,
+    logBabelErrors,
   };
 }

--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -36,6 +36,7 @@ export function createMiddlewares(config, fileWatcher) {
     watchExcludes,
     watchDebounce,
     customMiddlewares,
+    logBabelErrors,
   } = config;
 
   /** @type {import('koa').Middleware[]} */
@@ -110,6 +111,7 @@ export function createMiddlewares(config, fileWatcher) {
         customBabelConfig,
         babelExclude,
         babelModernExclude,
+        logBabelErrors,
       }),
     );
   }

--- a/packages/es-dev-server/src/utils/polyfills.js
+++ b/packages/es-dev-server/src/utils/polyfills.js
@@ -1,9 +1,14 @@
 import { compatibilityModes } from '../constants.js';
 
 /** @type {import('@open-wc/building-utils/index-html/create-index-html').PolyfillsConfig} */
-export const modernPolyfills = {
-  webcomponents: true,
+export const esmPolyfills = {
   esModuleShims: true,
+};
+
+/** @type {import('@open-wc/building-utils/index-html/create-index-html').PolyfillsConfig} */
+export const modernPolyfills = {
+  ...esmPolyfills,
+  webcomponents: true,
 };
 
 /** @type {import('@open-wc/building-utils/index-html/create-index-html').PolyfillsConfig} */
@@ -19,17 +24,14 @@ export const legacyPolyfills = {
  * @param {string} compatibilityMode
  */
 export function getPolyfills(compatibilityMode) {
-  if (!compatibilityMode || compatibilityMode === compatibilityModes.NONE) {
-    return {};
+  switch (compatibilityMode) {
+    case compatibilityModes.ESM:
+      return esmPolyfills;
+    case compatibilityModes.MODERN:
+      return modernPolyfills;
+    case compatibilityModes.ALL:
+      return legacyPolyfills;
+    default:
+      return {};
   }
-
-  if (compatibilityMode === compatibilityModes.ALL) {
-    return legacyPolyfills;
-  }
-
-  if ([compatibilityModes.MODERN, compatibilityModes.ESM].includes(compatibilityMode)) {
-    return modernPolyfills;
-  }
-
-  throw new Error(`Unknown compatibility mode: ${compatibilityMode}`);
 }

--- a/packages/es-dev-server/src/utils/transform-index-html.js
+++ b/packages/es-dev-server/src/utils/transform-index-html.js
@@ -57,7 +57,9 @@ export function getTransformedIndexHTML(indexUrl, indexHTMLString, compatibility
   indexHTML = addPolyfilledImportMaps(indexHTML, compatibilityMode, resources);
 
   // inject systemjs resolver which appends a query param to trigger es5 compilation
-  indexHTML = indexHTML.replace('</body>', `${systemJsLegacyResolveScript}</body>`);
+  if (compatibilityMode === compatibilityModes.ALL) {
+    indexHTML = indexHTML.replace('</body>', `${systemJsLegacyResolveScript}</body>`);
+  }
 
   return {
     indexHTML,

--- a/packages/es-dev-server/test/snapshots/transform-index-html/import-map-esm.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/import-map-esm.html
@@ -38,8 +38,6 @@
   }
 
   var polyfills = [];
-  if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype)) { polyfills.push(loadScript('polyfills/webcomponents.88b4b5855ede008ecad6bbdd4a69e57d.js', false)) }
-  if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) { polyfills.push(loadScript('polyfills/custom-elements-es5-adapter.01496319407efe7ef743b10afbb93714.js', false)) }
   if ('noModule' in HTMLScriptElement.prototype) { polyfills.push(loadScript('polyfills/es-module-shims.c9fab74391a606424f346398bb048a79.js', true)) }
 
   function loadEntries() {
@@ -47,15 +45,4 @@
   }
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
-})();</script>
-<script nomodule>
-  // appends a query param to each systemjs request to trigger es5 compilation
-  var originalResolve = System.constructor.prototype.resolve;
-  System.constructor.prototype.resolve = function () {
-    return Promise.resolve(originalResolve.apply(this, arguments))
-      .then(function (url) {
-        return url + '?legacy=true';
-      });
-  };
-</script>
-</body></html>
+})();</script></body></html>

--- a/packages/es-dev-server/test/snapshots/transform-index-html/import-map-modern.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/import-map-modern.html
@@ -48,17 +48,6 @@
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
 })();</script>
-<script nomodule>
-  // appends a query param to each systemjs request to trigger es5 compilation
-  var originalResolve = System.constructor.prototype.resolve;
-  System.constructor.prototype.resolve = function () {
-    return Promise.resolve(originalResolve.apply(this, arguments))
-      .then(function (url) {
-        return url + '?legacy=true';
-      });
-  };
-</script>
-
   <script>
     // sets up a message channel with es-dev-server to receive events
     // for reloading the browser on file change or logging errors

--- a/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-esm.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-esm.html
@@ -24,8 +24,6 @@
   }
 
   var polyfills = [];
-  if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype)) { polyfills.push(loadScript('polyfills/webcomponents.88b4b5855ede008ecad6bbdd4a69e57d.js', false)) }
-  if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) { polyfills.push(loadScript('polyfills/custom-elements-es5-adapter.01496319407efe7ef743b10afbb93714.js', false)) }
   if ('noModule' in HTMLScriptElement.prototype) { polyfills.push(loadScript('polyfills/es-module-shims.c9fab74391a606424f346398bb048a79.js', true)) }
 
   function loadEntries() {
@@ -33,15 +31,4 @@
   }
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
-})();</script>
-<script nomodule>
-  // appends a query param to each systemjs request to trigger es5 compilation
-  var originalResolve = System.constructor.prototype.resolve;
-  System.constructor.prototype.resolve = function () {
-    return Promise.resolve(originalResolve.apply(this, arguments))
-      .then(function (url) {
-        return url + '?legacy=true';
-      });
-  };
-</script>
-</body></html>
+})();</script></body></html>

--- a/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-modern.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-modern.html
@@ -34,17 +34,6 @@
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
 })();</script>
-<script nomodule>
-  // appends a query param to each systemjs request to trigger es5 compilation
-  var originalResolve = System.constructor.prototype.resolve;
-  System.constructor.prototype.resolve = function () {
-    return Promise.resolve(originalResolve.apply(this, arguments))
-      .then(function (url) {
-        return url + '?legacy=true';
-      });
-  };
-</script>
-
   <script>
     // sets up a message channel with es-dev-server to receive events
     // for reloading the browser on file change or logging errors

--- a/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-none-babel.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-none-babel.html
@@ -13,17 +13,6 @@
 
 
 <script src="./app.js" type="module"></script><script src="./inline-module-0.js?source=%2Findex.html" type="module"></script><script src="./inline-module-1.js?source=%2Findex.html" type="module"></script>
-<script nomodule>
-  // appends a query param to each systemjs request to trigger es5 compilation
-  var originalResolve = System.constructor.prototype.resolve;
-  System.constructor.prototype.resolve = function () {
-    return Promise.resolve(originalResolve.apply(this, arguments))
-      .then(function (url) {
-        return url + '?legacy=true';
-      });
-  };
-</script>
-
   <script>
     // sets up a message channel with es-dev-server to receive events
     // for reloading the browser on file change or logging errors

--- a/packages/es-dev-server/test/snapshots/transform-index-html/simple-esm.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/simple-esm.html
@@ -27,8 +27,6 @@
   }
 
   var polyfills = [];
-  if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype)) { polyfills.push(loadScript('polyfills/webcomponents.88b4b5855ede008ecad6bbdd4a69e57d.js', false)) }
-  if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) { polyfills.push(loadScript('polyfills/custom-elements-es5-adapter.01496319407efe7ef743b10afbb93714.js', false)) }
   if ('noModule' in HTMLScriptElement.prototype) { polyfills.push(loadScript('polyfills/es-module-shims.c9fab74391a606424f346398bb048a79.js', true)) }
 
   function loadEntries() {
@@ -36,15 +34,4 @@
   }
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
-})();</script>
-<script nomodule>
-  // appends a query param to each systemjs request to trigger es5 compilation
-  var originalResolve = System.constructor.prototype.resolve;
-  System.constructor.prototype.resolve = function () {
-    return Promise.resolve(originalResolve.apply(this, arguments))
-      .then(function (url) {
-        return url + '?legacy=true';
-      });
-  };
-</script>
-</body></html>
+})();</script></body></html>

--- a/packages/es-dev-server/test/snapshots/transform-index-html/simple-modern.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/simple-modern.html
@@ -37,17 +37,6 @@
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
 })();</script>
-<script nomodule>
-  // appends a query param to each systemjs request to trigger es5 compilation
-  var originalResolve = System.constructor.prototype.resolve;
-  System.constructor.prototype.resolve = function () {
-    return Promise.resolve(originalResolve.apply(this, arguments))
-      .then(function (url) {
-        return url + '?legacy=true';
-      });
-  };
-</script>
-
   <script>
     // sets up a message channel with es-dev-server to receive events
     // for reloading the browser on file change or logging errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -15779,7 +15779,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==


### PR DESCRIPTION
Fixes https://github.com/open-wc/open-wc/issues/685

- Don't polyfills webcomponents when esm mode is enabled (this was a bug)
- Fix typo in building-utils, placing es module shims inside the webcomponents if block
- Don't inject systemjs script unless in 'all' compatibility mode