### PR TITLE
fix(es-dev-server): don't send messages to a closed event stream

### DIFF
--- a/packages/es-dev-server/src/utils/message-channel.js
+++ b/packages/es-dev-server/src/utils/message-channel.js
@@ -44,6 +44,7 @@ export function setupMessageChannel(ctx) {
     ctx.req.socket.removeListener('close', close);
     stream.end();
     ctx.req.socket.end();
+    activeStream = null;
   }
 
   ctx.req.socket.setTimeout(0);


### PR DESCRIPTION
This fixes errors sometimes popping up in the console if you edit files after closing the browser in watch mode.