### PR TITLE
fix(create): add eslint dependency in create

### DIFF
--- a/packages/create/src/generators/linting-eslint/templates/_package.json
+++ b/packages/create/src/generators/linting-eslint/templates/_package.json
@@ -4,6 +4,7 @@
     "format:eslint": "eslint --ext .js,.html . --fix --ignore-path .gitignore"
   },
   "devDependencies": {
+    "eslint": "^6.1.0",
     "@open-wc/eslint-config": "^1.0.0"
   },
   "eslintConfig": {


### PR DESCRIPTION
In node a project should depend on anything it imports/uses directlry.