### PR TITLE
fix (es-dev-server): use `require` to resolve `@babel/preset-env`

### DIFF
--- a/packages/es-dev-server/src/utils/babel-compiler.js
+++ b/packages/es-dev-server/src/utils/babel-compiler.js
@@ -35,7 +35,7 @@ function createDefaultConfig(readUserBabelConfig) {
 const modernConfig = {
   presets: [
     [
-      '@babel/preset-env',
+      require.resolve('@babel/preset-env'),
       {
         targets: findSupportedBrowsers(),
         useBuiltIns: false,
@@ -48,7 +48,7 @@ const modernConfig = {
 const legacyConfig = {
   presets: [
     [
-      '@babel/preset-env',
+      require.resolve('@babel/preset-env'),
       {
         targets: ['ie 11'],
         useBuiltIns: false,


### PR DESCRIPTION
`@babel/preset-env` should be resolved relative to es-dev-server location