### PR TITLE
docs: improve testing documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -31,8 +31,10 @@ const sidebar = [
     collapsable: true,
     children: [
       ['/testing/', 'Getting started'],
+      '/testing/testing',
       '/testing/testing-helpers',
       '/testing/testing-chai-a11y-axe',
+      '/testing/testing-sinon',
       '/testing/semantic-dom-diff',
       '/testing/testing-karma',
       '/testing/karma-esm',

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,1 +1,56 @@
-../../packages/testing/README.md
+# Testing
+
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
+
+Testing is an important part of any software project. We have collected a set of libraries, tools and best practices to get you started with testing.
+
+Our setup is aimed specifically at working with minimal tooling, using the native es module loader of the browser just like our [developing setup](https://open-wc.org/developing/). We have special helper functions available for testing web components, but our setup works without web components as well.
+
+## Setup
+The easiest way to set up testing in your project is to use our project scaffolding. You can use this to create a new project or to upgrade an existing project:
+```bash
+npm init @open-wc
+```
+
+### Manual setup
+To set up testing in your project manually, you will need to follow the instructions of the separate tools and packages below.
+
+## Step by step guide
+To help you get started with testing, we recommend [reading this article](https://dev.to/open-wc/testing-workflow-for-web-components-g73) for a great step by step guide.
+
+## Karma
+For testing in the browser, we recommend [Karma](https://karma-runner.github.io/latest/index.html). With Karma, you can run unit tests for our javascript, as well as component tests on the rendered dom elements.
+
+See the [testing-karma page](https://open-wc.org/testing/testing-karma.html) to learn how to set this up with our default configuration.
+
+## Testing libraries
+When testing with karma, we recommend the following libraries:
+
+- [mocha](https://mochajs.org/) for setting up the testing structure.
+- [chai](https://www.chaijs.com/) for doing assertions
+- [sinon](https://open-wc.org/testing/testing-sinon.html) for mocks, spies and stubs
+- [@open-wc/testing-helpers](https://open-wc.org/testing/testing-helpers.html) for setting up test fixtures and helper functions
+- [@open-wc/semantic-dom-diff](https://open-wc.org/testing/smenatic-dom-diff.html) for snapshot testing the rendered HTML
+- [@open-wc/chai-axe-a11y](https://open-wc.org/testing/testing-chai-a11y-axe.html) for testing accessibility
+
+To use these testing libraries, we recommend [@open-wc/testing](https://open-wc.org/testing/testing.html). This is an opinionated package that combines and configures many of these testing libraries, to minimize the amount of ceremony required to set up tests. For example, it exports chai with plugins already registered.
+
+## Cross-browser testing
+To make sure your project is production-ready, we recommend running tests in all the browsers you want to support. If you do not have access to all browsers, we recommend using a service like [Browserstack](https://www.browserstack.com/) to make sure your project works as intended.
+
+Read more at [testing-karma-bs](https://open-wc.org/testing/testing-karma-bs.html) to learn how to set this up with karma.
+
+## Integration testing
+A large part of the tests that are traditionally done with selenium can be done with Karma. However, there are still tests that should be run after an application has been deployed. We're still looking for good solutions here, help us improve this documentation by making a pull request!
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/testing/README.md';
+      }
+    }
+  }
+</script>

--- a/docs/testing/testing-sinon.md
+++ b/docs/testing/testing-sinon.md
@@ -1,0 +1,32 @@
+# Testing with sinon
+
+[Sinon](https://sinonjs.org/) is a library that lets you set up mocks, spies, and stubs in javascript. They ship an es-module version, so it's easy to use it in your tests:
+
+Add Sinon as a dependency:
+```bash
+npm i -D sinon
+```
+
+Use it in your tests:
+```javascript
+import { html } from 'lit-html';
+import { stub } from 'sinon';
+import { expect, fixture } from '@open-wc/testing';
+
+describe('my component', () => {
+  it('calls myFunction when a button is clicked', () => {
+    const element = fixture(html`<my-component></my-component>`);
+
+    // stub a function
+    const myFunctionStub = stub(element, 'myFunction');
+
+    // click a button
+    element.shadowRoot.getElementByid('myButton').click();
+
+    // check if the function was called
+    expect(myFunctionStub.calledCount).to.equal(1);
+  });
+});
+```
+
+See the [sinon documentation](https://sinonjs.org/) to learn how to use the different features.

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -1,0 +1,1 @@
+../../packages/testing/README.md

--- a/packages/chai-a11y-axe/README.md
+++ b/packages/chai-a11y-axe/README.md
@@ -16,7 +16,7 @@ The BDD UI works with chai's `expect` function.
 
 Because the test is asynchronous, you must either await its result or pass a `done` parameter in the plugin's options object.
 
-Rules can be ignored by passing `ignoredRules` with list of ignored rules as a configuration option.
+Rules can be ignored by passing `ignoredRules` with a list of ignored rules as a configuration option.
 
 ```js
 import { fixture, expect, html } from '@open-wc/testing';

--- a/packages/karma-esm/README.md
+++ b/packages/karma-esm/README.md
@@ -4,7 +4,7 @@ Karma plugin for running tests with es modules on a wide range of browsers.
 
 Out the box es modules don't work with karma because they dynamically request their dependencies, which karma doesn't allow.
 
-The `karma-esm` plugin fixes this and spins up [es-dev-server](https://open-wc.org/developing/es-dev-server.html) behind the scenes. This lets you write tests using es mdodules, modern javascript syntax and features and have karma run them on all modern browsers and IE11.
+The `karma-esm` plugin fixes this and spins up [es-dev-server](https://open-wc.org/developing/es-dev-server.html) behind the scenes. This lets you write tests using es modules, modern javascript syntax and features, and have karma run them on all modern browsers and IE11.
 
 `karma-esm` takes care of loading the correct polyfills, and runs babel for older browsers if necessary. On modern browsers missing module features, such as import maps, are shimmed using [es-module-shims](https://github.com/guybedford/es-module-shims). On browsers without es module support, modules are polyfilled with [system-js](https://github.com/systemjs/systemjs).
 
@@ -14,14 +14,16 @@ See [the es-dev-server docs](https://open-wc.org/developing/es-dev-server.html) 
 We recommend the [testing-karma configuration](https://open-wc.org/testing/testing-karma.html) for a good default karma setup which includes `karma-esm` and many other good defaults.
 
 ### Manual setup
-To manually setup this plugin, add it as a karma framework:
+To manually set up this plugin, add it as a karma framework:
 
 1. Install the plugin
-`npm i --save @open-wc/karma-esm`
+```bash
+npm i -D @open-wc/karma-esm
+```
 
 2. Add to your karma config
 ```javascript
-{
+module.exports = {
   // define where your test files are, make sure to set type to module
   files: [
     { pattern: 'test/**/*.test.js', type: 'module' }
@@ -64,7 +66,7 @@ To manually setup this plugin, add it as a karma framework:
 | polyfills         | object  | Polyfill configuration.                                         |
 
 ### nodeResolve
-Node resolve is necessary when you have 'bare imports' in your code, and are not using import maps to resolve them.
+Node resolve is necessary when you have 'bare imports' in your code and are not using import maps to resolve them.
 
 It transforms: `import foo from 'bar'` to: `import foo from './node_modules/bar/bar.js`.
 
@@ -72,12 +74,12 @@ It transforms: `import foo from 'bar'` to: `import foo from './node_modules/bar/
 Due to a bug in karma, the test coverage reporter causes browser logs to appear twice which can be annoying
 
 ### compatibility
-The compatibility option makes your code compatible with older browsers. It loads polyfills and transform modern syntax where needed. For testing it's best to leave this at 'none' for no modifications, or 'all' for full compatibility.
+The compatibility option makes your code compatible with older browsers. It loads polyfills and transforms modern syntax where needed. For testing, it's best to leave this at 'none' for no modifications, or 'all' for full compatibility.
 
 See [the documentation of the dev server](https://open-wc.org/developing/es-dev-server.html) for information on all the different modes.
 
 ## Karma preprocessors
-Unfortunately, to make karma work with es modules regular karma preprocessors no longer work. You can however configure the `es-dev-server` to do code transoformations if needed.
+Unfortunately, to make karma work with es modules regular karma preprocessors no longer work. You can, however, configure the `es-dev-server` to do code transformations if needed.
 
 ## Custom babel plugins
 You can configure `karma-esm` to pick up the babel configuration files in your project:
@@ -125,7 +127,7 @@ npm i --save-dev @babel/preset-typescript
 }
 ```
 
-To add support for experimental features which are normally handled by the typescript compiler, you can add extra babel plugins. Because typescript implements the legacy decorators proposal, you need to add the legacy flag and add class properties in loose mode:
+To add support for experimental features that are normally handled by the typescript compiler, you can add extra babel plugins. Because typescript implements the legacy decorators proposal, you need to add the legacy flag and add class properties in loose mode:
 
   1. Install the plugins:
 ```bash

--- a/packages/semantic-dom-diff/README.md
+++ b/packages/semantic-dom-diff/README.md
@@ -4,13 +4,13 @@
 
 ## Manual Setup
 ```bash
-yarn add @open-wc/semantic-dom-diff --dev
+npm i -D @open-wc/semantic-dom-diff
 ```
-`semantic-dom-diff` allows diffing chunks of dom or HTML for semanticaly equality:
+`semantic-dom-diff` allows diffing chunks of dom or HTML for semantic equality:
 - whitespace and newlines are normalized
 - tags and attributes are printed on individual lines
 - comments are removed
-- style, script and svg contents are removed
+- style, script and SVG contents are removed
 - tags, attributes or element's light dom can be ignored through configuration
 
 ## Chai Plugin
@@ -75,7 +75,7 @@ it('my test', async () => {
 ```
 
 ### Manual diffing
-You can use the chai plugin to manually diff chunks of dom. The dom is diffed semantically: whitespace, newlines etc. are normalized.
+You can use the chai plugin to manually diff chunks of dom. The dom is diffed semantically: whitespace, newlines, etc. are normalized.
 
 ```javascript
 class MyElement extends HTMLElement {
@@ -151,7 +151,7 @@ describe('my-message', () => {
 });
 ```
 
-Snapshots are stored in the `__snapshots__` folder in your project, using the most top level `describe` as the name for your snapshots file.
+Snapshots are stored in the `__snapshots__` folder in your project, using the most top-level `describe` as the name for your snapshots file.
 
 #### Updating a snapshot
 
@@ -164,7 +164,7 @@ If the difference was an intended change, you can update the snapshots by passin
 
 #### Cleaning up unused snapshots
 
-After refactoring there might be leftover snapshot files which are unused. You can run karma with the `--prune-snapshots` flag to clean these up.
+After refactoring, there might be unused and leftover snapshot files. You can run karma with the `--prune-snapshots` flag to clean these up.
 
 **Ignoring tags and attributes**
 
@@ -177,7 +177,7 @@ it('renders correctly', async () => {
       Hey
     </div>
   `);
-  
+
   expect(el).dom.to.equal('<div>Hey</div>', {
     ignoreAttributes: ['my-random-attribute']
   });
@@ -239,7 +239,7 @@ it('renders correctly', async () => {
 
 **Ignoring children**
 
-When working with web components you may find that they sometimes render to their light dom, for example to meet some accessibility requirements. We don't want to ignore the tag completely, as we would then not be able to test if we did render the tag.
+When working with web components you may find that they sometimes render to their light dom, for example, to meet some accessibility requirements. We don't want to ignore the tag completely, as we would then not be able to test if we did render the tag.
 
 We can ignore just it's light dom:
 

--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -2,23 +2,43 @@
 
 [//]: # (AUTO INSERT HEADER PREPUBLISH)
 
-In order to efficiently test Web Components you will need some helpers to register and instantiate them for you.
-
-::: tip
-This is part of the default [open-wc testing](https://open-wc.org/testing/) recommendation
-:::
+A library with helpers functions for testing in the browser.
 
 ::: warning
-Testing helpers requires as a peer dependency [lit-html](https://lit-html.polymer-project.org/).
-You can install it inside your project with npm :
+
+Testing helpers uses [lit-html](https://lit-html.polymer-project.org/), but it's set up as a peer dependency to avoid version conflicts.
+
+You don't need to write your components with lit-html to use this library, but you will need to install it:
 ```bash
-npm i --save lit-html
+npm i -D lit-html
 ```
+
 :::
 
-## Test a custom element
-```js
+# Usage
+We recommend using this library through [@open-wc/testing](https://open-wc.org/testing/testing.html) which preconfigures and combines this library with other testing libraries.
+
+The examples that are shown here assume this setup, and import from `@open-wc/testing`. If you want to use this library standalone, you will need to import from `@open-wc/testing-helpers` directly instead:
+
+```javascript
+// import from general testing library
+import { fixture } from '@open-wc/testing';
+
+// import from testing-helpers directly
 import { fixture } from '@open-wc/testing-helpers';
+```
+
+## Test fixtures
+A test fixture renders a piece of HTML and injects into the DOM so that you can test the behavior of your component. It returns the first dom element from the template so that you can interact with it if needed. For example you can call functions, look up dom nodes or inspect the rendered HTML.
+
+Test fixtures are async to ensure rendering is properly completed.
+
+### Templates
+Test fixtures can be set up by using a string or a [lit-html](https://github.com/Polymer/lit-html) template. You don't need to use `lit-html` in your project to use the test fixtures, it just renders standard HTML.
+
+### Test a custom element
+```js
+import { fixture } from '@open-wc/testing';
 
 it('can instantiate an element', async () => {
   const el = await fixture('<my-el foo="bar"></my-el>');
@@ -26,9 +46,9 @@ it('can instantiate an element', async () => {
 }
 ```
 
-## Test a custom element with properties
+### Test a custom element with properties
 ```js
-import { html, fixture } from '@open-wc/testing-helpers';
+import { html, fixture } from '@open-wc/testing';
 
 it('can instantiate an element with properties', async () => {
   const el = await fixture(html`<my-el .foo=${'bar'}></my-el>`);
@@ -36,12 +56,10 @@ it('can instantiate an element with properties', async () => {
 })
 ```
 
-## Test a custom class
-If you're testing a mixin, or have multiple base classes that offer a various set of options you might find yourself in the situation of needing multiple custom element names in your tests.
-This can be dangerous as custom elements are global, so you don't want to have overlapping names in your tests.
-Therefore we recommend using a the following function to avoid that.
+### Test a custom class
+If you're testing a mixin, or have multiple base classes that offer a various set of options you might find yourself in the situation of needing multiple custom element names in your tests. This can be dangerous as custom elements are global, so you don't want to have overlapping names in your tests. We recommend using the `defineCE` function to avoid that:
 ```js
-import { fixture, defineCE } from '@open-wc/testing-helpers';
+import { fixture, defineCE } from '@open-wc/testing';
 
 const tag = defineCE(class extends MyMixin(HTMLElement) {
   constructor() {
@@ -58,7 +76,7 @@ For lit-html it's a little tougher as it does not support dynamic tag names by d
 This uses a workaround that's not performant for rerenders, which is fine for testing, but do NOT use this in production code.
 
 ```js
-import { html, fixture, defineCE, unsafeStatic } from '@open-wc/testing-helpers';
+import { html, fixture, defineCE, unsafeStatic } from '@open-wc/testing';
 
 const tagName = defineCE(class extends MyMixin(HTMLElement) {
   constructor() {
@@ -110,7 +128,7 @@ await aTimeout(10); // would wait 10ms
 If you want to test attribute and property changes, and an easy way to wait for those changes to propagate, you can import the `elementUpdated` helper (also available directly in the `testing` package)
 
 ```js
-import { fixture, elementUpdated } from '@open-wc/testing-helpers';
+import { fixture, elementUpdated } from '@open-wc/testing';
 import '../my-component.js';
 
 describe('Attributes', () => {
@@ -179,7 +197,7 @@ it('can be focused and blured', async () => {
 ```
 
 ## Fixture Cleanup
-By default, if you import anything via `import { ... } from '@open-wc/testing-helpers';`, it will automatically register a side-effect that cleans up your fixtures.
+By default, if you import anything via `import { ... } from '@open-wc/testing';`, it will automatically register a side-effect that cleans up your fixtures.
 If you want to be in full control you can do so by using
 ```js
 import { fixture, fixtureCleanup } from '@open-wc/testing-helpers/index-no-side-effects.js';

--- a/packages/testing-karma-bs/README.md
+++ b/packages/testing-karma-bs/README.md
@@ -2,41 +2,60 @@
 
 [//]: # (AUTO INSERT HEADER PREPUBLISH)
 
-This will run your local test via Browserstack browsers/devices.
-You will need to have a Browserstack automate account.
+To make sure your project is production-ready, we recommend running tests in all the browsers you want to support.
 
-Using:
-- Karma via `@open-wc/testing-karma`
-- Testing via [Browserstack](https://www.browserstack.com/) via [karma-browserstack-launcher](https://github.com/karma-runner/karma-browserstack-launcher)
+If you do not have access to all browsers, we recommend using a service like [Browserstack](https://www.browserstack.com/) to make sure your project works as intended.
+Browserstack offers free accounts for [open source projects](https://www.browserstack.com/open-source).
 
-::: tip
-This is part of the default [open-wc testing](https://open-wc.org/testing/) recommendation
-:::
+The `testing-karma-bs` configuration helps setting up karma with Browserstack. To set it up you need to use the configuration in your project, and follow the instructions below to set up a user account
 
 ## Setup
+With our project scaffolding you can set up a pre-configured project, or you can upgrade an existing project by choosing `Upgrade -> Testing`:
 ```bash
 npm init @open-wc
-# Upgrade > Testing
-
-# follow Setup user + key
 ```
 
 ### Manual
-- `yarn add @open-wc/testing-karma-bs --dev`
-- Copy [karma.bs.config.js](https://github.com/open-wc/open-wc/blob/master/packages/create/src/generators/testing-karma-bs/templates/static/karma.bs.config.js) to `karma.bs.config.js`
-- Add these scripts to your package.json
-  ```js
+Install:
+```bash
+npm i -D @open-wc/testing-karma-bs deepmerge
+```
+
+Add a `karma.conf.bs.js`:
+
+```javascript
+const merge = require('deepmerge');
+const bsSettings = require('@open-wc/testing-karma-bs/bs-settings.js');
+const createBaseConfig = require('./karma.conf.js');
+
+module.exports = config => {
+  config.set(
+    merge(bsSettings(config), createBaseConfig(config), {
+      browserStack: {
+        project: 'your-name',
+      },
+    }),
+  );
+
+  return config;
+};
+```
+
+Add a script to your `package.json`:
+```json
+{
   "scripts": {
-    "test:bs": "karma start karma.bs.config.js --legacy --coverage"
-  },
-  ```
+    "test:bs": "karma start karma.bs.config.js --compatibility all --coverage"
+  }
+}
+```
 
 ### Setup user + key
 - Go to [https://www.browserstack.com/accounts/settings](https://www.browserstack.com/accounts/settings)
 - Look for "Automate" and write down your "Access Key" and "Username"
 
 ```bash
-# for one time use only
+# for one-time use only
 export BROWSER_STACK_USERNAME=xxx
 export BROWSER_STACK_ACCESS_KEY=xxx
 

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -2,12 +2,16 @@
 
 [//]: # (AUTO INSERT HEADER PREPUBLISH)
 
-We recommend karma as a general purpose tool for testing your code which runs in the browser. Karma can run your tests in all major browsers, this way you have confidence your code runs correctly in all the supported environments.
+We recommend karma as a general-purpose tool for testing code which runs in the browser. Karma can run a large range of browsers, including IE11. This way you are confident that your code runs correctly in all supported environments.
 
-Karma can be used both for running unit tests, as well as for running more complex e2e/integration tests.
+During development you can run Chrome Headless, giving fast feedback in the terminal while writing your tests. In your CI you can run more browsers, and/or use a service like [Browserstack](https://www.browserstack.com/) or [Saucelabs](https://saucelabs.com/) for testing in all supported browsers.
 
-## Default configuration
+Karma can be used both for running unit tests, as well as for running more complex e2e/integration tests in the DOM.
+
+## Getting started
 Our configuration sets up karma to run tests based on es modules with the necessary polyfills and fallbacks for older browsers and convenient test reporting.
+
+This page explains how to set up `karma`, see the [testing overview](https://open-wc.org/testing/) for guides and libraries to get started with testing in general.
 
 ### Features
 - Runs tests with es modules
@@ -17,29 +21,19 @@ Our configuration sets up karma to run tests based on es modules with the necess
 - Test coverage through instanbul when passing the `coverage` flag
 - Supports older browsers (down to IE11) when passing the `compatibility` flag
 
-::: tip
-This is part of the default [open-wc testing](https://open-wc.org/testing/) recommendation
-:::
-
 ## Setup
-### New project
+With our project scaffolding you can set up a pre-configured project, or you can upgrade an existing project by choosing `Upgrade -> Testing`:
 ```bash
 npm init @open-wc
 ```
 
-### Existing project
+### Manual
+Install:
 ```bash
-npm init @open-wc
-# Upgrade > Testing
+npm i -D @open-wc/testing-karma deepmerge karma
 ```
 
-### Manual setup
-- Install the required dependencies:
-```bash
-npm i --save-dev @open-wc/testing-karma deepmerge karma
-```
-
-- Create a `karma.conf.js`:
+Create a `karma.conf.js`:
 ```js
 const { createDefaultConfig } = require('@open-wc/testing-karma');
 const merge = require('deepmerge');
@@ -66,19 +60,21 @@ module.exports = config => {
   return config;
 };
 ```
-- Add scripts to your package.json:
+
+Add scripts to your package.json:
 ```json
-"scripts": {
-  "test": "karma start --coverage",
-  "test:watch": "karma start --auto-watch=true --single-run=false",
-  "test:update-snapshots": "karma start --update-snapshots",
-  "test:prune-snapshots": "karma start --prune-snapshots",
-  "test:compatibility": "karma start --compatibility all --auto-watch=true --single-run=false"
-},
+{
+  "scripts": {
+    "test": "karma start --coverage",
+    "test:watch": "karma start --auto-watch=true --single-run=false",
+    "test:update-snapshots": "karma start --update-snapshots",
+    "test:prune-snapshots": "karma start --prune-snapshots",
+    "test:compatibility": "karma start --compatibility all --auto-watch=true --single-run=false"
+  }
+}
 ```
 
-### Workflow
-
+## Workflow
 Commands explained:
 - `test`: does a single test run on the configured browsers (default headless chrome) and prints tests and coverage results.
 - `test:watch`: does a single test run, and then re-runs on file changes. coverage is not analyzed for performance. in watch mode you can also visit http://localhost:9876/debug.html to debug in the browser
@@ -86,26 +82,32 @@ Commands explained:
 - `test:prune-snapshots`: prunes any used snapshots files from `@open-wc/semantic-dom-diff`.
 - `test:compatibility`: like `test:watch`, except that it makes your tests compatible with older browsers (including IE11).
 
-### Testing single files or folders
-By default karma runs all your test files. To test a single file or folder, use the `--grep` flag. (If you did a manual setup, makes sure your config handles this flag).
+## Testing single files or folders
+By default, karma runs all your test files. To test a single file or folder, use the `--grep` flag. (If you did a manual setup, makes sure your config handles this flag).
 
 Pass which files to test to the grep flag: `npm run test -- --grep test/foo/bar.test.js`.
 
-### Debugging in the browser
+## Debugging in the browser
 While testing, it can be useful to debug your tests in a real browser so that you can use the browser's dev tools.
 
-Use `npm run test:watch` to keep karma running. Then open the URL printed by karma when it boots up. By default this is `http://localhost:9876/`. Click the debug button in the top right corner, or go directly to `http://localhost:9876/debug.html`.
+Use `npm run test:watch` to keep karma running. Then open the URL printed by karma when it boots up. By default, this is `http://localhost:9876/`. Click the debug button in the top right corner, or go directly to `http://localhost:9876/debug.html`.
 
 You can bookmark this page for easy access.
 
 Adding `debugger` statements will allow you to debug using the browser's dev tools.
 
-### Testing on older browsers
-By default our configuration does not do any modifications to your code. It just runs it as is in the browser. Depending on which features you use, this should be fine for most major browsers.
+## Testing on older browsers
+By default, our configuration does not do any modifications to your code. It just runs it as is in the browser. Depending on which features you use, this should be fine for most major browsers.
 
-By passing the `compatibility` flag, we enable compatibility mode which makes your code run on older browsers as well. It loads polyfills and transform modern syntax where needed. There are a few possible modes, but generally 'all' is sufficient for testing. This mode is powered by `karma-esm`. [Check out the documentaton](https://open-wc.org/testing/karma-esm.html) for more information.
+By passing the `compatibility` flag, we enable compatibility mode which makes your code run on older browsers as well. It loads polyfills and transforms modern syntax where needed. There are a few possible modes, but generally 'all' is sufficient for testing. This mode is powered by `karma-esm`. [Check out the documentaton](https://open-wc.org/testing/karma-esm.html) for more information.
 
-### Extending the config
+
+## Why don't you recommend testing tool X?
+Sometimes people ask why we recommend Karma and not other popular testing tools. We're always on the lookout for improving our recommendations, so if you think we can do better please let us know. What's important for us is that the testing tool is robust, simple to use, does not require any building and runs in a real browser.
+
+Testing tools that don't use a real browser but something like jsdom constantly need to keep up with the latest browser standards, so you need to wait for your testing tool to update before you can use a new feature. It doesn't give the same confidence as testing in a real browser, and with Headless Chrome and Puppeteer it hardly seems necessary anymore.
+
+## Extending the config
 
 To extend the karma config, we recommend using `deepmerge`. This will do smart merging of complex objects. You can extend any of the configuration. For example to set your own test coverage threshold:
 
@@ -141,16 +143,16 @@ module.exports = config => {
 };
 ```
 
-### Custom babel plugins or typescipt support
+### Custom babel plugins or typescript support
 `karma-esm` supports custom babel configurations and typescript. [Check out the documentaton](https://open-wc.org/testing/karma-esm.html) for more information.
 
 ### Testing in a monorepository
-When testing without a bundler you will be serving every imported module straight from the file system. Karma cannot serve files outside the path of the web server, which by default starts from the directory of your karma config.
+When testing without a bundler you will be serving every imported module straight from the file system. Karma cannot serve files outside the path of the webserver, which by default starts from the directory of your karma config.
 
 In a monorepo dependencies are often two levels higher in the root of the repository. To run tests in a monorepository you either have to put your config in the root of the repository, or adjust the basePath in your karma config:
 
 ### Other configuration
-`karma-esm` is the plugin powering our configuration, and it supports a few more for advanced usage. [Check out the documentaton](https://open-wc.org/testing/karma-esm.html) for more information.
+`karma-esm` is the plugin powering our configuration, and it supports a few more for advanced use cases. [Check out the documentaton](https://open-wc.org/testing/karma-esm.html) for more information.
 
 ```js
 const { createDefaultConfig } = require('@open-wc/testing-karma');

--- a/packages/testing-wallaby/README.md
+++ b/packages/testing-wallaby/README.md
@@ -9,12 +9,12 @@ Using:
 
 ## Setup
 ```bash
-npm init @open-wc testing-wallaby
+npm init @open-wc
 ```
 
 ### Manual
 1. Copy the [config](https://github.com/open-wc/open-wc/blob/master/packages/create/src/generators/testing-wallaby/templates/static/wallaby.js) and save it as `wallaby.js` into your project root
-1. `yarn add @open-wc/testing-wallaby --dev`
+2. `npm i -D @open-wc/testing-wallaby`
 
 ## Usage
 Open your wallaby.js supported IDE and start with the provided config.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,150 +2,50 @@
 
 [//]: # (AUTO INSERT HEADER PREPUBLISH)
 
-We believe that testing is fundamental to every production-ready product.
+An opinionated package that combines and configures testing libraries to minimize the amount of ceremony required when writing tests.
 
-We recommend using [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development)(Behavior Driven Development) as it seem to be easier when talking to non tech collegues. However note that this can still be a personal preference - we give this recommendation to promote unity within everyone using this recommendation.
+## Testing helpers
+Exposes all functions of [@open-wc/testing-helpers](https://open-wc.org/testing/testing-helpers.html), so that you have a single package to import from:
 
-Using:
-- System via [mocha](https://mochajs.org/)
-- Assertions via [chai](https://www.chaijs.com/)
-  - Plugin [semantic-dom-diff](https://www.npmjs.com/package/@open-wc/semantic-dom-diff)
-- Mocks via [sinon](https://sinonjs.org/)
+```javascript
+import { html } from 'lit-html';
+import { fixture } from '@open-wc/testing';
 
-## Setup
-```bash
-npm init @open-wc
-# Upgrade > Testing
-```
-
-### Manual
-```bash
-yarn add @open-wc/testing --dev
-```
-
-Add to your test:
-```js
-import { expect } from '@open-wc/testing';
-```
-
-This will have the following side effects:
-  - Use [semantic-dom-diff](https://www.npmjs.com/package/@open-wc/semantic-dom-diff) as a Chai plugin
-  - Enables cleanup after each test for all `fixture`s
-
-## Automating Tests
-Ideally, you'll want some way of automatically running all of your tests. To do that, we recommend karma via `@open-wc/testing-karma` and browserstack via `@open-wc/testing-karma-bs`.
-If you use a different test runner or a different browser grid you may skip these steps.
-
-::: tip Note
-Already part of `npm init @open-wc testing`
-::::
-
-### Manual Install
-Read more at [testing-karma](https://open-wc.org/testing/testing-karma.html)
-
-## Automating Tests via Browserstack
-To make sure your project is production ready, we recommend running tests in all the browsers you want to support.
-If you do not have access to all browsers, we recommend using a service like [Browserstack](https://www.browserstack.com/) to make sure your project works as intended.
-
-The following step connects the automatic karma runner with browserstack.
-
-::: tip Note
-Already part of `npm init @open-wc testing`
-::::
-
-### Manual Install
-Read more at [testing-karma-bs](https://open-wc.org/testing/testing-karma-bs.html)
-
-## Example Tests
-
-A typical Web Component test will look something like this:
-
-```js
-/* eslint-disable no-unused-expressions */
-import {
-  html,
-  fixture,
-  expect,
-} from '@open-wc/testing';
-
-import '../src/get-result.js';
-
-describe('True Checking', () => {
-  it('is false by default', async () => {
-    const el = await fixture('<get-result></get-result>');
-    expect(el.success).to.be.false;
-  });
-
-  it('false values will have a light-dom of <p>NOPE</p>', async () => {
-    const el = await fixture('<get-result></get-result>');
-    expect(el).dom.to.equal('<get-result><p>NOPE</p></get-result>');
-  });
-
-  it('true values will have a light-dom of <p>YEAH</p>', async () => {
-    const foo = 1;
-    const el = await fixture(html`<get-result .success=${foo === 1}></get-result>`);
-    expect(el.success).to.be.true;
-    expect(el).dom.to.equal('<get-result><p>YEAH</p></get-result>');
+describe('my-test', () => {
+  it('works', async () => {
+    const element = await fixture(html`<my-element></my-element>`);
   });
 });
 ```
 
-If you run your tests automatically with `npm run test`, the output should look like this:
+## Chai
+Exposes chai as an es module with useful plugins pre-configured:
 
-```
-> karma start demo/karma.conf.js
-START:
-Webpack bundling...
-Hash: 268cd16a4849f1191bd5
-Version: webpack 4.26.1
-Time: 1590ms
-Built at: 12/18/2018 2:01:09 PM
-             Asset       Size           Chunks             Chunk Names
-        commons.js   1.93 MiB          commons  [emitted]  commons
-get-result.test.js  337 bytes  get-result.test  [emitted]  get-result.test
-        runtime.js   14.2 KiB          runtime  [emitted]  runtime
-Entrypoint get-result.test = runtime.js commons.js get-result.test.js
-18 12 2018 14:01:10.156:INFO [karma-server]: Karma v3.1.3 server started at http://0.0.0.0:9876/
-18 12 2018 14:01:10.160:INFO [launcher]: Launching browsers ChromeHeadlessNoSandbox with concurrency unlimited
-18 12 2018 14:01:10.166:INFO [launcher]: Starting browser ChromeHeadless
-18 12 2018 14:01:10.833:INFO [HeadlessChrome 70.0.3538 (Windows 10.0.0)]: Connected on socket 6PnebgDwW91bPrHzAAAA with id 55371387
-  True Checking
-    ✔ is false by default
-    ✔ false values will have a light-dom of <p>NOPE</p>
-    ✔ true values will have a light-dom of <p>YEAH</p>
-Finished in 0.12 secs / 0.029 secs @ 14:01:11 GMT+0100 (GMT+01:00)
-SUMMARY:
-✔ 3 tests completed
-TOTAL: 3 SUCCESS
-=============================== Coverage summary ===============================
-Statements   : 100% ( 8/8 )
-Branches     : 100% ( 2/2 )
-Functions    : 100% ( 3/3 )
-Lines        : 100% ( 8/8 )
-================================================================================
+[@open-wc/semantic-dom-diff](https://www.npmjs.com/package/@open-wc/semantic-dom-diff) for snapshot testing:
+
+```javascript
+import { html } from 'lit-html';
+import { expect, fixture } from '@open-wc/testing';
+
+describe('my-test', () => {
+  it('works', async () => {
+    const element = await fixture(html`<my-element></my-element>`);
+    expect(element).shadowDom.to.equalSnapshot();
+  });
+});
 ```
 
-::: tip Note
-Make sure you have Chrome (or Chromium) installed.
-Additionally you may need to set your CHROME_BIN env variable `export CHROME_BIN=/usr/bin/chromium-browser`.
-::::
+[@open-wc/chai-a11y-axe](https://www.npmjs.com/package/@open-wc/semantic-dom-diff) for a11y testing:
 
-## Fixture Cleanup
-By default, if you import anything via `import { ... } from '@open-wc/testing-helpers';`, it will automatically register a side-effect that cleans up your fixtures.
-If you want to be in full control you can do so by using
-```js
-import { fixture, fixtureCleanup } from '@open-wc/testing/index-no-side-effects.js';
+```javascript
+import { html } from 'lit-html';
+import { expect, fixture } from '@open-wc/testing';
 
-it('can instantiate an element with properties', async () => {
-  const el = await fixture(html`<my-el .foo=${'bar'}></my-el>`);
-  expect(el.foo).to.equal('bar');
-  fixtureCleanup();
-}
-
-// Alternatively, you can add the fixtureCleanup in the afterEach function.
-// Note that this is exactly what the automatically registered side-effect does.
-afterEach(() => {
-  fixtureCleanup();
+describe('my-test', () => {
+  it('works', async () => {
+    const element = await fixture(html`<my-element></my-element>`);
+    expect(element).to.be.accessible();
+  });
 });
 ```
 


### PR DESCRIPTION
Our testing docs had some outdated information, duplicate documentation and overall there wasn't a clear flow. I tried to improve this, while also keeping the readmes sensible for standalone reading outside our website.

- Created a new top-level testing page that acts as a table of content, delegating most of the information to the separate packages instead of repeating the same.
- Link to testing article from @daKmoR for a step by step guide.
- Made the `@open-wc/testing` readme specific to that library only, and no longer our general testing starting place. Moved specific information like browserstack testing to their relevant packages.
- Explained the relationship between `@open-wc/testing` and `@open-wc/testing-helper`
- Created a brief sinon explainer because their website doesn't explain how to install and use it as a module.
- Ran all docs through grammarly
- Made code snippets consistent

