### PR TITLE
Fixed the typo changed 'id' to 'Id'

### DIFF
--- a/docs/testing/testing-sinon.md
+++ b/docs/testing/testing-sinon.md
@@ -24,7 +24,7 @@ describe('my component', () => {
     const myFunctionStub = stub(el, 'myFunction');
 
     // click a button
-    el.shadowRoot.getElementByid('myButton').click();
+    el.shadowRoot.getElementById('myButton').click();
 
     // check if the function was called
     expect(myFunctionStub).to.have.callCount(1);


### PR DESCRIPTION
replaced el.shadowRoot.getElementByid with el.shadowRoot.getElementById