### PR TITLE
Fix: change installation logs prefix to package manager name

### DIFF
--- a/packages/create/src/core.js
+++ b/packages/create/src/core.js
@@ -403,7 +403,7 @@ function _install(command = 'npm', options) {
     });
 
     install.stderr.on('data', data => {
-      console.log(`Error: ${data}`);
+      console.log(`${command}: ${data}`);
     });
 
     install.on('close', () => {


### PR DESCRIPTION
Prefix the console log message with the package manager name/command `npm: ` or `yarn: ` instead of `Error: ` because not all `stderr`'s are actually errors, and if they are, the `data` already has "ERROR" at the start.

Old
```
Error: notice <description>
Error: WARN <description>
Error: ERROR <description>
```
New:
```
npm: notice <description>
npm: WARN <description>
npm: ERROR <description>
```

"Fix" because users actually perceive this as a "real" error when sometimes it's just an npm warning or even an npm notice. Similar for yarn