### PR TITLE
docs: Add Simplr Router to recommended routers

### DIFF
--- a/docs/developing/routing.md
+++ b/docs/developing/routing.md
@@ -10,5 +10,5 @@ In alphabetical order:
 - [lit-router](https://github.com/danevans/lit-router)
 - [pwa-helpers router](https://github.com/Polymer/pwa-helpers#routerjs)
 - [redux first routing](https://github.com/mksarge/redux-first-routing)
-- [vaadin-router](https://github.com/vaadin/vaadin-router)
 - [simplr-router](https://github.com/Matsuuu/simplr-router)  
+- [vaadin-router](https://github.com/vaadin/vaadin-router)

--- a/docs/developing/routing.md
+++ b/docs/developing/routing.md
@@ -11,4 +11,4 @@ In alphabetical order:
 - [pwa-helpers router](https://github.com/Polymer/pwa-helpers#routerjs)
 - [redux first routing](https://github.com/mksarge/redux-first-routing)
 - [vaadin-router](https://github.com/vaadin/vaadin-router)
-  
+- [simplr-router](https://github.com/Matsuuu/simplr-router)  


### PR DESCRIPTION
I have a created a light router for SPA -type applications built with Web Components. 

I would be honored if I could get it added to the list of routers for web component development. 