### PR TITLE
chore(demoing-storybook): export withA11y decorator

### DIFF
--- a/packages/demoing-storybook/index.js
+++ b/packages/demoing-storybook/index.js
@@ -1,7 +1,8 @@
 export { html } from 'lit-html';
 
-export { storiesOf, addParameters } from '@storybook/polymer';
+export { storiesOf, addParameters, addDecorator } from '@storybook/polymer';
 export { action } from '@storybook/addon-actions';
+export { withA11y } from '@storybook/addon-a11y';
 export { linkTo } from '@storybook/addon-links';
 export { withNotes } from '@storybook/addon-notes';
 export { document } from 'global';


### PR DESCRIPTION
Ehh yeah so I noticed this was not exported, even though it's already in the dependencies of demoing-storybook. I prefer exporting from one source (@open-wc/demoing-storybook) so would be awesome if you guys can export it so I can import from you guys :)!

Note: Registering the addon is already included in create -> generators -> demoing-storybook -> .storybook/addons.js so that's good ^^

Note 2: Was there a reason that addDecorator wasn't exported? I added it