### PR TITLE
fix(semantic-dom-diff): fix snapshot error messages

### DIFF
--- a/__snapshots__/component-a.md
+++ b/__snapshots__/component-a.md
@@ -1,5 +1,22 @@
 # `component-a`
 
+## `failed snapshots`
+
+####   `throws an error when a snapshot does not match`
+
+```html
+<div>
+  0.6523866720855873
+</div>
+```
+
+```html
+<div>
+  0.1401241753470146
+</div>
+
+```
+
 ## `success states`
 
 ####   `matches a string snapshot`
@@ -42,7 +59,6 @@
 <div>
   C
 </div>
-
 ```
 
 ## `error states`
@@ -59,7 +75,6 @@
 <span>
   A
 </span>
-
 ```
 
 ####   `matches shadow dom snapshot`
@@ -74,6 +89,5 @@
 <span>
   B
 </span>
-
 ```
 

--- a/packages/semantic-dom-diff/chai-dom-diff.js
+++ b/packages/semantic-dom-diff/chai-dom-diff.js
@@ -122,27 +122,34 @@ export const chaiDomDiff = (chai, utils) => {
     } else {
       html = el;
     }
-    return assertHtmlEqualsSnapshot(html, options);
+    return assertHtmlEqualsSnapshot.call(this, html, options);
   }
 
   utils.addMethod(chai.Assertion.prototype, 'equalSnapshot', equalSnapshot);
 
   utils.addMethod(chai.assert, 'equalSnapshot', assertHtmlEqualsSnapshot);
   chai.assert.dom = {
-    equal: (actualEl, expectedHTML, options) =>
-      assertHtmlEquals(getDomHtml(actualEl), expectedHTML, options),
-    equalSnapshot: (actualEl, options) => assertHtmlEqualsSnapshot(actualEl, options),
+    equal(actualEl, expectedHTML, options) {
+      return assertHtmlEquals.call(this, getDomHtml(actualEl), expectedHTML, options);
+    },
+    equalSnapshot(actualEl, options) {
+      return assertHtmlEqualsSnapshot.call(this, actualEl, options);
+    },
   };
   chai.assert.lightDom = {
-    equal: (actualEl, expectedHTML, options) =>
-      assertHtmlEquals(getLightDomHtml(actualEl), expectedHTML, options),
-    equalSnapshot: (actualEl, options) =>
-      assertHtmlEqualsSnapshot(getLightDomHtml(actualEl), options),
+    equal(actualEl, expectedHTML, options) {
+      return assertHtmlEquals.call(this, getLightDomHtml(actualEl), expectedHTML, options);
+    },
+    equalSnapshot(actualEl, options) {
+      return assertHtmlEqualsSnapshot.call(this, getLightDomHtml(actualEl), options);
+    },
   };
   chai.assert.shadowDom = {
-    equal: (actualEl, expectedHTML, options) =>
-      assertHtmlEquals(getShadowDomHtml(actualEl), expectedHTML, options),
-    equalSnapshot: (actualEl, options) =>
-      assertHtmlEqualsSnapshot(getShadowDomHtml(actualEl), options),
+    equal(actualEl, expectedHTML, options) {
+      return assertHtmlEquals.call(this, getShadowDomHtml(actualEl), expectedHTML, options);
+    },
+    equalSnapshot(actualEl, options) {
+      return assertHtmlEqualsSnapshot.call(this, getShadowDomHtml(actualEl), options);
+    },
   };
 };

--- a/packages/semantic-dom-diff/test/chai-dom-equals-snapshots.test.js
+++ b/packages/semantic-dom-diff/test/chai-dom-equals-snapshots.test.js
@@ -54,6 +54,35 @@ describe('component-a', () => {
       myElement.parentElement.removeChild(myElement);
     });
   });
+
+  describe('failed snapshots', () => {
+    it('throws an error when a snapshot does not match', () => {
+      const myElement = document.createElement('div');
+      myElement.textContent = `${Math.random()}`;
+      document.body.appendChild(myElement);
+
+      let thrownForExpect = false;
+      let thrownForAssert = false;
+      try {
+        expect(myElement).dom.to.equalSnapshot();
+      } catch (error) {
+        thrownForExpect = true;
+        expect(error.actual.startsWith('<div>')).to.be.true;
+        expect(error.expected.startsWith('<div>')).to.be.true;
+      }
+
+      try {
+        assert.dom.equalSnapshot(myElement);
+      } catch (error) {
+        thrownForAssert = true;
+        expect(error.actual.startsWith('<div>')).to.be.true;
+        expect(error.expected.startsWith('<div>')).to.be.true;
+      }
+
+      expect(thrownForExpect).to.be.true;
+      expect(thrownForAssert).to.be.true;
+    });
+  });
 });
 
 describe('component-b', () => {


### PR DESCRIPTION
Chai requires leaking `this` across functions. It's a lot of fun!