### PR TITLE
chore: cache dependencies on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,20 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v3-dependencies-
-      - run: yarn install --frozen-lockfile
+            - v4-dependencies-{{ checksum "yarn.lock" }}
+      - run:
+          name: Do `yarn install` on cache miss
+          command: |
+            if [ -d "./node_modules" ]; then
+              echo "Restored node_modules from cache";
+            else
+              echo "Fill node_modules via yarn install";
+              yarn install --frozen-lockfile
+            fi
       - save_cache:
           paths:
             - node_modules
-          key: v2-dependencies-{{ checksum "package.json" }}
+          key: v4-dependencies-{{ checksum "yarn.lock" }}
 
       # build what needs to be build so we can use it in the next steps
       - run: npm run build


### PR DESCRIPTION
💼 Cache your dependencies
🔑 Use your `yarn.lock` as a cache key
📦 Run `yarn install` only if no cache was found
🏅 Win time

PS: For us it was 54s to do yarn install vs 8s to restore cache => 84% faster 🎉
PPS: when there are no dep changes