### PR TITLE
feat(es-dev-server): allow max compat on modern browsers

### DIFF
--- a/packages/building-utils/index-html/create-index-html.js
+++ b/packages/building-utils/index-html/create-index-html.js
@@ -49,7 +49,7 @@ const { createContentHash, cleanImportPath, polyfillFilename } = require('./util
 /**
  * @typedef {object} PolyfillsConfig
  * @property {boolean} [coreJs] whether to polyfill core-js polyfills
- * @property {boolean} [regeneratorRuntime] whether to add regenerator runtime
+ * @property {boolean | string} [regeneratorRuntime] whether to add regenerator runtime
  * @property {boolean} [webcomponents] whether to polyfill webcomponents
  * @property {boolean} [fetch] whether to polyfill fetch
  * @property {boolean} [intersectionObserver] whether to polyfill intersection observer

--- a/packages/building-utils/index-html/polyfills.js
+++ b/packages/building-utils/index-html/polyfills.js
@@ -72,7 +72,12 @@ function getPolyfills(config) {
       instructions.push({
         name: 'regenerator-runtime',
         path: require.resolve('regenerator-runtime/runtime'),
-        nomodule: true,
+        /**
+         * Regenerator runtime is necessary when compiling to es5, which we generally only do on browsers
+         * which don't support modules. Using the nomodule flag means we don't need to load the library on
+         * other browsers. This can be overwritten by setting the value to 'always'
+         */
+        nomodule: config.polyfills.regeneratorRuntime !== 'always',
       });
     } catch (error) {
       throw new Error(

--- a/packages/es-dev-server/src/utils/polyfills-presets.js
+++ b/packages/es-dev-server/src/utils/polyfills-presets.js
@@ -12,7 +12,17 @@ const allWithSystemjs = {
   systemJsExtended: true,
 };
 
+/**
+ * In max compatibility mode, we need to load the regenerator runtime on all browsers since
+ * we're always compiling to es5.
+ */
+const max = {
+  ...allWithSystemjs,
+  regeneratorRuntime: 'always',
+};
+
 export const polyfillsPresets = {
   all,
+  max,
   allWithSystemjs,
 };

--- a/packages/es-dev-server/src/utils/transform-index-html.js
+++ b/packages/es-dev-server/src/utils/transform-index-html.js
@@ -4,6 +4,8 @@ import { polyfillsPresets } from './polyfills-presets.js';
 import { addPolyfilledImportMaps } from './import-maps.js';
 import { compatibilityModes, polyfillsModes } from '../constants.js';
 
+const regexpSystemJs = /(<script src=["|']polyfills\/system.*?><\/script>)/g;
+
 /**
  * @typedef {object} TransformIndexHTMLConfig
  * @property {string} indexUrl
@@ -23,7 +25,7 @@ function getPolyfills(cfg) {
 
   switch (cfg.compatibilityMode) {
     case compatibilityModes.MAX:
-      return polyfillsPresets.allWithSystemjs;
+      return polyfillsPresets.max;
     case compatibilityModes.MIN:
       return polyfillsPresets.all;
     case compatibilityModes.AUTO:
@@ -95,7 +97,8 @@ export function getTransformedIndexHTML(cfg) {
 
   // inject systemjs resolver which appends a query param to trigger es5 compilation
   if (polyfillModules) {
-    indexHTML = indexHTML.replace('</body>', `${systemJsLegacyResolveScript}</body>`);
+    // inject resolver right after system js script, to make sure it's loaded before and systemjs imports
+    indexHTML = indexHTML.replace(regexpSystemJs, `$1 \n${systemJsLegacyResolveScript}`);
   }
 
   return {

--- a/packages/es-dev-server/test/integration/integration.test.js
+++ b/packages/es-dev-server/test/integration/integration.test.js
@@ -38,7 +38,7 @@ const testCases = [
 
 describe('integration tests', () => {
   testCases.forEach(testCase => {
-    ['auto', 'min', 'always'].forEach(compatibility => {
+    ['auto', 'always', 'min', 'max'].forEach(compatibility => {
       describe(`testcase ${testCase.name}-${compatibility}`, () => {
         let server;
         let serverConfig;

--- a/packages/es-dev-server/test/snapshots/transform-index-html/import-map-max.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/import-map-max.html
@@ -26,7 +26,21 @@
 
 
 
-<script src="polyfills/core-js.77da473353460b142f5e09e540324336.js" nomodule=""></script><script src="polyfills/systemjs.dd4729ef25f652d7d05aed80a2ea00e7.js"></script><script src="polyfills/regenerator-runtime.45f8b90cc0fac37d446d8da4b68e27f5.js" nomodule=""></script><script>(function() {
+<script src="polyfills/core-js.77da473353460b142f5e09e540324336.js" nomodule=""></script><script src="polyfills/systemjs.dd4729ef25f652d7d05aed80a2ea00e7.js"></script> 
+
+<script>
+  (function() {
+    // appends a query param to each systemjs request to trigger es5 compilation
+    var originalResolve = System.constructor.prototype.resolve;
+    System.constructor.prototype.resolve = function () {
+      return Promise.resolve(originalResolve.apply(this, arguments))
+        .then(function (url) {
+          return url + (url.indexOf('?') > 0 ? '&' : '?') + 'transform-module';
+        });
+    };
+  })()
+</script>
+<script src="polyfills/regenerator-runtime.45f8b90cc0fac37d446d8da4b68e27f5.js"></script><script>(function() {
   function loadScript(src, module) {
     return new Promise(function (resolve, reject) {
       document.head.appendChild(Object.assign(
@@ -47,17 +61,4 @@
   }
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
-})();</script>
-<script>
-  (function() {
-    // appends a query param to each systemjs request to trigger es5 compilation
-    var originalResolve = System.constructor.prototype.resolve;
-    System.constructor.prototype.resolve = function () {
-      return Promise.resolve(originalResolve.apply(this, arguments))
-        .then(function (url) {
-          return url + (url.indexOf('?') > 0 ? '&' : '?') + 'transform-module';
-        });
-    };
-  })()
-</script>
-</body></html>
+})();</script></body></html>

--- a/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-max.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/inline-module-max.html
@@ -12,7 +12,21 @@
 
 
 
-<script src="polyfills/core-js.77da473353460b142f5e09e540324336.js" nomodule=""></script><script src="polyfills/systemjs.dd4729ef25f652d7d05aed80a2ea00e7.js"></script><script src="polyfills/regenerator-runtime.45f8b90cc0fac37d446d8da4b68e27f5.js" nomodule=""></script><script>(function() {
+<script src="polyfills/core-js.77da473353460b142f5e09e540324336.js" nomodule=""></script><script src="polyfills/systemjs.dd4729ef25f652d7d05aed80a2ea00e7.js"></script> 
+
+<script>
+  (function() {
+    // appends a query param to each systemjs request to trigger es5 compilation
+    var originalResolve = System.constructor.prototype.resolve;
+    System.constructor.prototype.resolve = function () {
+      return Promise.resolve(originalResolve.apply(this, arguments))
+        .then(function (url) {
+          return url + (url.indexOf('?') > 0 ? '&' : '?') + 'transform-module';
+        });
+    };
+  })()
+</script>
+<script src="polyfills/regenerator-runtime.45f8b90cc0fac37d446d8da4b68e27f5.js"></script><script>(function() {
   function loadScript(src, module) {
     return new Promise(function (resolve, reject) {
       document.head.appendChild(Object.assign(
@@ -33,17 +47,4 @@
   }
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
-})();</script>
-<script>
-  (function() {
-    // appends a query param to each systemjs request to trigger es5 compilation
-    var originalResolve = System.constructor.prototype.resolve;
-    System.constructor.prototype.resolve = function () {
-      return Promise.resolve(originalResolve.apply(this, arguments))
-        .then(function (url) {
-          return url + (url.indexOf('?') > 0 ? '&' : '?') + 'transform-module';
-        });
-    };
-  })()
-</script>
-</body></html>
+})();</script></body></html>

--- a/packages/es-dev-server/test/snapshots/transform-index-html/simple-max.html
+++ b/packages/es-dev-server/test/snapshots/transform-index-html/simple-max.html
@@ -15,7 +15,21 @@
 
 
 
-<script src="polyfills/core-js.77da473353460b142f5e09e540324336.js" nomodule=""></script><script src="polyfills/systemjs.dd4729ef25f652d7d05aed80a2ea00e7.js"></script><script src="polyfills/regenerator-runtime.45f8b90cc0fac37d446d8da4b68e27f5.js" nomodule=""></script><script>(function() {
+<script src="polyfills/core-js.77da473353460b142f5e09e540324336.js" nomodule=""></script><script src="polyfills/systemjs.dd4729ef25f652d7d05aed80a2ea00e7.js"></script> 
+
+<script>
+  (function() {
+    // appends a query param to each systemjs request to trigger es5 compilation
+    var originalResolve = System.constructor.prototype.resolve;
+    System.constructor.prototype.resolve = function () {
+      return Promise.resolve(originalResolve.apply(this, arguments))
+        .then(function (url) {
+          return url + (url.indexOf('?') > 0 ? '&' : '?') + 'transform-module';
+        });
+    };
+  })()
+</script>
+<script src="polyfills/regenerator-runtime.45f8b90cc0fac37d446d8da4b68e27f5.js"></script><script>(function() {
   function loadScript(src, module) {
     return new Promise(function (resolve, reject) {
       document.head.appendChild(Object.assign(
@@ -36,17 +50,4 @@
   }
 
   polyfills.length ? Promise.all(polyfills).then(loadEntries) : loadEntries();
-})();</script>
-<script>
-  (function() {
-    // appends a query param to each systemjs request to trigger es5 compilation
-    var originalResolve = System.constructor.prototype.resolve;
-    System.constructor.prototype.resolve = function () {
-      return Promise.resolve(originalResolve.apply(this, arguments))
-        .then(function (url) {
-          return url + (url.indexOf('?') > 0 ? '&' : '?') + 'transform-module';
-        });
-    };
-  })()
-</script>
-</body></html>
+})();</script></body></html>


### PR DESCRIPTION
Loads regenerator runtime on modern browsers as well in max compat mode, this way you can use max compat as a fallback to work anywhere.