### PR TITLE
Generate the SW once with the createCompatibilityConfig

### DIFF
--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -119,7 +119,8 @@ function createConfig(_options, legacy) {
       entrypointHashmanifest(),
 
       production &&
-        options.plugins.workbox && !legacy &&
+        options.plugins.workbox && 
+        !legacy &&
         workbox({
           mode: 'generateSW',
           workboxConfig: {

--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -119,7 +119,7 @@ function createConfig(_options, legacy) {
       entrypointHashmanifest(),
 
       production &&
-        options.plugins.workbox && 
+        options.plugins.workbox &&
         !legacy &&
         workbox({
           mode: 'generateSW',

--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -119,7 +119,7 @@ function createConfig(_options, legacy) {
       entrypointHashmanifest(),
 
       production &&
-        options.plugins.workbox &&
+        options.plugins.workbox && !legacy &&
         workbox({
           mode: 'generateSW',
           workboxConfig: {


### PR DESCRIPTION
Fix #874

I use `!legacy` to just create the SW in the second config, when the legacy files are already created.