### PR TITLE
chore: add more exempt stale labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,6 +9,11 @@ exemptLabels:
   - 'needs review'
   - 'high priority'
   - 'good first issue'
+  - 'bug'
+  - 'dependencies'
+  - 'docs'
+  - 'enhancement'
+  - 'help wanted'
 
 # Label to use when marking an issue as stale
 staleLabel: inactive


### PR DESCRIPTION
If we add labels like bug or enhancement, we are acknowledging that it is a legitimate thing we want to add to our code/docs. In those cases, the stale bot shouldn't close the issue.

If an issue is missing a reproduction, or if things aren't clear yet, we do want the stale bot to intervene.