### PR TITLE
feat(semantic-dom-diff): strip attributes that contains only whitespace

### DIFF
--- a/packages/semantic-dom-diff/get-diffable-html.js
+++ b/packages/semantic-dom-diff/get-diffable-html.js
@@ -119,7 +119,7 @@ export function getDiffableHTML(html, options = {}) {
   }
 
   function shouldStripAttribute({ name, value }) {
-    return stripEmptyAttributes.includes(name) && value === '';
+    return stripEmptyAttributes.includes(name) && value.trim() === '';
   }
 
   /**

--- a/packages/semantic-dom-diff/test/get-diffable-html.test.js
+++ b/packages/semantic-dom-diff/test/get-diffable-html.test.js
@@ -328,6 +328,13 @@ describe('getDiffableHTML()', () => {
 `,
       );
     });
+
+    it('removes class attributes that contains only whitespaces', () => {
+      const html = getDiffableHTML(`
+        <div class="  "></div>
+        `);
+      expect(html).to.equal('<div>\n</div>\n');
+    });
   });
 
   describe('special elements', () => {


### PR DESCRIPTION
Its an improvement of (#556). It strips attribute that contains only whitespace as a value.