### PR TITLE
chore(testing-karma): remove unused dependencies

### DIFF
--- a/packages/testing-karma/package.json
+++ b/packages/testing-karma/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@open-wc/karma-esm": "^2.7.2",
     "axe-core": "^3.3.1",
-    "istanbul-instrumenter-loader": "^3.0.0",
     "karma": "^4.0.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage-istanbul-reporter": "^2.0.0",
@@ -39,7 +38,6 @@
     "karma-mocha-snapshot": "^0.2.1",
     "karma-snapshot": "^0.6.0",
     "karma-source-map-support": "^1.3.0",
-    "karma-sourcemap-loader": "^0.3.0",
     "mocha": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Looks like these 2 dependencies are leftovers from using `karma-webpack`

- `istanbul-instrumenter-loader` was used through webpack config,

- `karma-sourcemap-loader` was used through `preprocessors`.

Now when`karma-esm` is used, those packages can be removed.