### PR TITLE
fix(demoing-storybook): escape quotes in Storybook scripts

### DIFF
--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -21,8 +21,8 @@
   "scripts": {
     "build:start": "es-dev-server --root-dir static-storybook --app-index index.html --open",
     "prepublishOnly": "../../scripts/insert-header.js",
-    "site:build": "node src/build/cli.js --stories 'demo/stories/*.stories.{js,mdx}' --config-dir demo/.storybook -o ../../_site/demoing-storybook",
-    "storybook": "cd ../.. && node packages/demoing-storybook/src/start/cli.js --stories 'packages/demoing-storybook/demo/stories/*.stories.{js,mdx}' --config-dir packages/demoing-storybook/demo/.storybook --node-resolve --watch --open",
+    "site:build": "node src/build/cli.js --stories \"demo/stories/*.stories.{js,mdx}\" --config-dir demo/.storybook -o ../../_site/demoing-storybook",
+    "storybook": "cd ../.. && node packages/demoing-storybook/src/start/cli.js --stories \"packages/demoing-storybook/demo/stories/*.stories.{js,mdx}\" --config-dir packages/demoing-storybook/demo/.storybook --node-resolve --watch --open",
     "storybook:build": "node src/build/cli.js --stories 'demo/stories/*.stories.{js,mdx}' --config-dir demo/.storybook"
   },
   "files": [


### PR DESCRIPTION
Resolves an issue when the stories source pattern was not being recognized due to incorrect interpretation of single quotes on Windows.