### PR TITLE
chore: lint alignment of all versions in the monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:eslint": "eslint --ext .js,.html .",
     "lint:prettier": "prettier \"**/*.{js,md}\" \"**/package.json\" --check",
     "lint:types": "tsc",
+    "lint:versions": "node ./scripts/lint-versions.js",
     "postinstall": "npm run build",
     "publish": "lerna publish --message 'chore: release new versions'",
     "site:build": "npm run vuepress:build && lerna run site:build",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "npm-run-all": "4.1.3",
     "prettier": "^1.18.2",
     "prettier-plugin-package": "^0.3.1",
-    "rimraf": "^3.0.0",
+    "rimraf": "^2.6.3",
     "typescript-temporary-fork-for-jsdoc": "^3.6.0-insiders.20190802",
     "vuepress": "^1.0.0-alpha.30",
     "webpack-merge": "^4.1.5"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -25,6 +25,6 @@
   ],
   "dependencies": {
     "eslint-config-prettier": "^3.3.0",
-    "prettier": "^1.15.0"
+    "prettier": "^1.18.2"
   }
 }

--- a/scripts/lint-versions.js
+++ b/scripts/lint-versions.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+const { readdirSync, existsSync, readFileSync } = require('fs');
+
+const getDirectories = source =>
+  readdirSync(source, { withFileTypes: true })
+    .filter(pathMeta => pathMeta.isDirectory())
+    .map(pathMeta => pathMeta.name);
+
+function readPackageJson(filePath) {
+  if (existsSync(filePath)) {
+    const jsonData = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const merged = { ...jsonData.dependencies, ...jsonData.devDependencies };
+    const result = {};
+    Object.keys(merged).forEach(dep => {
+      if (merged[dep] && !merged[dep].includes('file:')) {
+        result[dep] = merged[dep];
+      }
+    });
+    return result;
+  }
+  return {};
+}
+
+function compareVersions(versionsA, versionsB) {
+  let output = '';
+  Object.keys(versionsA).forEach(dep => {
+    if (versionsA[dep] && versionsB[dep] && versionsA[dep] !== versionsB[dep]) {
+      output += `  - "${dep}": "${versionsA[dep]}" !== "${versionsB[dep]}"`;
+    }
+  });
+  return output;
+}
+
+const currentVersions = readPackageJson('./package.json');
+let endReturn = 0;
+getDirectories('./packages').forEach(subPackage => {
+  const filePath = `./packages/${subPackage}/package.json`;
+  const subPackageVersions = readPackageJson(filePath);
+  const result = compareVersions(currentVersions, subPackageVersions);
+  if (result) {
+    console.log(`Version miss matches found in "${filePath}":`);
+    console.log(result);
+    console.log();
+    endReturn = 1;
+  }
+});
+
+process.exit(endReturn);


### PR DESCRIPTION
example output (= current situation)
```bash
$ npm run lint:versions

> @open-wc/root@ lint:versions /Users/ff67qn/html/open-wc
> node ./scripts/lint-versions.js

Version miss matches found in "./packages/building-rollup/package.json":
  - "rimraf": "^3.0.0" !== "^2.6.3"

Version miss matches found in "./packages/building-utils/package.json":
  - "rimraf": "^3.0.0" !== "^2.6.3"

Version miss matches found in "./packages/create/package.json":
  - "rimraf": "^3.0.0" !== "^2.6.3"

Version miss matches found in "./packages/prettier-config/package.json":
  - "prettier": "^1.18.2" !== "^1.15.0"

Version miss matches found in "./packages/rollup-plugin-index-html/package.json":
  - "rimraf": "^3.0.0" !== "^2.6.3"

Version miss matches found in "./packages/webpack-index-html-plugin/package.json":
  - "rimraf": "^3.0.0" !== "^2.6.3"
```

will fix with second commit 💪 