### PR TITLE
fix(es-dev-server): don't throw on cancelled requests

### DIFF
--- a/packages/es-dev-server/demo/performance/server.js
+++ b/packages/es-dev-server/demo/performance/server.js
@@ -1,6 +1,6 @@
 module.exports = {
   rootDir: '../../',
-  appIndex: 'packages/es-dev-server/demo/node-resolve/index.html',
+  appIndex: 'packages/es-dev-server/demo/performance/index.html',
   nodeResolve: true,
   open: true,
   watch: true,

--- a/packages/es-dev-server/src/middleware/compatibility-transform.js
+++ b/packages/es-dev-server/src/middleware/compatibility-transform.js
@@ -1,6 +1,11 @@
 import stripAnsi from 'strip-ansi';
 import { defaultFileExtensions } from '@open-wc/building-utils';
-import { getBodyAsString, getRequestFilePath, isPolyfill } from '../utils/utils.js';
+import {
+  getBodyAsString,
+  getRequestFilePath,
+  isPolyfill,
+  RequestCancelledError,
+} from '../utils/utils.js';
 import { sendMessageToActiveBrowsers } from '../utils/message-channel.js';
 import { ResolveSyntaxError } from '../utils/resolve-module-imports.js';
 import { createCompatibilityTransform } from '../utils/compatibility-transform.js';
@@ -76,6 +81,10 @@ export function createCompatibilityTransformMiddleware(cfg) {
       ctx.status = 200;
       return undefined;
     } catch (error) {
+      if (error instanceof RequestCancelledError) {
+        return undefined;
+      }
+
       // ResolveSyntaxError is thrown when resolveModuleImports runs into a syntax error from
       // the lexer, but babel didn't see any errors. this means either a bug in the lexer, or
       // some experimental syntax. log a message and return the module untransformed to the

--- a/packages/es-dev-server/src/middleware/message-channel.js
+++ b/packages/es-dev-server/src/middleware/message-channel.js
@@ -4,7 +4,7 @@
  * @property {string} rootDir
  */
 
-import { isIndexHTMLResponse, getBodyAsString } from '../utils/utils.js';
+import { isIndexHTMLResponse, getBodyAsString, RequestCancelledError } from '../utils/utils.js';
 import { setupMessageChannel } from '../utils/message-channel.js';
 import { messageChannelEndpoint } from '../constants.js';
 import messageChannelScript from '../browser-scripts/message-channel.js';
@@ -15,9 +15,16 @@ import messageChannelScript from '../browser-scripts/message-channel.js';
  * @param {import('koa').Context} ctx
  */
 async function injectMessageChannelScript(ctx) {
-  const bodyString = await getBodyAsString(ctx);
-  const reloadInjected = bodyString.replace('</body>', messageChannelScript);
-  ctx.body = reloadInjected;
+  try {
+    const bodyString = await getBodyAsString(ctx);
+    const reloadInjected = bodyString.replace('</body>', messageChannelScript);
+    ctx.body = reloadInjected;
+  } catch (error) {
+    if (error instanceof RequestCancelledError) {
+      return;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/packages/es-dev-server/src/middleware/response-transform.js
+++ b/packages/es-dev-server/src/middleware/response-transform.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop, no-restricted-syntax */
-import { getBodyAsString } from '../utils/utils.js';
+import { getBodyAsString, RequestCancelledError } from '../utils/utils.js';
 
 /**
  * @typedef {object} ResponseTransformerArgs
@@ -33,7 +33,16 @@ export function createResponseTransformMiddleware(config) {
   async function responseTransformMiddlewareConfig(ctx, next) {
     await next();
 
-    const body = await getBodyAsString(ctx);
+    let body;
+    try {
+      body = await getBodyAsString(ctx);
+    } catch (error) {
+      if (error instanceof RequestCancelledError) {
+        return;
+      }
+      throw error;
+    }
+
     let newBody = body;
     let newContentType = ctx.response.get('content-type');
     let changedBody = false;

--- a/packages/es-dev-server/src/middleware/transform-index-html.js
+++ b/packages/es-dev-server/src/middleware/transform-index-html.js
@@ -7,6 +7,7 @@ import {
   getBodyAsString,
   toBrowserPath,
   isInlineModule,
+  RequestCancelledError,
 } from '../utils/utils.js';
 import { getUserAgentCompat } from '../utils/user-agent-compat.js';
 
@@ -98,30 +99,37 @@ export function createTransformIndexHTMLMiddleware(cfg) {
       return undefined;
     }
 
-    // transforms index.html to make the code load correctly with the right polyfills and shims
-    const indexHTMLString = await getBodyAsString(ctx);
-    const transformResult = getTransformedIndexHTML({
-      indexUrl: ctx.url,
-      indexHTMLString,
-      compatibilityMode: cfg.compatibilityMode,
-      polyfillsMode: cfg.polyfillsMode,
-      uaCompat,
-    });
+    try {
+      // transforms index.html to make the code load correctly with the right polyfills and shims
+      const indexHTMLString = await getBodyAsString(ctx);
+      const transformResult = getTransformedIndexHTML({
+        indexUrl: ctx.url,
+        indexHTMLString,
+        compatibilityMode: cfg.compatibilityMode,
+        polyfillsMode: cfg.polyfillsMode,
+        uaCompat,
+      });
 
-    // add new index.html
-    ctx.body = transformResult.indexHTML;
+      // add new index.html
+      ctx.body = transformResult.indexHTML;
 
-    // cache index for later use
-    indexHTMLData.set(uaCompat.browserTarget + ctx.url, { ...transformResult, lastModified });
+      // cache index for later use
+      indexHTMLData.set(uaCompat.browserTarget + ctx.url, { ...transformResult, lastModified });
 
-    // cache polyfills for serving
-    transformResult.polyfills.forEach(p => {
-      let root = ctx.url.endsWith('/') ? ctx.url : path.posix.dirname(ctx.url);
-      if (!root.endsWith('/')) {
-        root = `${root}/`;
+      // cache polyfills for serving
+      transformResult.polyfills.forEach(p => {
+        let root = ctx.url.endsWith('/') ? ctx.url : path.posix.dirname(ctx.url);
+        if (!root.endsWith('/')) {
+          root = `${root}/`;
+        }
+        polyfills.set(`${root}${toBrowserPath(p.path)}`, p.content);
+      });
+    } catch (error) {
+      if (error instanceof RequestCancelledError) {
+        return undefined;
       }
-      polyfills.set(`${root}${toBrowserPath(p.path)}`, p.content);
-    });
+      throw error;
+    }
     return undefined;
   }
 


### PR DESCRIPTION
When a request is cancelled, reading a response stream throws. This doesn't cause any issues, but it spams the terminal. This is especially apparent when working with larger applications.

This change handles this gracefully, reducing terminal spam.

Fixes https://github.com/open-wc/open-wc/issues/1010