### PR TITLE
chore(codelabs): build for site not for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:types": "tsc",
     "postinstall": "npm run build",
     "publish": "lerna publish --message 'chore: release new versions'",
-    "site:build": "npm run vuepress:build && lerna run storybook:build --scope @open-wc/demoing-storybook --stream",
+    "site:build": "npm run vuepress:build && lerna run site:build && lerna run storybook:build --scope @open-wc/demoing-storybook --stream",
     "site:start": "npm run vuepress:start",
     "test": "yarn test:browser && yarn test:node",
     "test:browser": "karma start --coverage",

--- a/packages/codelabs/package.json
+++ b/packages/codelabs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-wc/codelabs",
   "version": "1.2.1",
+  "private": true,
   "publishConfig": {
     "access": "public"
   },
@@ -14,7 +15,7 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/",
   "scripts": {
-    "build": "node build-codelabs.js"
+    "site:build": "node build-codelabs.js"
   },
   "keywords": [
     "open-wc",


### PR DESCRIPTION
- make codelabs private
- build codelabs for the website and not when locally working or in ci for testing/linting