### PR TITLE
Use `conservativeCollapse` in the `htmlMinifier` config.

### DIFF
--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -89,6 +89,7 @@ function createConfig(_options, legacy) {
                 },
                 htmlMinifier: {
                   collapseWhitespace: true,
+                  conservativeCollapse: true,
                   removeComments: true,
                   caseSensitive: true,
                   minifyCSS: customMinifyCss,

--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -79,6 +79,7 @@ module.exports = function createBasicConfig(_options) {
                 },
                 htmlMinifier: {
                   collapseWhitespace: true,
+                  conservativeCollapse: true,
                   removeComments: true,
                   caseSensitive: true,
                   minifyCSS: customMinifyCss,

--- a/packages/building-webpack/modern-and-legacy-config.js
+++ b/packages/building-webpack/modern-and-legacy-config.js
@@ -87,6 +87,7 @@ function createConfig(options, legacy) {
                     },
                     htmlMinifier: {
                       collapseWhitespace: true,
+                      conservativeCollapse: true,
                       removeComments: true,
                       caseSensitive: true,
                       minifyCSS: customMinifyCSS,

--- a/packages/building-webpack/modern-config.js
+++ b/packages/building-webpack/modern-config.js
@@ -87,6 +87,7 @@ module.exports = userOptions => {
                     },
                     htmlMinifier: {
                       collapseWhitespace: true,
+                      conservativeCollapse: true,
                       removeComments: true,
                       caseSensitive: true,
                       minifyCSS: customMinifyCSS,


### PR DESCRIPTION
fixes #1049 

Update the config of `htmlMinifier` touse `conservativeCollapse: true` so that multiple whitespaces will get collapsed to one whitespace instead of none. This is of particular benefit when adjacent to non-known `display: inline` elements, as `htmlMinifier` attempts to do this by default for known elements.