### PR TITLE
fix(eslint-config): set arrow-parens rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   plugins: ['html'],
   rules: {
+    'arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
     'no-underscore-dangle': 'off',
     'import/extensions': ['error', 'always', { ignorePackages: true }],
     'import/prefer-default-export': 'off',


### PR DESCRIPTION
After a dependency update it is now required to use parameter parentheses in arrow functions. This rule only requires parentheses when needed (except forcing it for blocks).