### PR TITLE
feat(es-dev-server): don't add custom plugins in legacy compile

### DIFF
--- a/packages/es-dev-server/src/middleware/compile-middleware.js
+++ b/packages/es-dev-server/src/middleware/compile-middleware.js
@@ -50,7 +50,7 @@ function createBabelCompilers(cfg) {
     ? createBabelCompiler({ ...cfg, modern: compileModern, legacy: false })
     : null;
   const legacy = compileLegacy
-    ? createBabelCompiler({ ...cfg, modern: false, legacy: true })
+    ? createBabelCompiler({ readUserBabelConfig: false, modern: false, legacy: true })
     : null;
 
   return { defaultCompiler, legacy };


### PR DESCRIPTION
In legacy mode we run babel twice in order to resolve modules on the es module source code. In this legacy run we don't need to add in any custom plugins again, so we can skip for a small saving.