### PR TITLE
fix(karma-esm): log errors starting up es-dev-server

### DIFF
--- a/packages/karma-esm/src/esm-middleware.js
+++ b/packages/karma-esm/src/esm-middleware.js
@@ -65,10 +65,12 @@ function esmMiddlewareFactory(config, karmaEmitter) {
       watch,
       babelConfig,
       karmaEmitter,
-    ).then(port => {
-      devServerPort = port;
-      setupServerPromise = null;
-    });
+    )
+      .then(port => {
+        devServerPort = port;
+        setupServerPromise = null;
+      })
+      .catch(console.error);
 
     /**
      * @type {import('connect').NextHandleFunction}


### PR DESCRIPTION
We were missing a catch handler when starting up es dev server. This causes errors to not get logged, which was very confusing.