### PR TITLE
feat(testing-helpers): allow rendering non-TemplateResult

### DIFF
--- a/packages/testing-helpers/src/fixture-no-side-effect.js
+++ b/packages/testing-helpers/src/fixture-no-side-effect.js
@@ -1,6 +1,6 @@
-import { TemplateResult } from 'lit-html';
 import { stringFixture, stringFixtureSync } from './stringFixture.js';
 import { litFixture, litFixtureSync } from './litFixture.js';
+import { isValidRenderArg } from './lib.js';
 
 /**
  * Renders a string/TemplateResult and puts it in the DOM via a fixtureWrapper.
@@ -9,17 +9,19 @@ import { litFixture, litFixtureSync } from './litFixture.js';
  * const el = fixtureSync('<my-el><span></span></my-el>');
  *
  * @template {Element} T
- * @param {string | TemplateResult} template Either a string or lit-html TemplateResult
+ * @param {import('./litFixture').LitHTMLRenderable} template Either a string or lit-html TemplateResult
  * @returns {T} First child of the rendered DOM
  */
 export function fixtureSync(template) {
   if (typeof template === 'string') {
     return stringFixtureSync(template);
   }
-  if (template instanceof TemplateResult) {
+  if (isValidRenderArg(template)) {
     return litFixtureSync(template);
   }
-  throw new Error('Invalid template provided - string or lit-html TemplateResult is supported');
+  throw new Error(
+    'Invalid template provided - string, number, boolean, Node, TemplateResult, or array or iterable thereof are supported',
+  );
 }
 
 /**
@@ -39,14 +41,14 @@ export function fixtureSync(template) {
  * expect(el.fullyRendered).to.be.true;
  *
  * @template {Element} T
- * @param {string | TemplateResult} template Either a string or lit-html TemplateResult
+ * @param {import('./litFixture').LitHTMLRenderable} template Either a string or lit-html TemplateResult
  * @returns {Promise<T>} A Promise that will resolve to the first child of the rendered DOM
  */
 export async function fixture(template) {
   if (typeof template === 'string') {
     return stringFixture(template);
   }
-  if (template instanceof TemplateResult) {
+  if (isValidRenderArg(template)) {
     return litFixture(template);
   }
   throw new Error('Invalid template provided - string or lit-html TemplateResult is supported');

--- a/packages/testing-helpers/src/lib.js
+++ b/packages/testing-helpers/src/lib.js
@@ -1,0 +1,29 @@
+import { TemplateResult } from 'lit-html';
+
+export const isIterable = object => object != null && typeof object[Symbol.iterator] === 'function';
+
+function isValidNonIterableRenderArg(x) {
+  return (
+    x instanceof TemplateResult ||
+    x instanceof Node ||
+    typeof x === 'number' ||
+    typeof x === 'boolean' ||
+    typeof x === 'string'
+  );
+}
+
+export function isValidRenderArg(x) {
+  return isIterable(x) ? [...x].every(isValidNonIterableRenderArg) : isValidNonIterableRenderArg(x);
+}
+
+/**
+ * Node#nodeType enum
+ * @readonly
+ * @enum {number}
+ */
+export const NODE_TYPES = Object.freeze({
+  ELEMENT_NODE: 1,
+  TEXT_NODE: 3,
+  COMMENT_NODE: 8,
+  DOCUMENT_FRAGMENT_NODE: 11,
+});

--- a/packages/testing-helpers/src/litFixture.js
+++ b/packages/testing-helpers/src/litFixture.js
@@ -1,25 +1,53 @@
+import { TemplateResult } from 'lit-html';
 import { fixtureWrapper } from './fixtureWrapper.js';
 import { render } from './lit-html.js';
 import { elementUpdated } from './elementUpdated.js';
+import { NODE_TYPES } from './lib.js';
+
+/**
+ * @typedef {
+     import('lit-html').TemplateResult | import('lit-html').TemplateResult[]
+   | Node | Node[]
+   | string | string[]
+   | number | number[]
+   | boolean | boolean[]
+ } LitHTMLRenderable
+ */
+
+const isUsefulNode = ({ nodeType, textContent }) => {
+  switch (nodeType) {
+    case NODE_TYPES.COMMENT_NODE:
+      return false;
+    case NODE_TYPES.TEXT_NODE:
+      return textContent.trim();
+    default:
+      return true;
+  }
+};
 
 /**
  * Setups an element synchronously from the provided lit-html template and puts it in the DOM.
  *
  * @template {Element} T - Is an element or a node
- * @param {import('lit-html').TemplateResult} template
+ * @param {LitHTMLRenderable} template
  * @returns {T}
  */
 export function litFixtureSync(template) {
   const wrapper = fixtureWrapper();
   render(template, wrapper);
-  return /** @type {T} */ (wrapper.children[0]);
+  if (template instanceof TemplateResult) {
+    return /** @type {T} */ (wrapper.firstElementChild);
+  }
+  const [node] = Array.from(wrapper.childNodes).filter(isUsefulNode);
+
+  return /** @type {T} */ (node);
 }
 
 /**
  * Setups an element asynchronously from the provided lit-html template and puts it in the DOM.
  *
  * @template {Element} T - Is an element or a node
- * @param {import('lit-html').TemplateResult} template
+ * @param {LitHTMLRenderable} template
  * @returns {Promise<T>}
  */
 export async function litFixture(template) {

--- a/packages/testing-helpers/test/fixture.test.js
+++ b/packages/testing-helpers/test/fixture.test.js
@@ -6,6 +6,7 @@ import { cachedWrappers } from '../src/fixtureWrapper.js';
 import { defineCE } from '../src/helpers.js';
 import { fixture, fixtureSync } from '../src/fixture.js';
 import { html, unsafeStatic } from '../src/lit-html.js';
+import { NODE_TYPES } from '../src/lib.js';
 
 describe('fixtureSync & fixture', () => {
   it('supports strings', async () => {
@@ -42,6 +43,219 @@ describe('fixtureSync & fixture', () => {
     `);
     // @ts-ignore
     testElement(elementAsync);
+  });
+
+  it('supports lit-html TemplateResult with whitespace', async () => {
+    /**
+     * @param {Element} element
+     */
+    function testElement(element) {
+      expect(element.localName).to.equal('div');
+    }
+
+    const elementSync = fixtureSync(html`
+      <div></div>
+    `);
+    // @ts-ignore
+    testElement(elementSync);
+
+    const elementAsync = await fixture(html`
+      <div></div>
+    `);
+    // @ts-ignore
+    testElement(elementAsync);
+  });
+
+  describe('Node', () => {
+    it('supports Text Node', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('test');
+        expect(node.nodeType).to.equal(NODE_TYPES.TEXT_NODE);
+      }
+
+      const textNode = document.createTextNode('test');
+
+      const textNodeSync = fixtureSync(textNode);
+      doTest(textNodeSync);
+
+      const textNodeAsync = await fixture(textNode);
+      doTest(textNodeAsync);
+    });
+
+    it('supports Text Node Array', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('test');
+        expect(node.nodeType).to.equal(NODE_TYPES.TEXT_NODE);
+      }
+
+      const textNodeArray = [
+        document.createTextNode('test'),
+        document.createTextNode('silently ignored'),
+      ];
+
+      const textNodeSync = fixtureSync(textNodeArray);
+      doTest(textNodeSync);
+
+      const textNodeAsync = await fixture(textNodeArray);
+      doTest(textNodeAsync);
+    });
+
+    it('supports Element Node', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('test');
+        expect(node.nodeType).to.equal(NODE_TYPES.ELEMENT_NODE);
+      }
+
+      const elementNode = document.createElement('div');
+      elementNode.innerHTML = 'test';
+
+      const textNodeSync = fixtureSync(elementNode);
+      doTest(textNodeSync);
+
+      const textNodeAsync = await fixture(elementNode);
+      doTest(textNodeAsync);
+    });
+
+    it('supports Element Node Array', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('test');
+        expect(node.nodeType).to.equal(NODE_TYPES.ELEMENT_NODE);
+      }
+
+      const elementNodeArray = [document.createElement('div'), document.createElement('div')];
+
+      elementNodeArray[0].innerHTML = 'test';
+      elementNodeArray[1].innerHTML = 'silently ignored';
+
+      const textNodeSync = fixtureSync(elementNodeArray);
+      doTest(textNodeSync);
+
+      const textNodeAsync = await fixture(elementNodeArray);
+      doTest(textNodeAsync);
+    });
+
+    it('supports DOM tree', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('test the tree');
+        expect(node.nodeType).to.equal(NODE_TYPES.ELEMENT_NODE);
+      }
+
+      const parent = document.createElement('div');
+      const child = document.createElement('div');
+      const grandchild = document.createElement('div');
+
+      grandchild.appendChild(document.createTextNode('tree'));
+      child.appendChild(document.createTextNode('the '));
+      parent.appendChild(document.createTextNode('test '));
+
+      child.appendChild(grandchild);
+      parent.appendChild(child);
+
+      /*
+        <div>
+          test
+          <div>
+            the
+            <div>
+              tree
+            </div>
+          </div>
+        </div>
+       */
+
+      const textNodeSync = fixtureSync(parent);
+      doTest(textNodeSync);
+
+      const textNodeAsync = await fixture(parent);
+      doTest(textNodeAsync);
+    });
+  });
+
+  describe('primitives', () => {
+    it('supports number', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('1');
+        expect(node.nodeType).to.equal(NODE_TYPES.TEXT_NODE);
+      }
+
+      const textNodeSync = fixtureSync(1);
+      doTest(textNodeSync);
+
+      const textNodeAsync = await fixture(1);
+      doTest(textNodeAsync);
+    });
+
+    it('supports number array', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('0');
+        expect(node.nodeType).to.equal(NODE_TYPES.TEXT_NODE);
+      }
+
+      // NB: the 1 is silently ignored
+      const numberArray = [0, 1];
+
+      const numberArraySync = fixtureSync(numberArray);
+      doTest(numberArraySync);
+
+      const numberArrayAsync = await fixture(numberArray);
+      doTest(numberArrayAsync);
+    });
+
+    it('supports boolean', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('true');
+        expect(node.nodeType).to.equal(NODE_TYPES.TEXT_NODE);
+      }
+
+      const textNodeSync = fixtureSync(true);
+      doTest(textNodeSync);
+
+      const textNodeAsync = await fixture(true);
+      doTest(textNodeAsync);
+    });
+
+    it('supports boolean array', async () => {
+      /**
+       * @param {Node} node
+       */
+      function doTest(node) {
+        expect(node.textContent).to.equal('true');
+        expect(node.nodeType).to.equal(NODE_TYPES.TEXT_NODE);
+      }
+
+      // NB: the `false` is silently ignored
+      const booleanArray = [true, false];
+
+      const booleanArraySync = fixtureSync(booleanArray);
+      doTest(booleanArraySync);
+
+      const booleanArrayAsync = await fixture(booleanArray);
+      doTest(booleanArrayAsync);
+    });
   });
 
   it('will cleanup after each test', async () => {


### PR DESCRIPTION
`render` from `lit-html` accepts more than just a `TemplateResult` nowadays.
testing-helpers can support string, number, boolean, TemplateResult,
Node, or Arrays or iterables of such.

Note: in the case of Array or Iterable, only the first child will be
taken. All others will be silently ignored. See https://github.com/open-wc/open-wc/issues/833

fixes: #716 
affects: @open-wc/testing-helpers