### PR TITLE
docs(testing): update README adding karma webpack doc

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -79,6 +79,21 @@ describe('Plugin: chai-dom', () => {
 });
 ```
 
+> **__NOTE:__** if you are using `karma-webpack` you have to add `chai/chai.js` to your files in the `karma.conf.js`
+
+```javascript
+files: [
+  { pattern: require.resolve('chai/chai.js' }, 
+  // other files
+]
+```
+
+> and replacing in your test files where you `import { chai } from '@open-wc/testing` by referencing chai on window (if it applies).
+
+```javascript
+window.chai.use(sinonChai);
+```
+
 <script>
   export default {
     mounted() {

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -88,7 +88,7 @@ files: [
 ]
 ```
 
-> and replacing in your test files where you `import { chai } from '@open-wc/testing` by referencing chai on window (if it applies).
+> If your test files use `import { chai } from '@open-wc/testing`, replace those imports with referencing chai on window.
 
 ```javascript
 window.chai.use(sinonChai);


### PR DESCRIPTION
Update README to add karma webpack documentation as it occurs an error if you do not include chai in `karma.conf.js`

Closes #750 