### PR TITLE
chore: add eslint-plugin-no-only-tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,8 @@
 module.exports = {
   extends: ['./packages/eslint-config/index.js', require.resolve('eslint-config-prettier')],
+  plugins: ['no-only-tests'],
   rules: {
     'max-classes-per-file': 'off',
+    'no-only-tests/no-only-tests': 'error',
   },
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-wc": "^1.2.0",
     "husky": "3.0.0",
     "lerna": "3.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,16 +2031,16 @@
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.2.3"
+  version "1.2.7"
   dependencies:
-    "@open-wc/testing-karma" "^3.1.42"
+    "@open-wc/testing-karma" "^3.1.46"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.1.42"
+  version "3.1.46"
   dependencies:
-    "@open-wc/karma-esm" "^2.7.4"
+    "@open-wc/karma-esm" "^2.9.0"
     axe-core "^3.3.1"
     karma "^4.0.0"
     karma-chrome-launcher "^2.0.0"
@@ -7228,6 +7228,11 @@ eslint-plugin-import@^2.18.0:
     object.values "^1.1.0"
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
+
+eslint-plugin-no-only-tests@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.3.1.tgz#7b24a4df55b818d0838410aa96b24a5a4a072262"
+  integrity sha512-LzCzeQrlkNjEwUWEoGhfjz+Kgqe0080W6qC8I8eFwSMXIsr1zShuIQnRuSZc4Oi7k1vdUaNGDc+/GFvg6IHSHA==
 
 eslint-plugin-wc@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
say I wanted to test `es-dev-server`, I might change https://github.com/open-wc/open-wc/blob/dfd02845aa29fdd0f7ac9a44a184df9d5a836747/packages/es-dev-server/test/start-server.test.js#L9 from `describe` to `describe.only`.

when finished testing, if I forget to revert that change, I might end up accidentally committing it to master, which is dangerous, because no other tests will run.

This PR adds [`eslint-plugin-no-only-tests`](https://www.npmjs.com/package/eslint-plugin-no-only-tests) so that the linter will complain about any `.only` tests, suites, etc.
So now I'll get this error:
```
yarn run v1.16.0
$ run-p lint:*
$ prettier "**/*.{js,md}" "**/package.json" --check
$ eslint --ext .js,.html .
$ tsc
Checking formatting...
packages/es-dev-server/test/middleware/message-channel.test.js
/Users/bennyp/Documents/open-wc/packages/es-dev-server/test/start-server.test.js
  9:10  error  describe.only not permitted  no-only-tests/no-only-tests
```