### PR TITLE
fix(es-dev-server): correctly close previous message channel

### DIFF
--- a/packages/es-dev-server/src/utils/message-channel.js
+++ b/packages/es-dev-server/src/utils/message-channel.js
@@ -33,20 +33,17 @@ export function setupMessageChannel(ctx) {
 
     activeSocket = null;
     activeStream = null;
-    return;
   }
 
-  activeSocket = ctx.socket;
-  activeStream = new SSEStream();
+  const stream = new SSEStream();
+  activeStream = stream;
+  activeSocket = ctx.req.socket;
 
   function close() {
-    activeSocket.removeListener('error', close);
-    activeSocket.removeListener('close', close);
-    activeStream.end();
-    activeSocket.end();
-
-    activeSocket = null;
-    activeStream = null;
+    ctx.req.socket.removeListener('error', close);
+    ctx.req.socket.removeListener('close', close);
+    stream.end();
+    ctx.req.socket.end();
   }
 
   ctx.req.socket.setTimeout(0);


### PR DESCRIPTION
The logic around closing the previous and opening a new message channel (used for logging error messages + reloading the browser) wasn't correct. You can reproduce this by opening multiple tabs, it should close the channel on the old tabs and open it on the new tab.