### PR TITLE
docs: add codelab scaffolding

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -14,6 +14,7 @@ const sidebar = [
       '/developing/best-practices',
       '/developing/es-dev-server',
       ['/init/', 'Generators'],
+      '/developing/codelab',
       '/developing/types',
       '/developing/routing',
     ],
@@ -99,6 +100,25 @@ module.exports = {
             'unit-testing-custom-events',
             'unit-testing-init-error',
           ],
+        },
+      ],
+      '/codelab/': [
+        ['', 'Codelab'],
+        ['/codelab/getting-started', 'Getting started'],
+        {
+          title: 'lit-html',
+          collapsable: true,
+          children: ['template-literals', 'tagged-template-literals', 'lit-html'],
+        },
+        {
+          title: 'lit-element',
+          collapsable: true,
+          children: ['webcomponents', 'lifecycle', 'properties'],
+        },
+        {
+          title: 'Making a news app',
+          collapsable: true,
+          children: ['news-api', 'assignment-1', 'assignment-2'],
         },
       ],
       '/about/': [['/about/', 'About'], '/about/contact', '/about/rationales', '/about/blog'],

--- a/docs/codelab/README.md
+++ b/docs/codelab/README.md
@@ -1,0 +1,5 @@
+# Codelab
+
+Hello this is a codelab
+
+[Original repo](https://github.com/LarsDenBakker/lit-html-workshop)

--- a/docs/codelab/assignment-1.md
+++ b/docs/codelab/assignment-1.md
@@ -4,4 +4,4 @@ Do another thing
 
 ## Stuck?
 
-[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/1-hello-world.html) or take a look at our [code samples]('/developing/code-examples')
+[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/1-hello-world.html) or take a look at our [code samples](/developing/code-examples)

--- a/docs/codelab/assignment-1.md
+++ b/docs/codelab/assignment-1.md
@@ -1,0 +1,7 @@
+# Assignment 1
+
+Do another thing
+
+## Stuck?
+
+[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/1-hello-world.html)

--- a/docs/codelab/assignment-1.md
+++ b/docs/codelab/assignment-1.md
@@ -4,4 +4,4 @@ Do another thing
 
 ## Stuck?
 
-[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/1-hello-world.html)
+[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/1-hello-world.html) or take a look at our [code samples]('/developing/code-examples')

--- a/docs/codelab/assignment-2.md
+++ b/docs/codelab/assignment-2.md
@@ -4,4 +4,4 @@ Do a thing
 
 ## Stuck?
 
-[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/2-fetch-first-article.html)
+[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/2-fetch-first-article.html) or take a look at our [code samples]('/developing/code-examples')

--- a/docs/codelab/assignment-2.md
+++ b/docs/codelab/assignment-2.md
@@ -4,4 +4,4 @@ Do a thing
 
 ## Stuck?
 
-[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/2-fetch-first-article.html) or take a look at our [code samples]('/developing/code-examples')
+[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/2-fetch-first-article.html) or take a look at our [code samples](/developing/code-examples)

--- a/docs/codelab/assignment-2.md
+++ b/docs/codelab/assignment-2.md
@@ -1,0 +1,7 @@
+# Assignment 2
+
+Do a thing
+
+## Stuck?
+
+[Find the solution here](https://github.com/LarsDenBakker/lit-html-workshop/blob/master/2-lit-element/solutions/2-fetch-first-article.html)

--- a/docs/codelab/getting-started.md
+++ b/docs/codelab/getting-started.md
@@ -1,0 +1,7 @@
+# Getting Started
+
+Make a index.html add script tag etc etc
+
+`https://unpkg.com/lit-html@1.1.2/lit-html.js?module`
+
+`https://unpkg.com/lit-element?module`

--- a/docs/codelab/lifecycle.md
+++ b/docs/codelab/lifecycle.md
@@ -1,0 +1,3 @@
+# Lifecycle
+
+LitElement has a lifecycle

--- a/docs/codelab/lit-html.md
+++ b/docs/codelab/lit-html.md
@@ -1,0 +1,63 @@
+# Lit-html
+
+## Declarative
+
+```js
+function myTemplate(message, selected) {
+    return html`
+        <p class="${selected ? 'selected' : 'not-selected'}">
+            Hello ${message}
+        </p>
+
+        <button @click=${() => console.log('Updated!')}>
+            Update
+        </button>
+    `;
+}
+```
+
+## Composable
+
+```js
+import { footerTemplate } from './footer.js';
+
+function bodyTemplate(message) {
+    return html`
+        <p>Hello ${message}</p>
+    `;
+}
+
+const headerTemplate = html`
+    <h1>Composed template</h1>
+`;
+
+const composedTemplate = html`
+    ${headerTemplate}
+    ${bodyTemplate('World')}
+    ${footerTemplate}
+`;
+```
+
+## Syntax sugar
+
+Syntax sugar for calling a function
+
+```js
+const href = '/foo/bar';
+const message = 'world';
+
+const template = html`
+    <a href="${href}">
+        Hello ${message}
+    </a>
+`;
+```
+
+Is the same as:
+
+```js
+const href = '/foo/bar';
+const message = 'world';
+
+html(['<a href="', '">Hello ', "</a>"], href, message);
+```

--- a/docs/codelab/news-api.md
+++ b/docs/codelab/news-api.md
@@ -1,0 +1,3 @@
+# News Api
+
+get api key etc

--- a/docs/codelab/properties.md
+++ b/docs/codelab/properties.md
@@ -1,0 +1,3 @@
+# Properties
+
+LitElement has properties

--- a/docs/codelab/tagged-template-literals.md
+++ b/docs/codelab/tagged-template-literals.md
@@ -1,0 +1,16 @@
+# Tagged template literals
+
+Tagged template literals are blabla
+
+```js
+function html(staticValues, ...dynamicValues) {
+    console.log(staticValues);
+    console.log(dynamicValues);
+}
+
+const planet = 'earth';
+
+const template = html`Hello ${planet}!`; 
+// ["Hello ", "!"] <-- static values
+// ["earth] <-- dynamic values
+```

--- a/docs/codelab/template-literals.md
+++ b/docs/codelab/template-literals.md
@@ -1,0 +1,9 @@
+# Template literals
+
+Template literals are blabla
+
+```js
+const planet = 'earth';
+
+const template = `Hello ${planet}!`; // Hello earth
+```

--- a/docs/codelab/webcomponents.md
+++ b/docs/codelab/webcomponents.md
@@ -1,0 +1,3 @@
+# Web Components
+
+Some basic intro to web components

--- a/docs/developing/codelab.md
+++ b/docs/developing/codelab.md
@@ -1,0 +1,3 @@
+# Codelab
+
+We have a [codelab](/codelab/)


### PR DESCRIPTION
[Preview here](https://5d855e556d72140009f47032--open-wc-org.netlify.com/codelab/)

<a href="https://5d855e556d72140009f47032--open-wc-org.netlify.com/codelab/">
<img width="937" alt="Screenshot 2019-09-20 at 19 39 35" src="https://user-images.githubusercontent.com/17054057/65347054-6b3ea100-dbde-11e9-9b80-0516d0480c38.png"></a>


Lars and I talked about adding a codelab version of the [lit-html workshop](https://github.com/LarsDenBakker/lit-html-workshop) that we did in ING.

I thought I'd make some scaffolding so we can actually kick this off

## Adding sidebar menu items

<img width="207" alt="Screenshot 2019-09-20 at 19 32 55" src="https://user-images.githubusercontent.com/17054057/65346654-7b09b580-dbdd-11e9-9457-6e8e35c80d80.png">

In order to add a collapsible sidebar menu item, add another object to the [`'/codelab/'`](https://github.com/open-wc/open-wc/pull/811/files#diff-d669c10d59b56bb12a815dd48ce8d884R105) array in `/docs/.vuepress/config.js`.

```
       {
          title: 'lit-html',
          collapsable: true,
          children: ['template-literals', 'tagged-template-literals', 'lit-html'],
        },
```

For every 'child' of this menu, create a markdown file in `/docs/codelab/`, eg: `/docs/codelab/lit-html.md`.

<hr>
Obviously very WIP, but now we have something we can talk about/collaborate on 🙂 