### PR TITLE
chore(create): add test:update-snapshots command

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -22,6 +22,7 @@
     "start": "npm run build && node ./dist/create.js",
     "test": "npm run test:node",
     "test:node": "mocha --require @babel/register",
+    "test:update-snapshots": "node -r @babel/register ./test/update-snapshots.js",
     "test:watch": "onchange 'src/**/*.js' 'test/**/*.js' -- npm run test --silent"
   },
   "files": [

--- a/packages/create/test/generate-command.js
+++ b/packages/create/test/generate-command.js
@@ -1,0 +1,17 @@
+import { join } from 'path';
+
+const COMMAND_PATH = join(__dirname, '../src/create.js');
+
+export function generateCommand({ destinationPath = '.' } = {}) {
+  return `node -r @babel/register ${COMMAND_PATH} \
+      --destinationPath ${destinationPath} \
+      --type scaffold \
+      --scaffoldType app \
+      --features linting testing demoing building \
+      --buildingType rollup \
+      --scaffoldFilesFor testing demoing building \
+      --tagName scaffold-app \
+      --writeToDisk true \
+      --installDependencies false
+  `;
+}

--- a/packages/create/test/integration.test.js
+++ b/packages/create/test/integration.test.js
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { lstatSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { CLIEngine } from 'eslint';
+import { generateCommand } from './generate-command.js';
 
 const exec = promisify(_exec);
 
@@ -16,8 +17,6 @@ const { expect } = chai;
 chai.use(chaiFs);
 
 const getFileMessages = ({ messages, filePath }) => `${filePath}:\n${messages.join('\n')}`;
-
-const COMMAND_PATH = join(__dirname, '../src/create.js');
 
 const ACTUAL_PATH = join(process.cwd(), './scaffold-app');
 
@@ -81,18 +80,7 @@ describe('create', () => {
 
   const expectedPath = join(__dirname, './snapshots/fully-loaded-app');
 
-  const command = `node -r @babel/register \
-    ${COMMAND_PATH} \
-      --destinationPath ${destinationPath} \
-      --type scaffold \
-      --scaffoldType app \
-      --features linting testing demoing building \
-      --buildingType rollup \
-      --scaffoldFilesFor testing demoing building \
-      --tagName scaffold-app \
-      --writeToDisk true \
-      --installDependencies false
-  `;
+  const command = generateCommand({ destinationPath });
 
   before(generate({ command, expectedPath }));
 

--- a/packages/create/test/update-snapshots.js
+++ b/packages/create/test/update-snapshots.js
@@ -1,0 +1,24 @@
+import { join } from 'path';
+
+import { existsSync } from 'fs';
+
+import { execSync } from 'child_process';
+
+import { generateCommand } from './generate-command.js';
+
+const destinationPath = join(__dirname, './snapshots');
+
+const UPDATE_SNAPSHOTS_COMMAND = generateCommand({ destinationPath });
+
+execSync(UPDATE_SNAPSHOTS_COMMAND);
+
+// HACK(bennyp): destinationPath doesn't work.
+// see https://github.com/open-wc/open-wc/issues/1040
+const OOPS_I_WROTE_TO_PACKAGE_ROOT = join(process.cwd(), './scaffold-app');
+
+const DESTINATION_PATH = join(__dirname, './snapshots/fully-loaded-app');
+
+if (existsSync(OOPS_I_WROTE_TO_PACKAGE_ROOT)) {
+  execSync(`rm -rf ${DESTINATION_PATH}`);
+  execSync(`mv -f ${OOPS_I_WROTE_TO_PACKAGE_ROOT} ${DESTINATION_PATH}`);
+}


### PR DESCRIPTION
closes #1032

## What this PR does
adds a `test:update-snapshots` command to the create package which:
- executes the generator (in whichever state it's in, broken or not),
- then moves the output to the test/snapshots dir
    - (**NB**: `--destination-path` option is broken see #1040 )

## What this PR does NOT do
- does not generate the snapshot in packages/create/test/snapshots/fully-loaded-app.output.txt
I'd prefer to save that until after some refactors of the generator