### PR TITLE
Feat/random ports

### DIFF
--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -39,7 +39,7 @@ npx es-dev-server
 ### Server configuration
 | name                 |  type          | description                                                                |
 | -------------------- | -------------- | -------------------------------------------------------------------------- |
-| port                 | number         | The port to use. Default: 8080                                             |
+| port                 | number         | The port to use, uses a random free port if not set.                       |
 | hostname             | string         | The hostname to use. Default: localhost                                    |
 | open                 | boolean/string | Opens the browser on app-index, root dir or a custom path                  |
 | app-index            | string         | The app's index.html file, sets up history API fallback for SPA routing    |

--- a/packages/es-dev-server/es-dev-server.config.js
+++ b/packages/es-dev-server/es-dev-server.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  port: 8000,
-};

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -70,6 +70,7 @@
     "lru-cache": "^5.1.1",
     "minimatch": "^3.0.4",
     "opn": "^5.4.0",
+    "portfinder": "^1.0.21",
     "strip-ansi": "^5.2.0"
   },
   "devDependencies": {

--- a/packages/es-dev-server/src/config.js
+++ b/packages/es-dev-server/src/config.js
@@ -86,7 +86,7 @@ import { compatibilityModes } from './constants.js';
  */
 export function createConfig(config) {
   const {
-    port = 8080,
+    port,
     hostname = '127.0.0.1',
     open = false,
     rootDir = process.cwd(),

--- a/packages/es-dev-server/src/start-server.js
+++ b/packages/es-dev-server/src/start-server.js
@@ -1,42 +1,17 @@
 import opn from 'opn';
 import chokidar from 'chokidar';
+import portfinder from 'portfinder';
 import { createServer } from './create-server.js';
 
 /** @param {import('./config.js').InternalConfig} cfg */
-export function startServer(cfg) {
+export async function startServer(cfg) {
   let fileWatcher = cfg.watch ? chokidar.watch([]) : undefined;
 
   const result = createServer(cfg, fileWatcher);
   const { app } = result;
   let { server } = result;
 
-  // start the server, open the browser and log messages
-  server.listen({ port: cfg.port, host: cfg.hostname }, () => {
-    const prettyHost = cfg.hostname === '127.0.0.1' ? 'localhost' : cfg.hostname;
-
-    if (cfg.logStartup) {
-      const msgs = [];
-      msgs.push(`es-dev-server started on http${cfg.http2 ? 's' : ''}://${prettyHost}:${cfg.port}`);
-      msgs.push(`  Serving files from '${cfg.rootDir}'.`);
-
-      if (cfg.openBrowser) {
-        msgs.push(`  Opening browser on '${cfg.openPath}'`);
-      }
-
-      if (cfg.appIndex) {
-        msgs.push(
-          `  Using history API fallback, redirecting non-file requests to '${cfg.appIndex}'`,
-        );
-      }
-
-      /* eslint-disable-next-line no-console */
-      console.log(msgs.join('\n'));
-    }
-
-    if (cfg.openBrowser) {
-      opn(`http${cfg.http2 ? 's' : ''}://${prettyHost}:${cfg.port}${cfg.openPath}`);
-    }
-  });
+  const port = typeof cfg.port === 'number' ? cfg.port : await portfinder.getPortPromise();
 
   // cleanup after quit
   server.addListener('close', () => {
@@ -46,15 +21,55 @@ export function startServer(cfg) {
     }
   });
 
-  ['exit', 'SIGINT', 'uncaughtException'].forEach(event => {
+  function stopServer() {
+    if (server) {
+      server.close();
+      server = undefined;
+    }
+  }
+
+  ['exit', 'SIGINT'].forEach(event => {
     // @ts-ignore
-    process.on(event, () => {
-      if (server) {
-        server.close();
-        server = undefined;
-      }
-    });
+    process.on(event, stopServer);
   });
+
+  process.on('uncaughtException', error => {
+    /* eslint-disable-next-line no-console */
+    console.error(error);
+    stopServer();
+  });
+
+  // start the server, open the browser and log messages
+  await new Promise(resolve =>
+    server.listen({ port, host: cfg.hostname }, () => {
+      const prettyHost = cfg.hostname === '127.0.0.1' ? 'localhost' : cfg.hostname;
+
+      if (cfg.logStartup) {
+        const msgs = [];
+        msgs.push(`es-dev-server started on http${cfg.http2 ? 's' : ''}://${prettyHost}:${port}`);
+        msgs.push(`  Serving files from '${cfg.rootDir}'.`);
+
+        if (cfg.openBrowser) {
+          msgs.push(`  Opening browser on '${cfg.openPath}'`);
+        }
+
+        if (cfg.appIndex) {
+          msgs.push(
+            `  Using history API fallback, redirecting non-file requests to '${cfg.appIndex}'`,
+          );
+        }
+
+        /* eslint-disable-next-line no-console */
+        console.log(msgs.join('\n'));
+      }
+
+      if (cfg.openBrowser) {
+        opn(`http${cfg.http2 ? 's' : ''}://${prettyHost}:${port}${cfg.openPath}`);
+      }
+
+      resolve();
+    }),
+  );
 
   return {
     server,

--- a/packages/es-dev-server/test/middleware/babel.test.js
+++ b/packages/es-dev-server/test/middleware/babel.test.js
@@ -9,9 +9,10 @@ const host = 'http://localhost:8080/';
 describe('babel middleware', () => {
   describe('no flags', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
         }),
       ));
@@ -34,9 +35,10 @@ describe('babel middleware', () => {
 
   describe('node resolve', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           nodeResolve: true,
           babelModernExclude: ['**/src/excluded-modern.js'],
@@ -108,8 +110,9 @@ describe('babel middleware', () => {
 
   describe('babel flag', () => {
     it('transforms code based on .babelrc from the user', async () => {
-      const { server } = startServer(
+      const { server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           babel: true,
         }),
@@ -127,8 +130,9 @@ describe('babel middleware', () => {
     });
 
     it('can handle any file extensions', async () => {
-      const { server } = startServer(
+      const { server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           fileExtensions: ['.html', '.foo'],
           babel: true,
@@ -153,9 +157,10 @@ describe('babel middleware', () => {
 
   describe('compatibility modern', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
           compatibility: compatibilityModes.MODERN,
@@ -208,9 +213,10 @@ describe('babel middleware', () => {
 
   describe('compatibility all', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
           compatibility: compatibilityModes.ALL,
@@ -308,9 +314,10 @@ describe('babel middleware', () => {
 
   describe('custom babel config', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
           babelConfig: {
@@ -346,9 +353,10 @@ describe('babel middleware', () => {
 
   describe('typescript', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'typescript'),
           appIndex: path.resolve(__dirname, '..', 'fixtures', 'typescript', 'index.html'),
           babel: true,
@@ -378,8 +386,9 @@ describe('babel middleware', () => {
   it('compiles inline modules', async () => {
     let server;
     try {
-      ({ server } = startServer(
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'inline-module'),
           compatibility: compatibilityModes.ALL,
           nodeResolve: true,

--- a/packages/es-dev-server/test/middleware/base-path.test.js
+++ b/packages/es-dev-server/test/middleware/base-path.test.js
@@ -7,9 +7,10 @@ const host = 'http://localhost:8080/';
 
 describe('base path middleware', () => {
   let server;
-  beforeEach(() => {
-    ({ server } = startServer(
+  beforeEach(async () => {
+    ({ server } = await startServer(
       createConfig({
+        port: 8080,
         rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
         appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
         basePath: '/foo',

--- a/packages/es-dev-server/test/middleware/cache.test.js
+++ b/packages/es-dev-server/test/middleware/cache.test.js
@@ -11,9 +11,10 @@ const testFile = path.join(fixtureDir, 'cached-files.js');
 
 describe('cache middleware', () => {
   let server;
-  beforeEach(() => {
-    ({ server } = startServer(
+  beforeEach(async () => {
+    ({ server } = await startServer(
       createConfig({
+        port: 8080,
         rootDir: fixtureDir,
       }),
     ));

--- a/packages/es-dev-server/test/middleware/history-api-fallback.test.js
+++ b/packages/es-dev-server/test/middleware/history-api-fallback.test.js
@@ -8,9 +8,10 @@ const host = 'http://localhost:8080/';
 describe('history api fallback middleware', () => {
   describe('index in root', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           appIndex: path.resolve(__dirname, '..', 'fixtures', 'simple', 'index.html'),
         }),
@@ -57,9 +58,10 @@ describe('history api fallback middleware', () => {
 
   describe('index not in root', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'index-not-in-root'),
           appIndex: path.resolve(
             __dirname,

--- a/packages/es-dev-server/test/middleware/message-channel.test.js
+++ b/packages/es-dev-server/test/middleware/message-channel.test.js
@@ -20,9 +20,10 @@ const reloadWithHost = `${host}${messageChannelEndpoint.substring(
 describe.skip('message channel middleware', () => {
   describe('no flags', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'reload'),
           appIndex: path.resolve(__dirname, '..', 'fixtures', 'reload', 'index.html'),
         }),
@@ -44,8 +45,8 @@ describe.skip('message channel middleware', () => {
 
   describe('watch flag', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer({
+    beforeEach(async () => {
+      ({ server } = await startServer({
         ...createConfig({
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'reload'),
           appIndex: path.resolve(__dirname, '..', 'fixtures', 'reload', 'index.html'),

--- a/packages/es-dev-server/test/middleware/reload-browser.test.js
+++ b/packages/es-dev-server/test/middleware/reload-browser.test.js
@@ -42,7 +42,7 @@ describe.skip('reload browser middleware', function describe() {
   this.timeout(60000);
   let server;
   beforeEach(async () => {
-    ({ server } = startServer({
+    ({ server } = await startServer({
       ...createConfig({
         rootDir: path.resolve(__dirname, '..', 'fixtures', 'reload'),
         watch: true,

--- a/packages/es-dev-server/test/middleware/transform-index-html.test.js
+++ b/packages/es-dev-server/test/middleware/transform-index-html.test.js
@@ -25,8 +25,9 @@ describe('transform-index-html middleware', () => {
         it(`${name} matches the snapshot`, async () => {
           let server;
           try {
-            ({ server } = startServer(
+            ({ server } = await startServer(
               createConfig({
+                port: 8080,
                 rootDir: path.resolve(__dirname, '..', 'fixtures', fixture),
                 compatibility,
                 ...extraOptions,
@@ -60,8 +61,9 @@ describe('transform-index-html middleware', () => {
   it('serves polyfills', async () => {
     let server;
     try {
-      ({ server } = startServer(
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'inline-module'),
           compatibility: compatibilityModes.ALL,
         }),
@@ -85,8 +87,9 @@ describe('transform-index-html middleware', () => {
   it('serves inline modules', async () => {
     let server;
     try {
-      ({ server } = startServer(
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'inline-module'),
           compatibility: compatibilityModes.ESM,
         }),
@@ -113,8 +116,9 @@ describe('transform-index-html middleware', () => {
   it('handles pages without modules', async () => {
     let server;
     try {
-      ({ server } = startServer(
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
           compatibility: compatibilityModes.ESM,
         }),

--- a/packages/es-dev-server/test/start-server.test.js
+++ b/packages/es-dev-server/test/start-server.test.js
@@ -9,9 +9,10 @@ const host = 'http://localhost:8080/';
 describe('server', () => {
   context('', () => {
     let server;
-    beforeEach(() => {
-      ({ server } = startServer(
+    beforeEach(async () => {
+      ({ server } = await startServer(
         createConfig({
+          port: 8080,
           rootDir: path.resolve(__dirname, 'fixtures', 'simple'),
         }),
       ));
@@ -52,10 +53,11 @@ describe('server', () => {
   });
 
   it('can configure the hostname', async () => {
-    const { server } = startServer(
+    const { server } = await startServer(
       createConfig({
         rootDir: path.resolve(__dirname, 'fixtures', 'simple'),
         hostname: '0.0.0.0',
+        port: 8080,
       }),
     );
     const response = await fetch(`http://0.0.0.0:8080/index.html`);
@@ -67,17 +69,17 @@ describe('server', () => {
   });
 
   it('can run multiple servers in parallel', async () => {
-    function createServer(port) {
-      return startServer(
+    async function createServer(port) {
+      return (await startServer(
         createConfig({
+          port,
           rootDir: path.resolve(__dirname, 'fixtures', 'simple'),
           hostname: '0.0.0.0',
-          port,
         }),
-      ).server;
+      )).server;
     }
 
-    const servers = [8080, 8081, 8082, 8083, 8084, 8085].map(createServer);
+    const servers = await Promise.all([8080, 8081, 8082, 8083, 8084, 8085].map(createServer));
     const requests = servers.map((server, i) => fetch(`http://0.0.0.0:808${i}/index.html`));
 
     for (const request of requests) {
@@ -95,8 +97,9 @@ describe('server', () => {
 
   it('can install custom middlewares', async () => {
     let requestURL;
-    const { server } = startServer(
+    const { server } = await startServer(
       createConfig({
+        port: 8080,
         rootDir: path.resolve(__dirname, 'fixtures', 'simple'),
         hostname: '0.0.0.0',
         middlewares: [

--- a/packages/karma-esm/README.md
+++ b/packages/karma-esm/README.md
@@ -50,18 +50,19 @@ To manually setup this plugin, add it as a karma framework:
 ## Configuration
 `karma-esm` can be configured with these options:
 
-| name              |  type   | description                                                     |
-| ----------------- | ------- | --------------------------------------------------------------- |
-| nodeResolve       | boolean | Transforms bare module imports using node resolve.              |
-| coverage          | boolean | Whether to report test code coverage.                           |
-| importMap         | string  | Path to import map used for testing.                            |
-| compatibility     | string  | Compatibility level to run the `es-dev-server` with.            |
-| coverageExclude   | array   | Extra glob patterns of tests to exclude from coverage.          |
-| babelConfig       | string  | Custom babel configuration file to run on served code.          |
-| moduleDirs        | string  | Directories to resolve modules from. Defaults to `node_modules` |
-| babel             | boolean | Whether to pick up a babel configuration file in your project.  |
-| fileExtensions    | array   | Custom file extensions to serve as es modules.                  |
-| polyfills         | object  | Polyfill configuration.                                         |
+| name              | type    | description                                                                                                   |
+| ----------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| nodeResolve       | boolean | Transforms bare module imports using node resolve.                                                            |
+| coverage          | boolean | Whether to report test code coverage.                                                                         |
+| importMap         | string  | Path to import map used for testing.                                                                          |
+| compatibility     | string  | Compatibility level to run the `es-dev-server` with.                                                          |
+| coverageExclude   | array   | Extra glob patterns of tests to exclude from coverage.                                                        |
+| babelConfig       | string  | Custom babel configuration file to run on served code.                                                        |
+| moduleDirs        | string  | Directories to resolve modules from. Defaults to `node_modules`                                               |
+| babel             | boolean | Whether to pick up a babel configuration file in your project.                                                |
+| fileExtensions    | array   | Custom file extensions to serve as es modules.                                                                |
+| polyfills         | object  | Polyfill configuration.                                                                                       |
+| devServerPort     | number  | port of server that serves the modules. Note that this is not the karma port. Picks a random port if not set. |
 
 ### nodeResolve
 Node resolve is necessary when you have 'bare imports' in your code, and are not using import maps to resolve them.

--- a/packages/karma-esm/package.json
+++ b/packages/karma-esm/package.json
@@ -33,6 +33,7 @@
     "deepmerge": "^3.3.0",
     "es-dev-server": "^1.10.6",
     "minimatch": "^3.0.4",
+    "portfinder": "^1.0.21",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,30 +1964,6 @@
     "@open-wc/semantic-dom-diff" "^0.13.16"
     "@types/chai" "^4.1.7"
 
-"@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.1.31"
-  dependencies:
-    "@open-wc/testing-karma" "^3.1.6"
-    "@types/node" "^11.13.0"
-    karma-browserstack-launcher "^1.0.0"
-
-"@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.1.6"
-  dependencies:
-    "@open-wc/karma-esm" "^2.2.4"
-    axe-core "^3.3.1"
-    istanbul-instrumenter-loader "^3.0.0"
-    karma "^4.0.0"
-    karma-chrome-launcher "^2.0.0"
-    karma-coverage-istanbul-reporter "^2.0.0"
-    karma-mocha "^1.0.0"
-    karma-mocha-reporter "^2.0.0"
-    karma-mocha-snapshot "^0.2.1"
-    karma-snapshot "^0.6.0"
-    karma-source-map-support "^1.3.0"
-    karma-sourcemap-loader "^0.3.0"
-    mocha "^6.2.0"
-
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -12809,6 +12785,15 @@ portfinder@^1.0.13, portfinder@^1.0.20:
   version "1.0.20"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.20.tgz#bea68632e54b2e13ab7b0c4775e9b41bf270e44a"
   integrity sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==
+  dependencies:
+    async "^1.5.2"
+    debug "^2.2.0"
+    mkdirp "0.5.x"
+
+portfinder@^1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.21.tgz#60e1397b95ac170749db70034ece306b9a27e324"
+  integrity sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==
   dependencies:
     async "^1.5.2"
     debug "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,6 +1964,30 @@
     "@open-wc/semantic-dom-diff" "^0.13.16"
     "@types/chai" "^4.1.7"
 
+"@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
+  version "1.1.36"
+  dependencies:
+    "@open-wc/testing-karma" "^3.1.11"
+    "@types/node" "^11.13.0"
+    karma-browserstack-launcher "^1.0.0"
+
+"@open-wc/testing-karma@file:./packages/testing-karma":
+  version "3.1.11"
+  dependencies:
+    "@open-wc/karma-esm" "^2.2.9"
+    axe-core "^3.3.1"
+    istanbul-instrumenter-loader "^3.0.0"
+    karma "^4.0.0"
+    karma-chrome-launcher "^2.0.0"
+    karma-coverage-istanbul-reporter "^2.0.0"
+    karma-mocha "^1.0.0"
+    karma-mocha-reporter "^2.0.0"
+    karma-mocha-snapshot "^0.2.1"
+    karma-snapshot "^0.6.0"
+    karma-source-map-support "^1.3.0"
+    karma-sourcemap-loader "^0.3.0"
+    mocha "^6.2.0"
+
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"


### PR DESCRIPTION
If no port is explicitly configured, picks a random port in testing and the dev server. This fixes running multiple instances of karma, and is generally good for stability. 

For the dev server it's really useful when you're working with many different projects.

Also fixes logging uncaught exceptions.

fixes https://github.com/open-wc/open-wc/issues/698
fixes https://github.com/open-wc/open-wc/issues/694
fixes https://github.com/open-wc/open-wc/issues/670
