### PR TITLE
fix(create): support setting scaffoldFilesFor via command line argument

### DIFF
--- a/packages/create/src/generators/app/index.js
+++ b/packages/create/src/generators/app/index.js
@@ -95,10 +95,14 @@ export const AppMixin = subclass =>
           ],
         },
         {
-          type: () => (scaffoldOptions.length > 0 ? 'multiselect' : null),
+          type: () =>
+            scaffoldOptions.length > 0 || overrides.scaffoldFilesFor.length > 0
+              ? 'multiselect'
+              : null,
           name: 'scaffoldFilesFor',
           message: 'Would you like to scaffold examples files for?',
           choices: scaffoldOptions,
+          initial: overrides.scaffoldFilesFor,
         },
         {
           type: 'text',


### PR DESCRIPTION
Since `scaffoldOptions` is initialized as an empty array, any arguments passed via command line get ignored by prompts, and do not get passed along to `this.options`.

This fix allows for setting that, like:
`npm init @open-wc --type scaffold --scaffoldType wc --features --scaffoldFilesFor demoing testing --installDependencies false --tagName`

For context, we are using this as an npm-run-script within a monorepo style component library, and would like to scaffold the story and test files, without the storybook and karma configs, since we have a root level test runner and Storybook instance.