### PR TITLE
chore(prettier-config): refer to lit-element css literal

### DIFF
--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -45,7 +45,7 @@ npm init @open-wc
 
 - Apply formatting to JS files
 - Apply formatting to HTML inside of `html` tagged template literals used by [lit-html](https://github.com/Polymer/lit-html)
-- Apply formatting to CSS inside of `css` tagged template literals used by [lit-css](https://github.com/lit-styles/lit-styles/tree/master/packages/lit-css)
+- Apply formatting to CSS inside of `css` tagged template literals used by [lit-element](https://lit-element.polymer-project.org/guide/styles#static-styles)
 - Integration with ESLint to prevent potentially conflicting rules
 
 ## Usage


### PR DESCRIPTION
It looks like `lit-styles` is not actively developed and the docs haven't been updated to point to the `css` tag which is used by `lit-element`. Let's consider updating a link in README.