### PR TITLE
feat(building-webpack): allow overriding mode through config

### DIFF
--- a/packages/building-webpack/package.json
+++ b/packages/building-webpack/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "demo:start": "http-server dist -o",
     "demo:build": "webpack --mode production --config demo/js/webpack.config.js",
+    "demo:build:dev": "webpack --mode development --config demo/js/webpack.config.js",
     "demo:webpack-dev": "webpack-dev-server --mode development --config demo/js/webpack.config.js --open",
     "demo:webpack-dev:legacy": "webpack-dev-server --mode development --config demo/js/webpack.config.js --open --legacy",
     "demo:build:modern": "webpack --mode production --config demo/js/webpack.modern.config.js",


### PR DESCRIPTION
Allows overriding webpack mode through the config if set. Also defaults to production rather than development to match webpack's behavior.

Fixes https://github.com/open-wc/open-wc/issues/696

