### PR TITLE
feat(es-dev-server): add response transformers

### DIFF
--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -265,7 +265,7 @@ You can rewrite certain file requests using the `responseTransformers` property.
 
 A response transformer is a function which receives the original response and returns an optionally modified response. This transformation happens before any other built-in transformations such as node resolve, babel or compatibility. You can register multiple transformers, they are called in order.
 
-The funtions can be sync or async, the full signature:
+The functions can be sync or async, see the full signature below:
 
 ```typescript
 ({ url: string, status: number, contentType: string, body: string }) => Promise<{ body?: string, contentType?: string } | null>

--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -110,10 +110,11 @@ module.exports = {
 
 In addition to the command-line flags, the configuration file accepts these additional options:
 
-| name        | type   | description                                            |
-| ----------- | ------ | ------------------------------------------------------ |
-| middlewares | array  | Koa middlewares to add to the server, read more below. |
-| babelConfig | object | Babel config to run with the server                    |
+| name                 | type   | description                                            |
+| -------------------- | ------ | ------------------------------------------------------ |
+| middlewares          | array  | Koa middlewares to add to the server, read more below. |
+| responseTransformers | array  | Functions which transform the server's response.       |
+| babelConfig          | object | Babel config to run with the server                    |
 
 ## Folder structure
 
@@ -230,14 +231,14 @@ module.exports = {
 
 </details>
 
-### Rewriting file requests
+### Rewriting request urls
 
-You can rewrite certain file requests using a simple custom middleware. This can be useful for example to serve your `index.html` from a different file location.
+You can rewrite certain file requests using a simple custom middleware. This can be useful for example to serve your `index.html` from a different file location or to alias a module.
 
 <details>
   <summary>Read more</summary>
 
-Set up a configuration file with a custom middleware:
+Serve `/index.html` from `/src/index.html`:
 
 ```javascript
 module.exports = {
@@ -253,9 +254,94 @@ module.exports = {
 };
 ```
 
-This way from the browser you can request `/` or `/index.html` and it will serve `/src/index.html`. This middleware is run before the dev server's file serving logic, which will use the rewritten URL.
-
 </details>
+
+### Response transformers
+
+You can rewrite certain file requests using the `responseTransformers` property. With this you can adjust served files or serve virtual non-existing files programmatically.
+
+<details>
+  <summary>Read more</summary>
+
+A response transformer is a function which receives the original response and returns an optionally modified response. This transformation happens before any other built-in transformations such as node resolve, babel or compatibility. You can register multiple transformers, they are called in order.
+
+The funtions can be sync or async, the full signature:
+
+```typescript
+({ url: string, status: number, contentType: string, body: string }) => Promise<{ body?: string, contentType?: string } | null>
+```
+
+Some examples:
+
+Rewrite the base path of your `index.html`:
+
+```javascript
+module.exports = {
+  responseTransformers: [
+    function rewriteBasePath({ url, status, contentType, body }) {
+      if (url === '/' || url === '/index.html') {
+        const rewritten = body.replace(/<base href=".*">/, '<base href="/foo/">');
+        return { body: rewritten };
+      }
+    },
+  ],
+};
+```
+
+Serve a virtual file, for example an auto generated `index.html`:
+
+```javascript
+const indexHTML = generateIndexHTML();
+
+module.exports = {
+  responseTransformers: [
+    function serveIndex({ url, status, contentType, body }) {
+      if (url === '/' || url === '/index.html') {
+        return { body: indexHTML, contentType: 'text/html' };
+      }
+    },
+  ],
+};
+```
+
+Transform markdown to HTML:
+
+```javascript
+const markdownToHTML = require('markdown-to-html-library');
+
+module.exports = {
+  responseTransformers: [
+    async function transformMarkdown({ url, status, contentType, body }) {
+      if (url === '/readme.md') {
+        const html = await markdownToHTML(body);
+        return {
+          body: html,
+          contentType: 'text/html',
+        };
+      }
+    },
+  ],
+};
+```
+
+Polyfill CSS modules in JS:
+
+```javascript
+module.exports = {
+  responseTransformers: [
+    async function transformCSS({ url, status, contentType, body }) {
+      if (url.endsWith('.css')) {
+        const transformedBody = `
+          const stylesheet = new CSSStyleSheet();
+          stylesheet.replaceSync(${JSON.stringify(body)});
+          export default stylesheet;
+        `;
+        return { body: transformedBody, contentType: 'application/javascript' };
+      }
+    },
+  ],
+};
+```
 
 ### Typescript support
 

--- a/packages/es-dev-server/demo/response-transformers/config.js
+++ b/packages/es-dev-server/demo/response-transformers/config.js
@@ -1,0 +1,45 @@
+module.exports = {
+  responseTransformers: [
+    function serveIndex({ url }) {
+      if (url === '/demo/response-transformers/index.html') {
+        return {
+          body: `
+            <html>
+              <head>
+                <base href="to-be-replaced">
+              </head>
+              <body>
+                <img width="100" src="../logo.png">
+                <h1>Demo app</h1>
+              </body>
+              <script type="module" src="./module-a.js"></script>
+            </html>
+          `,
+          contentType: 'text/html',
+        };
+      }
+      return null;
+    },
+
+    function rewriteBasePath({ url, body }) {
+      if (url === '/demo/response-transformers/index.html') {
+        return {
+          body: body.replace(/<base href=".*">/, '<base href="/demo/response-transformers/">'),
+        };
+      }
+      return null;
+    },
+
+    function transformCSS({ url, body }) {
+      if (url.endsWith('.css')) {
+        const transformedBody = `
+          const stylesheet = new CSSStyleSheet();
+          stylesheet.replaceSync(${JSON.stringify(body)});
+          export default stylesheet;
+        `;
+        return { body: transformedBody, contentType: 'application/javascript' };
+      }
+      return null;
+    },
+  ],
+};

--- a/packages/es-dev-server/demo/response-transformers/module-a.js
+++ b/packages/es-dev-server/demo/response-transformers/module-a.js
@@ -1,0 +1,3 @@
+import myStyles from './my-styles.css';
+
+document.adoptedStyleSheets = [...document.adoptedStyleSheets, myStyles];

--- a/packages/es-dev-server/demo/response-transformers/my-styles.css
+++ b/packages/es-dev-server/demo/response-transformers/my-styles.css
@@ -1,0 +1,3 @@
+body {
+  color: blue;
+}

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -45,6 +45,7 @@
     "start:performance:compat-esm": "yarn build && node dist/cli.js --root-dir ../../ --app-index packages/es-dev-server/demo/performance/index.html --node-resolve --compatibility esm --watch",
     "start:root-dir": "yarn build && node dist/cli.js --root-dir demo/static/ --open",
     "start:static": "yarn build && node dist/cli.js --open demo/static/",
+    "start:transformers": "yarn build && node dist/cli.js --app-index demo/response-transformers/index.html --config demo/response-transformers/config.js --node-resolve --open --watch",
     "start:typescript": "yarn build && node dist/cli.js --app-index demo/typescript/index.html --file-extensions .ts --node-resolve --open --watch --babel",
     "test": "npm run test:node",
     "test:node": "mocha test/**/*.test.js test/*.test.js --require @babel/register",
@@ -112,6 +113,7 @@
     "node-fetch": "^2.6.0",
     "request": "^2.88.0",
     "selfsigned": "^1.10.4",
+    "sinon": "^7.5.0",
     "uuid": "^3.3.2"
   }
 }

--- a/packages/es-dev-server/src/config.js
+++ b/packages/es-dev-server/src/config.js
@@ -22,6 +22,7 @@ import { compatibilityModes } from './constants.js';
  *   and ends with no/. For example: /my-app, /foo, /foo/bar
  * @property {boolean|CompressOptions} [compress=true] Whether the server should compress responses.
  * @property {import('koa').Middleware[]} [middlewares]
+ * @property {import('./middleware/transform-response').ResponseTransformer[]} responseTransformers
  * @property {boolean} logStartup whether to log server startup
  *
  * Development help
@@ -70,6 +71,7 @@ import { compatibilityModes } from './constants.js';
  * @property {string} rootDir
  * @property {boolean} logStartup whether to log a startup message
  * @property {import('koa').Middleware[]} customMiddlewares
+ * @property {import('./middleware/transform-response').ResponseTransformer[]} responseTransformers
  *
  * Development help
  * @property {boolean} watch
@@ -117,6 +119,7 @@ export function createConfig(config) {
     sslCert,
     sslKey,
     watch = false,
+    responseTransformers,
   } = config;
 
   // middlewares used to be called customMiddlewares
@@ -170,6 +173,7 @@ export function createConfig(config) {
     compress,
     customBabelConfig: babelConfig,
     customMiddlewares: middlewares,
+    responseTransformers,
     extraFileExtensions: fileExtensions,
     hostname,
     http2,

--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -11,6 +11,7 @@ import { createEtagCacheMiddleware } from './middleware/etag-cache-middleware.js
 import { createResponseCacheMiddleware } from './middleware/response-cache-middleware.js';
 import { setupBrowserReload } from './utils/setup-browser-reload.js';
 import { compatibilityModes } from './constants.js';
+import { createTransformResponseMiddleware } from './middleware/transform-response.js';
 
 const defaultCompressOptions = {
   filter(contentType) {
@@ -38,6 +39,7 @@ export function createMiddlewares(config, fileWatcher) {
     compress,
     customBabelConfig,
     customMiddlewares,
+    responseTransformers,
     extraFileExtensions,
     moduleDirectories,
     nodeResolve,
@@ -141,6 +143,10 @@ export function createMiddlewares(config, fileWatcher) {
 
   if (watch) {
     setupBrowserReload({ fileWatcher, watchDebounce });
+  }
+
+  if (responseTransformers) {
+    middlewares.push(createTransformResponseMiddleware({ responseTransformers }));
   }
 
   // serve sstatic files

--- a/packages/es-dev-server/src/middleware/transform-response.js
+++ b/packages/es-dev-server/src/middleware/transform-response.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-await-in-loop, no-restricted-syntax */
+import { getBodyAsString } from '../utils/utils.js';
+
+/**
+ * @typedef {object} ResponseTransformerArgs
+ * @property {string} url
+ * @property {number} status
+ * @property {string} contentType
+ * @property {string} body
+ */
+
+/**
+ * @typedef {object} ResponseTransformerReturnValue
+ * @property {string} [body]
+ * @property {string} [contentType]
+ */
+
+/**
+ * @typedef {(ResponseTransformerArgs) => ResponseTransformerReturnValue | null | Promise<ResponseTransformerReturnValue | null>} ResponseTransformer
+ */
+
+/**
+ * @typedef {object} TransformResponseMiddlewareConfig
+ * @property {ResponseTransformer[]} responseTransformers
+ */
+
+/**
+ *
+ * @param {TransformResponseMiddlewareConfig} config
+ */
+export function createTransformResponseMiddleware(config) {
+  /** @type {import('koa').Middleware} */
+  async function transformResponseMiddleware(ctx, next) {
+    await next();
+
+    const body = await getBodyAsString(ctx);
+    let newBody = body;
+    let newContentType = ctx.response.get('content-type');
+    let changedBody = false;
+    let changedContentType = false;
+
+    // execute transformers in order, not parallel
+    for (const transformer of config.responseTransformers) {
+      const result = await transformer({
+        url: ctx.url,
+        status: ctx.status,
+        contentType: newContentType,
+        body: newBody,
+      });
+
+      if (result) {
+        if (typeof result.body === 'string') {
+          newBody = result.body;
+          changedBody = true;
+        }
+
+        if (result.contentType) {
+          newContentType = result.contentType;
+          changedContentType = true;
+        }
+      }
+
+      if (result && result.body) {
+        newBody = result.body;
+      }
+    }
+
+    // if the body was transformed, we always serve it as 200. this allows serving a
+    // virtual file which doesn't exist (404 on the file system)
+    if (changedBody) {
+      ctx.status = 200;
+      ctx.body = newBody;
+    }
+
+    if (changedContentType) {
+      ctx.response.set('content-type', newContentType);
+    }
+  }
+
+  return transformResponseMiddleware;
+}

--- a/packages/es-dev-server/test/middleware/transform-response.test.js
+++ b/packages/es-dev-server/test/middleware/transform-response.test.js
@@ -1,0 +1,214 @@
+import { expect } from 'chai';
+import fetch from 'node-fetch';
+import path from 'path';
+import { stub } from 'sinon';
+import { startServer, createConfig } from '../../src/es-dev-server.js';
+
+const host = 'http://localhost:8080/';
+
+describe('transform response middleware', () => {
+  it('has no effect when no transforms are set', async () => {
+    let server;
+
+    try {
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+        }),
+      ));
+      const response = await fetch(`${host}text-files/hello-world.txt`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.equal('Hello world!');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('passes args to the transformer and returns the new response', async () => {
+    let server;
+    try {
+      const transformer = stub().returns({ body: 'transformed response' });
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+          responseTransformers: [transformer],
+        }),
+      ));
+      const response = await fetch(`${host}text-files/hello-world.txt`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.equal('transformed response');
+      expect(transformer.callCount).to.equal(1);
+      expect(transformer.getCall(0).args).to.eql([
+        {
+          status: 200,
+          url: '/text-files/hello-world.txt',
+          contentType: 'text/plain; charset=utf-8',
+          body: 'Hello world!',
+        },
+      ]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('can change only the content-type', async () => {
+    let server;
+    try {
+      const transformer = stub().returns({
+        body: 'transformed response',
+        contentType: 'application/javascript',
+      });
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+          responseTransformers: [transformer],
+        }),
+      ));
+      const response = await fetch(`${host}text-files/hello-world.txt`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(response.headers.get('content-type')).to.equal('application/javascript');
+      expect(responseText).to.equal('transformed response');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('can change both the content type and body', async () => {
+    let server;
+    try {
+      const transformer = stub().returns({
+        contentType: 'application/javascript',
+      });
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+          responseTransformers: [transformer],
+        }),
+      ));
+      const response = await fetch(`${host}text-files/hello-world.txt`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(response.headers.get('content-type')).to.equal('application/javascript');
+      expect(responseText).to.equal('Hello world!');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('transforms can be async', async () => {
+    let server;
+    try {
+      const transformer = stub().returns(Promise.resolve({ body: 'transformed response' }));
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+          responseTransformers: [transformer],
+        }),
+      ));
+      const response = await fetch(`${host}text-files/hello-world.txt`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.equal('transformed response');
+      expect(transformer.callCount).to.equal(1);
+      expect(transformer.getCall(0).args).to.eql([
+        {
+          status: 200,
+          url: '/text-files/hello-world.txt',
+          contentType: 'text/plain; charset=utf-8',
+          body: 'Hello world!',
+        },
+      ]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns the original response when a transformer returns null', async () => {
+    let server;
+    try {
+      const transformer = stub().returns(null);
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+          responseTransformers: [transformer],
+        }),
+      ));
+      const response = await fetch(`${host}text-files/hello-world.txt`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.equal('Hello world!');
+      expect(transformer.callCount).to.equal(1);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('calls multiple transformer in order, passing along the result', async () => {
+    let server;
+    try {
+      const transformer1 = stub().returns({ body: 'transform 1' });
+      const transformer2 = stub().returns(null);
+      const transformer3 = stub().returns({ body: 'transform 2' });
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+          responseTransformers: [transformer1, transformer2, transformer3],
+        }),
+      ));
+      const response = await fetch(`${host}text-files/hello-world.txt`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.equal('transform 2');
+      expect(transformer1.callCount).to.equal(1);
+      expect(transformer2.callCount).to.equal(1);
+      expect(transformer3.callCount).to.equal(1);
+      expect(transformer1.getCall(0).args[0].body).to.equal('Hello world!');
+      expect(transformer2.getCall(0).args[0].body).to.equal('transform 1');
+      expect(transformer3.getCall(0).args[0].body).to.equal('transform 1');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('can serve a virtal file', async () => {
+    let server;
+
+    try {
+      ({ server } = await startServer(
+        createConfig({
+          port: 8080,
+          rootDir: path.resolve(__dirname, '..', 'fixtures', 'simple'),
+          responseTransformers: [
+            () => ({
+              body: 'this is a virtual file',
+            }),
+          ],
+        }),
+      ));
+      const response = await fetch(`${host}non-existing.js`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.equal('this is a virtual file');
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,16 +2232,16 @@
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.2.9"
+  version "1.2.10"
   dependencies:
-    "@open-wc/testing-karma" "^3.1.48"
+    "@open-wc/testing-karma" "^3.1.49"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.1.48"
+  version "3.1.49"
   dependencies:
-    "@open-wc/karma-esm" "^2.9.2"
+    "@open-wc/karma-esm" "^2.9.3"
     axe-core "^3.3.1"
     karma "^4.0.0"
     karma-chrome-launcher "^2.0.0"
@@ -2278,6 +2278,13 @@
   dependencies:
     type-detect "4.0.8"
 
+"@sinonjs/commons@^1.3.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
+  dependencies:
+    type-detect "4.0.8"
+
 "@sinonjs/formatio@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
@@ -2294,6 +2301,15 @@
     "@sinonjs/commons" "^1.0.2"
     array-from "^2.1.1"
     lodash "^4.17.11"
+
+"@sinonjs/samsam@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
+  dependencies:
+    "@sinonjs/commons" "^1.3.0"
+    array-from "^2.1.1"
+    lodash "^4.17.15"
 
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.1"
@@ -12333,6 +12349,17 @@ nise@^1.5.1:
     lolex "^4.1.0"
     path-to-regexp "^1.7.0"
 
+nise@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
+  integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
+  dependencies:
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^4.1.0"
+    path-to-regexp "^1.7.0"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -15781,6 +15808,19 @@ sinon@^7.4.1:
     diff "^3.5.0"
     lolex "^4.2.0"
     nise "^1.5.1"
+    supports-color "^5.5.0"
+
+sinon@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
+  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.3"
+    diff "^3.5.0"
+    lolex "^4.2.0"
+    nise "^1.5.2"
     supports-color "^5.5.0"
 
 sisteransi@^1.0.3:


### PR DESCRIPTION
This adds a new option to the dev server config to transform a response before serving. This has a number of use cases:
- An easier way to write transformations than custom middlewares. Easier for people to understand, and easier to hook into other tools.
- Serve virtual files, such as an auto generated storybook index.html
- Transform javascript **before** it goes through compatibility transforms.
- Light transformations, such as rewriting an app's base path