### PR TITLE
fix(create): regression in app scaffolding when no options are selected

### DIFF
--- a/packages/create/src/generators/wc-lit-element/index.js
+++ b/packages/create/src/generators/wc-lit-element/index.js
@@ -3,6 +3,7 @@ import { CommonRepoMixin } from '../common-repo/index.js';
 import { processTemplate, readFileFromPath } from '../../core.js';
 
 const compose = (...fns) => fns.reduce((f, g) => (...args) => f(g(...args)));
+const safeReduce = (f, initial) => xs => (Array.isArray(xs) ? xs.reduce(f, initial) : xs);
 
 const getTemplatePart = compose(
   processTemplate,
@@ -18,11 +19,13 @@ function featureReadme(acc, feature, i, a) {
   return `${acc + featureReadmeBlurb(feature)}${i === a.length - 1 ? '' : '\n'}`;
 }
 
+const safeFeatureReadme = safeReduce(featureReadme, '');
+
 /* eslint-disable no-console */
 export const WcLitElementMixin = subclass =>
   class extends subclass {
     async execute() {
-      this.templateData.featureReadmes = this.options.features.reduce(featureReadme, '');
+      this.templateData.featureReadmes = safeFeatureReadme(this.options.features);
       this.templateData.scriptRunCommand =
         this.options.installDependencies === 'yarn' ? 'yarn' : 'npm run';
 


### PR DESCRIPTION
affects: @open-wc/create