### PR TITLE
fix(create): use standard webpack mode notation

### DIFF
--- a/packages/create/src/generators/building-webpack/templates/_package.json
+++ b/packages/create/src/generators/building-webpack/templates/_package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start:build": "cd dist && es-dev-server --open",
-    "build": "webpack --mode production"
+    "build": "webpack --mode=production"
   },
   "devDependencies": {
     "@open-wc/building-webpack": "^2.1.0",


### PR DESCRIPTION
Hello,

I think I fixed all wrong mode notations on create (#706). I made a search in the create folder on "mode" and "webpack".

Please tell me if I need to do something else !

Thanks