### PR TITLE
feat(es-dev-server): check last changed timestamp when caching

### DIFF
--- a/packages/es-dev-server/demo/node-resolve/module-a.js
+++ b/packages/es-dev-server/demo/node-resolve/module-a.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
 import { foo } from './module-b.js';
 
-console.log('module a');
+console.log('module a temp');
 console.log(foo());


### PR DESCRIPTION
Fixes https://github.com/open-wc/open-wc/issues/930

There are reports that the dev server sometimes doesn't serve an updated file correctly, I've seen this myself too locally. 

Right now we're fully reliant on chokidar / node's file system watching logic to receive events correctly. If we miss an event, the user sees the outdated version until restarting the server. There have been quite some bugs with chokidar in past, so I'd rather not rely on it entirely. 

With this change we're checking the file system's last modified timestamp before serving from cache. Unfortunately, we can't switch to this approach entirely and ditch chokidar because many file systems are not accurate to the millisecond so you can still end up with race conditions. We need chokidar anyway for watch mode, so doing both is fine.