### PR TITLE
docs: fix HelixUI link

### DIFF
--- a/docs/guide/component-libraries.md
+++ b/docs/guide/component-libraries.md
@@ -18,7 +18,7 @@ The hardest part of any project is often getting content onto that first blank p
 
   The Elix project aims to create a universal library of all general-purpose user interface patterns commonly found in desktop and mobile UIs, where each pattern is implemented as a well-designed, attractive, high-quality, performant, accessible, localizable, and extensively customizable web component.
 
-- [HelixUI](https://rackerlabs.github.io/helix-ui/)
+- [HelixUI](https://helixdesignsystem.github.io/helix-ui/)
 
   The HelixUI library provides front-end developers a set of reusable CSS classes and HTML Custom Elements that adhere to Helix design standards, as outlined by Rackspace.
 


### PR DESCRIPTION
HelixUi demo link can be found at https://github.com/HelixDesignSystem/helix-ui
It's now https://helixdesignsystem.github.io/helix-ui/
Previous link https://rackerlabs.github.io/helix-ui/ is returning 404