### PR TITLE
fix(webpack-index-html-plugin): create entry without extension

### DIFF
--- a/packages/webpack-index-html-plugin/src/create-entrypoints.js
+++ b/packages/webpack-index-html-plugin/src/create-entrypoints.js
@@ -4,6 +4,11 @@ const SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
 const MultiEntryPlugin = require('webpack/lib/MultiEntryPlugin');
 const { extractResources } = require('@open-wc/building-utils/index-html');
 
+function getFilenameWithoutExtension(filePath) {
+  const filename = path.basename(filePath);
+  return filename.substring(0, filename.length - path.extname(filename).length);
+}
+
 function createEntrypoints(compiler, context, entry, config, createError) {
   let index;
   let nonAppEntryPoints;
@@ -52,7 +57,7 @@ function createEntrypoints(compiler, context, entry, config, createError) {
 
   const entries = resources.jsModules.map(jsModule => ({
     jsModule: path.resolve(indexFolder, jsModule),
-    entryName: jsModule.substring(jsModule.lastIndexOf(path.sep) + 1, jsModule.length - 3),
+    entryName: getFilenameWithoutExtension(jsModule),
   }));
 
   if (new Set(entries.map(e => e.entryName)).size !== entries.length) {


### PR DESCRIPTION
The way we currently compute the entry filename is a bit native, if it doesn't end with an extension with two characters it leaves some characters behind. This change properly extracts any extension.