### PR TITLE
fix(es-dev-server): import URLSearchParams for node v8

### DIFF
--- a/packages/es-dev-server/src/middleware/transform-index-html.js
+++ b/packages/es-dev-server/src/middleware/transform-index-html.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import { URLSearchParams } from 'url';
 import { getTransformedIndexHTML } from '../utils/transform-index-html.js';
 import { isIndexHTMLResponse, getBodyAsString, toBrowserPath } from '../utils/utils.js';
 


### PR DESCRIPTION
`URLSearchParams` is a global variable in node v10, but not in node v8. Importing it makes it work in both.