### PR TITLE
docs: document preserveSymlinks option

### DIFF
--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -82,17 +82,17 @@ es-dev-server requires node v10 or higher
 
 ### Code transformation
 
-| name                 | type         | description                                                                                  |
-| -------------------- | ------------ | -------------------------------------------------------------------------------------------- |
-| compatibility        | string       | Compatibility mode for older browsers. Can be: `auto`, `min`, `max` or `none` Default `auto` |
-| node-resolve         | number       | Resolve bare import imports using node resolve                                               |
-| preserve-symlinks    | boolean      | Preserve symlinks when resolving modules. Default false.                                     |
-| module-dirs          | string/array | Directories to resolve modules from. Used by node-resolve                                    |
-| babel                | boolean      | Transform served code through babel. Requires .babelrc                                       |
-| file-extensions      | number/array | Extra file extensions to use when transforming code.                                         |
-| babel-exclude        | number/array | Patterns of files to exclude from babel compilation.                                         |
-| babel-modern-exclude | number/array | Patterns of files to exclude from babel compilation on modern browsers.                      |
-| babel-module-exclude | number/array | Patterns of files to exclude from babel compilation for modules only.                        |
+| name                 | type         | description                                                                                                                     |
+| -------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| compatibility        | string       | Compatibility mode for older browsers. Can be: `auto`, `min`, `max` or `none` Default `auto`                                    |
+| node-resolve         | number       | Resolve bare import imports using node resolve                                                                                  |
+| preserve-symlinks    | boolean      | Preserve symlinks when resolving modules. Set to true, if using tools that rely on symlinks, such as `npm link`. Default false. |
+| module-dirs          | string/array | Directories to resolve modules from. Used by node-resolve                                                                       |
+| babel                | boolean      | Transform served code through babel. Requires .babelrc                                                                          |
+| file-extensions      | number/array | Extra file extensions to use when transforming code.                                                                            |
+| babel-exclude        | number/array | Patterns of files to exclude from babel compilation.                                                                            |
+| babel-modern-exclude | number/array | Patterns of files to exclude from babel compilation on modern browsers.                                                         |
+| babel-module-exclude | number/array | Patterns of files to exclude from babel compilation for modules only.                                                           |
 
 Most commands have an alias/shorthand. You can view them by using `--help`.
 

--- a/packages/es-dev-server/src/utils/resolve-module-imports.js
+++ b/packages/es-dev-server/src/utils/resolve-module-imports.js
@@ -155,7 +155,7 @@ async function resolveImport(rootDir, sourceFilePath, importPath, config, concat
       throw new Error(
         `Import "${importPath}" resolved to the file "${resolvedImportFilePath}" which is outside the root directory. ` +
           'Install the module locally in the current project, or expand the root directory. If this is a symlink or if you used npm link, ' +
-          ' you can use the preserveSymlinks option',
+          ' you can run es-dev-server with the --preserve-symlinks option',
       );
     }
 

--- a/packages/karma-esm/README.md
+++ b/packages/karma-esm/README.md
@@ -57,19 +57,20 @@ module.exports = {
 
 `karma-esm` can be configured with these options:
 
-| name            | type    | description                                                                                                   |
-| --------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
-| nodeResolve     | boolean | Transforms bare module imports using node resolve.                                                            |
-| coverage        | boolean | Whether to report test code coverage.                                                                         |
-| importMap       | string  | Path to import map used for testing.                                                                          |
-| compatibility   | string  | Compatibility level to run the `es-dev-server` with.                                                          |
-| coverageExclude | array   | Extra glob patterns of tests to exclude from coverage.                                                        |
-| babelConfig     | string  | Custom babel configuration file to run on served code.                                                        |
-| moduleDirs      | string  | Directories to resolve modules from. Defaults to `node_modules`                                               |
-| babel           | boolean | Whether to pick up a babel configuration file in your project.                                                |
-| fileExtensions  | array   | Custom file extensions to serve as es modules.                                                                |
-| polyfills       | object  | Polyfill configuration.                                                                                       |
-| devServerPort   | number  | port of server that serves the modules. Note that this is not the karma port. Picks a random port if not set. |
+| name             | type    | description                                                                                                   |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| nodeResolve      | boolean | Transforms bare module imports using node resolve.                                                            |
+| coverage         | boolean | Whether to report test code coverage.                                                                         |
+| importMap        | string  | Path to import map used for testing.                                                                          |
+| compatibility    | string  | Compatibility level to run the `es-dev-server` with.                                                          |
+| coverageExclude  | array   | Extra glob patterns of tests to exclude from coverage.                                                        |
+| babelConfig      | string  | Custom babel configuration file to run on served code.                                                        |
+| moduleDirs       | string  | Directories to resolve modules from. Defaults to `node_modules`                                               |
+| babel            | boolean | Whether to pick up a babel configuration file in your project.                                                |
+| fileExtensions   | array   | Custom file extensions to serve as es modules.                                                                |
+| polyfills        | object  | Polyfill configuration.                                                                                       |
+| devServerPort    | number  | Port of server that serves the modules. Note that this is not the karma port. Picks a random port if not set. |
+| preserveSymlinks | boolean | Run the `es-dev-server` with the `--preserve-symlinks` option.                                                |
 
 ### nodeResolve
 
@@ -86,6 +87,12 @@ Due to a bug in karma, the test coverage reporter causes browser logs to appear 
 The compatibility option makes your code compatible with older browsers. It loads polyfills and transforms modern syntax where needed. For testing, it's best to leave this at 'none' for no modifications, or 'all' for full compatibility.
 
 See [the documentation of the dev server](https://open-wc.org/developing/es-dev-server.html) for information on all the different modes.
+
+### preserveSymlinks
+
+The `es-dev-server` by default resolves the symlinks in the dependency directory. This can cause problem when you're using `npm link` command or other tools which rely on them. This option will make `es-dev-server` preserve symlinks.
+
+See [the documentation of the dev server](https://open-wc.org/developing/es-dev-server.html) for more information.
 
 ## Karma preprocessors
 

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -164,6 +164,23 @@ When testing without a bundler you will be serving every imported module straigh
 
 In a monorepo dependencies are often two levels higher in the root of the repository. To run tests in a monorepository you either have to put your config in the root of the repository, or adjust the basePath in your karma config:
 
+### Preserving symlinks
+
+When using a tool that relies on symlinks such as `npm link` or `lerna`, the `es-dev-server` that runs under the hood of `karma-esm` plugin needs to be ran with `--preserve-symlinks` option.
+
+You can pass this option via the `esm` plugin configuration:
+
+```js
+  ...
+  esm: {
+    nodeResolve: true,
+    preserveSymlinks: true,
+  },
+  ...
+```
+
+[Check out the documentaton](https://open-wc.org/testing/karma-esm.html) for more information.
+
 ### Other configuration
 
 `karma-esm` is the plugin powering our configuration, and it supports a few more for advanced use cases. [Check out the documentaton](https://open-wc.org/testing/karma-esm.html) for more information.


### PR DESCRIPTION
- Add mentions of `preserveSymlinks` option to `karma-esm` and `testing-karma` docs
- Improve `es-dev-server` doc
- Improve `preserveSymlink` related error message, to be more useful when it comes up while trying to run tests