### PR TITLE
feat(lit-helpers): add spread directives

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -14,6 +14,7 @@ const sidebar = [
       '/developing/best-practices',
       '/developing/es-dev-server',
       ['/init/', 'Generators'],
+      '/developing/lit-helpers',
       '/developing/types',
       '/developing/routing',
     ],

--- a/docs/developing/lit-helpers.md
+++ b/docs/developing/lit-helpers.md
@@ -1,0 +1,1 @@
+../../packages/lit-helpers/README.md

--- a/packages/lit-helpers/LICENSE
+++ b/packages/lit-helpers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 open-wc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lit-helpers/README.md
+++ b/packages/lit-helpers/README.md
@@ -1,0 +1,108 @@
+# Lit Helpers
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
+
+A library with helpers functions for working with [lit-html](https://lit-html.polymer-project.org/) and [lit-element](https://lit-element.polymer-project.org/)
+
+## Installation
+
+```bash
+npm i --save @open-wc/lit-helpers
+```
+
+## Spread directives
+
+Spread directives can be used to set an arbitrary collection of properties, attributes or event listeners on an element without knowing all the keys in advance.
+
+The spread directives work by taking in an object of data to spread. Because of `lit-html` syntax, we need one attribute to apply the directive to. It doesn't actually matter what the name of this attribute is, we recommend sticking to the convention of using `...` as the attribute name.
+
+### Regular spread
+
+The regular `spread` directive can be used to set properties, attribute or event listeners. It uses the same syntax as `lit-html` for distinguishing different types of bindings:
+
+```js
+import { html, render } from 'lit-html';
+import { spread } from '@open-wc/lit-helpers';
+
+render(
+  html`
+    <div
+      ...=${spread({
+        'my-attribute': 'foo',
+        '?my-boolean-attribute': true
+        '.myProperty': { foo: 'bar' },
+        '@my-event': () => console.log('my-event fired'),
+      })}
+    ></div>
+  `,
+  document.body,
+);
+```
+
+### Property spread
+
+Because spreading properties is a common use case, you can use the `spreadProps` directive so that you don't need prefix each property with a `.`. This is especially useful when the data comes from external sources.
+
+```js
+import { html, render } from 'lit-html';
+import { spreadProps } from '@open-wc/lit-helpers';
+
+render(
+  html`
+    <div ...="${spreadProps({ propertyA: 'a', propertyB: 'b' })}"></div>
+  `,
+  document.body,
+);
+```
+
+### Attribute spread
+
+Since `spread` already spreads attribute as the default case, we do not need a separate `spreadAttributes` directive.
+
+### Re-rendering
+
+When re-rendering, values are updated if they changed from the previous value. We use the same strict equality check (`!==`) as `lit-html` for this.
+
+Unlike `lit-html`, when spreading attributes we remove the attribute if it is set to `null` or `undefined`.
+
+If an entry in the spread data is removed, the property is set to undefined, the attribute is removed or the event listener is deregistered.
+
+Example:
+
+```js
+function renderSpread(data) {
+  render(
+    html`
+      <div ...="${spread(data)}"></div>
+    `,
+    document.body,
+  );
+}
+
+// result: <div foo="bar">
+renderSpread({ foo: 'bar' });
+
+// result: <div foo="buz">
+renderSpread({ foo: 'buz' });
+
+// result: <div foo="buz" lorem="ipsum">
+renderSpread({ foo: 'buz', lorem: 'ipsum' });
+
+// result: <div foo="buz">
+renderSpread({ foo: 'buz' });
+
+// result: <div>
+renderSpread({ foo: undefined' });
+```
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/testing-helpers/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/lit-helpers/index.js
+++ b/packages/lit-helpers/index.js
@@ -1,0 +1,2 @@
+export { spread } from './src/spread.js';
+export { spreadProps } from './src/spreadProps.js';

--- a/packages/lit-helpers/package.json
+++ b/packages/lit-helpers/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@open-wc/lit-helpers",
+  "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Helpers and utils for lit-html and lit-element.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wc/open-wc.git",
+    "directory": "packages/lit-helpers"
+  },
+  "author": "open-wc",
+  "homepage": "https://github.com/open-wc/open-wc/",
+  "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js"
+  },
+  "files": [
+    "*.d.ts",
+    "*.js",
+    "src"
+  ],
+  "keywords": [
+    "lit-html",
+    "lit-element",
+    "web components",
+    "utils",
+    "helpers"
+  ],
+  "peerDependencies": {
+    "lit-html": "^1.0.0"
+  },
+  "dependencies": {
+    "@open-wc/testing": "^2.4.1"
+  },
+  "devDependencies": {
+    "sinon": "^7.4.1"
+  },
+  "module": "index.js"
+}

--- a/packages/lit-helpers/src/spread.js
+++ b/packages/lit-helpers/src/spread.js
@@ -1,0 +1,109 @@
+/* eslint-disable no-param-reassign, no-restricted-syntax, guard-for-in, no-continue */
+import { directive, noChange } from 'lit-html';
+
+/** @typedef {import('lit-html').AttributePart} AttributePart */
+
+/** @type {WeakMap<AttributePart, { [key: string]: unknown }>} */
+const prevCache = new WeakMap();
+
+export const spread = directive((/** @type {{ [key: string]: unknown }} */ spreadData) => (
+  /** @type {AttributePart} */ part,
+) => {
+  const prevData = prevCache.get(part);
+  if (prevData === spreadData) {
+    return;
+  }
+  prevCache.set(part, spreadData);
+
+  // set new spread data
+  if (spreadData) {
+    // for in is faster than Object.entries().forEach
+    for (const key in spreadData) {
+      const value = spreadData[key];
+      if (value === noChange) {
+        continue;
+      }
+
+      const prefix = key[0];
+      const { element } = part.committer;
+
+      // event listener
+      if (prefix === '@') {
+        const prevHandler = prevData && prevData[key];
+        if (!prevHandler || prevHandler !== value) {
+          const name = key.slice(1);
+          if (prevHandler) {
+            // @ts-ignore
+            element.removeEventListener(name, prevHandler);
+          }
+          // @ts-ignore
+          element.addEventListener(name, value);
+        }
+        continue;
+      }
+
+      // property
+      if (prefix === '.') {
+        if (!prevData || prevData[key] !== value) {
+          element[key.slice(1)] = value;
+        }
+        continue;
+      }
+
+      // boolean attribute
+      if (prefix === '?') {
+        if (!prevData || prevData[key] !== value) {
+          const name = key.slice(1);
+          if (value) {
+            element.setAttribute(name, '');
+          } else {
+            element.removeAttribute(name);
+          }
+        }
+        continue;
+      }
+
+      // attribute
+      if (!prevData || prevData[key] !== value) {
+        if (value != null) {
+          element.setAttribute(key, String(value));
+        } else {
+          element.removeAttribute(key);
+        }
+      }
+    }
+  }
+
+  // remove previously set spread data if they were removed
+  if (prevData) {
+    // for in is faster than Object.entries().forEach
+    for (const key in prevData) {
+      if (!spreadData || !(key in spreadData)) {
+        const prefix = key[0];
+        const { element } = part.committer;
+
+        // event listener
+        if (prefix === '@') {
+          // @ts-ignore
+          element.removeEventListener(key.slice(1), prevData[key]);
+          continue;
+        }
+
+        // property
+        if (prefix === '.') {
+          element[key.slice(1)] = undefined;
+          continue;
+        }
+
+        // boolean attribute
+        if (prefix === '?') {
+          element.removeAttribute(key.slice(1));
+          continue;
+        }
+
+        // attribute
+        element.removeAttribute(key);
+      }
+    }
+  }
+});

--- a/packages/lit-helpers/src/spreadProps.js
+++ b/packages/lit-helpers/src/spreadProps.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-param-reassign, no-restricted-syntax, guard-for-in */
+import { directive } from 'lit-html';
+
+/** @typedef {import('lit-html').PropertyPart} PropertyPart */
+
+const previousProps = new WeakMap();
+
+export const spreadProps = directive((/** @type {{ [key: string]: unknown }} */ props) => (
+  /** @type {PropertyPart} */ part,
+) => {
+  const prev = previousProps.get(part);
+  if (prev === props) {
+    return;
+  }
+  previousProps.set(part, props);
+
+  // set new properties if they changed
+  if (props) {
+    // for in is faster than Object.entries().forEach
+    for (const key in props) {
+      const value = props[key];
+      if (!prev || prev[key] !== value) {
+        part.committer.element[key] = value;
+      }
+    }
+  }
+
+  // remove previously set properties if they were removed
+  if (prev) {
+    // for in is faster than Object.entries().forEach
+    for (const key in prev) {
+      if (!props || !(key in props)) {
+        part.committer.element[key] = undefined;
+      }
+    }
+  }
+});

--- a/packages/lit-helpers/test/spread.test.js
+++ b/packages/lit-helpers/test/spread.test.js
@@ -1,0 +1,268 @@
+import { expect, html, fixture } from '@open-wc/testing';
+import { stub } from 'sinon';
+import { render } from 'lit-html';
+import { spread } from '../src/spread.js';
+
+describe('spread', () => {
+  let wrapper;
+  beforeEach(async () => {
+    wrapper = await fixture(document.createElement('div'));
+  });
+
+  function renderSpread(data) {
+    render(
+      html`
+        <div ...=${spread(data)}></div>
+      `,
+      wrapper,
+    );
+    return wrapper.firstElementChild;
+  }
+
+  it('can render undefined', async () => {
+    renderSpread(undefined);
+  });
+
+  it('can render null', async () => {
+    renderSpread(null);
+  });
+
+  describe('properties', () => {
+    it('sets properties on an element', async () => {
+      const element = renderSpread({ '.foo': 'bar', '.lorem': 'ipsum' });
+      expect(element.foo).to.equal('bar');
+      expect(element.lorem).to.equal('ipsum');
+    });
+
+    it('can change value in subsequent renders', async () => {
+      let element = renderSpread({ '.foo': 'bar' });
+      expect(element.foo).to.equal('bar');
+
+      element = renderSpread({ '.foo': 'buz' });
+      expect(element.foo).to.equal('buz');
+
+      element = renderSpread({ '.foo': undefined });
+      expect(element.foo).to.equal(undefined);
+    });
+
+    it('can add properties in subsequent renders', async () => {
+      let element = renderSpread({ '.foo': 'bar' });
+      expect(element.foo).to.equal('bar');
+
+      element = renderSpread({ '.foo': 'bar', '.lorem': 'ipsum' });
+      expect(element.foo).to.equal('bar');
+      expect(element.lorem).to.equal('ipsum');
+    });
+
+    it('can remove properties in subsequent renders', async () => {
+      let element = renderSpread({ '.foo': 'bar', '.lorem': 'ipsum' });
+      expect(element.foo).to.equal('bar');
+      expect(element.lorem).to.equal('ipsum');
+
+      element = renderSpread({ '.foo': 'bar' });
+      expect(element.foo).to.equal('bar');
+      expect(element.lorem).to.equal(undefined);
+    });
+
+    it('can remove properties when rendering to undefined', async () => {
+      let element = renderSpread({ '.foo': 'bar' });
+      expect(element.foo).to.equal('bar');
+
+      element = renderSpread();
+      expect(element.foo).to.equal(undefined);
+    });
+  });
+
+  describe('attributes', () => {
+    it('sets attributes on an element', async () => {
+      const element = renderSpread({ foo: 'bar', lorem: 'ipsum' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+      expect(element.getAttribute('lorem')).to.equal('ipsum');
+    });
+
+    it('can change value in subsequent renders', async () => {
+      let element = renderSpread({ foo: 'bar' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+
+      element = renderSpread({ foo: 'buz' });
+      expect(element.getAttribute('foo')).to.equal('buz');
+    });
+
+    it('removes the attribute if it is null or undefined', async () => {
+      let element = renderSpread({ foo: 'bar' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+
+      element = renderSpread({ foo: undefined });
+      expect(element.hasAttribute('foo')).to.equal(false);
+
+      element = renderSpread({ foo: null });
+      expect(element.hasAttribute('foo')).to.equal(false);
+    });
+
+    it('can add attributes in subsequent renders', async () => {
+      let element = renderSpread({ foo: 'bar' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+
+      element = renderSpread({ foo: 'bar', lorem: 'ipsum' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+      expect(element.getAttribute('lorem')).to.equal('ipsum');
+    });
+
+    it('can remove attributes in subsequent renders', async () => {
+      let element = renderSpread({ foo: 'bar', lorem: 'ipsum' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+      expect(element.getAttribute('lorem')).to.equal('ipsum');
+
+      element = renderSpread({ foo: 'bar' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+      expect(element.getAttribute('lorem')).to.equal(null);
+    });
+
+    it('removes attributes when rendering to undefined', async () => {
+      let element = renderSpread({ foo: 'bar' });
+      expect(element.getAttribute('foo')).to.equal('bar');
+
+      element = renderSpread(undefined);
+      expect(element.getAttribute('foo')).to.equal(null);
+    });
+  });
+
+  describe('boolean attributes', () => {
+    it('sets boolean attributes on an element', async () => {
+      const element = renderSpread({ '?foo': true, '?lorem': false, '?x': true });
+      expect(element.hasAttribute('foo')).to.equal(true);
+      expect(element.hasAttribute('lorem')).to.equal(false);
+      expect(element.hasAttribute('x')).to.equal(true);
+    });
+
+    it('can change value in subsequent renders', async () => {
+      let element = renderSpread({ '?foo': true });
+      expect(element.hasAttribute('foo')).to.equal(true);
+
+      element = renderSpread({ '?foo': false });
+      expect(element.hasAttribute('foo')).to.equal(false);
+    });
+
+    it('can add attributes in subsequent renders', async () => {
+      let element = renderSpread({ '?foo': true, '?lorem': false });
+      expect(element.hasAttribute('foo')).to.equal(true);
+      expect(element.hasAttribute('lorem')).to.equal(false);
+
+      element = renderSpread({ '?foo': true, '?lorem': false, '?x': true });
+      expect(element.hasAttribute('foo')).to.equal(true);
+      expect(element.hasAttribute('lorem')).to.equal(false);
+      expect(element.hasAttribute('x')).to.equal(true);
+    });
+
+    it('can remove attributes in subsequent renders', async () => {
+      let element = renderSpread({ '?foo': true });
+      expect(element.hasAttribute('foo')).to.equal(true);
+
+      element = renderSpread({});
+      expect(element.hasAttribute('foo')).to.equal(false);
+    });
+
+    it('removes attributes when rendering to undefined', async () => {
+      let element = renderSpread({ '?foo': true });
+      expect(element.hasAttribute('foo')).to.equal(true);
+
+      element = renderSpread(undefined);
+      expect(element.hasAttribute('foo')).to.equal(false);
+    });
+  });
+
+  describe('event listeners', () => {
+    it('adds event listeners to an element', async () => {
+      const eventHandlerA = stub();
+      const eventHandlerB = stub();
+
+      const element = renderSpread({ '@my-event-a': eventHandlerA, '@my-event-b': eventHandlerB });
+      element.dispatchEvent(new Event('my-event-a'));
+      element.dispatchEvent(new Event('my-event-b'));
+
+      expect(eventHandlerA.calledOnce).to.equal(true);
+      expect(eventHandlerB.calledOnce).to.equal(true);
+    });
+
+    it('can change event listeners in subsequent renders, deregistering the earlier listener', async () => {
+      const eventHandlerA = stub();
+      const eventHandlerB = stub();
+
+      let element = renderSpread({ '@my-event-a': eventHandlerA });
+      element.dispatchEvent(new Event('my-event-a'));
+      expect(eventHandlerA.calledOnce).to.equal(true);
+
+      element = renderSpread({ '@my-event-a': eventHandlerB });
+      element.dispatchEvent(new Event('my-event-a'));
+      expect(eventHandlerA.calledOnce).to.equal(true);
+      expect(eventHandlerB.calledOnce).to.equal(true);
+    });
+
+    it('can add listeners in subsequent renders', async () => {
+      const eventHandlerA = stub();
+      const eventHandlerB = stub();
+
+      let element = renderSpread({ '@my-event-a': eventHandlerA });
+
+      element.dispatchEvent(new Event('my-event-a'));
+      expect(eventHandlerA.calledOnce).to.equal(true);
+
+      element = renderSpread({ '@my-event-a': eventHandlerA, '@my-event-b': eventHandlerB });
+
+      element.dispatchEvent(new Event('my-event-a'));
+      element.dispatchEvent(new Event('my-event-b'));
+      expect(eventHandlerA.calledTwice).to.equal(true);
+      expect(eventHandlerB.calledOnce).to.equal(true);
+    });
+
+    it('can remove listeners in subsequent renders', async () => {
+      const eventHandlerA = stub();
+      const eventHandlerB = stub();
+
+      let element = renderSpread({ '@my-event-a': eventHandlerA, '@my-event-b': eventHandlerB });
+
+      element.dispatchEvent(new Event('my-event-a'));
+      element.dispatchEvent(new Event('my-event-b'));
+      expect(eventHandlerA.calledOnce).to.equal(true);
+      expect(eventHandlerB.calledOnce).to.equal(true);
+
+      element = renderSpread({ '@my-event-a': eventHandlerA });
+
+      element.dispatchEvent(new Event('my-event-a'));
+      expect(eventHandlerA.calledTwice).to.equal(true);
+      expect(eventHandlerB.calledOnce).to.equal(true);
+    });
+
+    it('removes listeners when rendering to undefined', async () => {
+      const eventHandlerA = stub();
+
+      let element = renderSpread({ '@my-event-a': eventHandlerA });
+
+      element.dispatchEvent(new Event('my-event-a'));
+      expect(eventHandlerA.calledOnce).to.equal(true);
+
+      element = renderSpread(undefined);
+
+      element.dispatchEvent(new Event('my-event-a'));
+      expect(eventHandlerA.calledOnce).to.equal(true);
+    });
+  });
+
+  describe('mixed', () => {
+    it('can render a mix of types', () => {
+      const eventHandler = stub();
+      const element = renderSpread({
+        foo: 'bar',
+        '.foo': 'bar',
+        '?bar': true,
+        '@foo': eventHandler,
+      });
+
+      element.dispatchEvent(new Event('foo'));
+      expect(element.foo).to.equal('bar');
+      expect(element.getAttribute('foo')).to.equal('bar');
+      expect(element.hasAttribute('bar')).to.equal(true);
+      expect(eventHandler.calledOnce).to.equal(true);
+    });
+  });
+});

--- a/packages/lit-helpers/test/spreadProps.test.js
+++ b/packages/lit-helpers/test/spreadProps.test.js
@@ -1,0 +1,76 @@
+import { expect, html, fixture } from '@open-wc/testing';
+import { render } from 'lit-html';
+import { spreadProps } from '../src/spreadProps.js';
+
+describe('spreadProps', () => {
+  let wrapper;
+  beforeEach(async () => {
+    wrapper = await fixture(document.createElement('div'));
+  });
+
+  function renderSpread(props) {
+    render(
+      html`
+        <div ...=${spreadProps(props)}></div>
+      `,
+      wrapper,
+    );
+    return wrapper.firstElementChild;
+  }
+
+  it('sets properties on an element', async () => {
+    const element = renderSpread({ foo: 'bar', lorem: 'ipsum' });
+    expect(element.foo).to.equal('bar');
+    expect(element.lorem).to.equal('ipsum');
+  });
+
+  it('can change value in subsequent renders', async () => {
+    let element = renderSpread({ foo: 'bar' });
+    expect(element.foo).to.equal('bar');
+
+    element = renderSpread({ foo: 'buz' });
+    expect(element.foo).to.equal('buz');
+
+    element = renderSpread({ foo: undefined });
+    expect(element.foo).to.equal(undefined);
+  });
+
+  it('can add properties in subsequent renders', async () => {
+    let element = renderSpread({ foo: 'bar' });
+    expect(element.foo).to.equal('bar');
+
+    element = renderSpread({ foo: 'bar', lorem: 'ipsum' });
+    expect(element.foo).to.equal('bar');
+    expect(element.lorem).to.equal('ipsum');
+  });
+
+  it('can remove properties in subsequent renders', async () => {
+    let element = renderSpread({ foo: 'bar', lorem: 'ipsum' });
+    expect(element.foo).to.equal('bar');
+    expect(element.lorem).to.equal('ipsum');
+
+    element = renderSpread({ foo: 'bar' });
+    expect(element.foo).to.equal('bar');
+    expect(element.lorem).to.equal(undefined);
+  });
+
+  it('can render undefined', async () => {
+    let element = renderSpread(undefined);
+
+    element = renderSpread({ foo: 'bar' });
+    expect(element.foo).to.equal('bar');
+
+    element = renderSpread(undefined);
+    expect(element.foo).to.equal(undefined);
+  });
+
+  it('can render null', async () => {
+    let element = renderSpread(null);
+
+    element = renderSpread({ foo: 'bar' });
+    expect(element.foo).to.equal('bar');
+
+    element = renderSpread(null);
+    expect(element.foo).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
This introduces a new package, `@open-wc/lit-helper`, with two spread directives `spread` and `spreadProps`.

I considered adding `spreadAttributes`, but I felt that it wasn't needed because you can already use `spread` to do the same since there is no syntax difference for attributes.

Fixes https://github.com/open-wc/open-wc/issues/967