### PR TITLE
Chore/eslint updates

### DIFF
--- a/packages/create/src/generators/linting-eslint/templates/_package.json
+++ b/packages/create/src/generators/linting-eslint/templates/_package.json
@@ -4,6 +4,7 @@
     "format:eslint": "eslint --ext .js,.html . --fix --ignore-path .gitignore"
   },
   "devDependencies": {
+    "eslint": "^5.13.0",
     "@open-wc/eslint-config": "^1.0.0"
   },
   "eslintConfig": {

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -2,6 +2,8 @@
 
 [//]: # (AUTO INSERT HEADER PREPUBLISH)
 
+> Note that we only support eslint v5, we are blocked on some of our dependencies updating. See https://github.com/airbnb/javascript/issues/2036 for progress.
+
 Use [ESLint](https://eslint.org/) to lint your es6 code.
 
 ## Setup

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.0",
     "eslint": "^5.13.0",
     "eslint-config-airbnb-base": "^13.2.0",
-    "eslint-plugin-html": "^4.0.0",
+    "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-wc": "^1.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,16 +1965,16 @@
     "@types/chai" "^4.1.7"
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.1.31"
+  version "1.1.38"
   dependencies:
-    "@open-wc/testing-karma" "^3.1.6"
+    "@open-wc/testing-karma" "^3.1.13"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.1.6"
+  version "3.1.13"
   dependencies:
-    "@open-wc/karma-esm" "^2.2.4"
+    "@open-wc/karma-esm" "^2.2.11"
     axe-core "^3.3.1"
     istanbul-instrumenter-loader "^3.0.0"
     karma "^4.0.0"
@@ -7341,12 +7341,12 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-eslint-plugin-html@^4.0.0:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-4.0.6.tgz#724bb9272efb4df007dfee8dfb269ed83577e5b4"
-  integrity sha512-nj6A9oK+7BKnMm0E7dMRH3r75BfpkXtcVIb3pFC4AcDdBTNyg2NGxHXyFNT1emW4VsR7P2SZvRXXQtUR+kY08w==
+eslint-plugin-html@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-6.0.0.tgz#28e5c3e71e6f612e07e73d7c215e469766628c13"
+  integrity sha512-PQcGippOHS+HTbQCStmH5MY1BF2MaU8qW/+Mvo/8xTa/ioeMXdSP+IiaBw2+nh0KEMfYQKuTz1Zo+vHynjwhbg==
   dependencies:
-    htmlparser2 "^3.8.2"
+    htmlparser2 "^3.10.1"
 
 eslint-plugin-import@^2.0.0:
   version "2.17.2"
@@ -9004,7 +9004,7 @@ html-webpack-plugin@^4.0.0-beta.2:
     tapable "^1.1.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.3.0, htmlparser2@^3.8.2:
+htmlparser2@^3.10.1, htmlparser2@^3.3.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==


### PR DESCRIPTION
- Updates eslint-config dependencies 
- Adds a notice about eslint 6 support
- Add eslint as a dependency to `create`. When we support eslint 6 we can release a breaking change and remove it from `esling-config`.

Fixes https://github.com/open-wc/open-wc/issues/651