### PR TITLE
fix(es-dev-server): compile generated systemjs template literals

### DIFF
--- a/packages/es-dev-server/demo/syntax/index.html
+++ b/packages/es-dev-server/demo/syntax/index.html
@@ -60,6 +60,7 @@
         importMeta: window.__importMeta || false,
         staticImports: window.__staticImports || false,
         dynamicImports: await window.__dynamicImports || false,
+        dynamicImportsString: await window.__dynamicImportsString || false,
       };
       document.getElementById('test').innerHTML = `<pre>${JSON.stringify(window.__tests, null, 2)}</pre>`;
     })();

--- a/packages/es-dev-server/demo/syntax/module-features.js
+++ b/packages/es-dev-server/demo/syntax/module-features.js
@@ -1,6 +1,9 @@
 import { html, render } from 'lit-html';
 import module from './module-features-a.js';
 
+const featuresB = 'features-b';
+
 window.__importMeta = import.meta.url.indexOf('syntax/module-features.js') > 0;
 window.__staticImports = module === 'moduleFeaturesA';
 window.__dynamicImports = (async () => (await import('./module-features-b.js')).default === 'moduleFeaturesB')();
+window.__dynamicImportsString = (async () => (await import(`./module-${featuresB}.js`)).default === 'moduleFeaturesB')();

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -57,6 +57,7 @@
     "@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0",
     "@babel/plugin-syntax-numeric-separator": "^7.2.0",
     "@babel/plugin-syntax-optional-chaining": "^7.2.0",
+    "@babel/plugin-transform-template-literals": "^7.7.4",
     "@babel/preset-env": "^7.7.1",
     "@open-wc/building-utils": "^2.10.7",
     "@types/minimatch": "^3.0.3",

--- a/packages/es-dev-server/src/utils/babel-transform.js
+++ b/packages/es-dev-server/src/utils/babel-transform.js
@@ -116,6 +116,9 @@ export const polyfillModulesTransform = createBabelTransform(
     plugins: [
       require.resolve('@babel/plugin-proposal-dynamic-import'),
       require.resolve('@babel/plugin-transform-modules-systemjs'),
+      // systemjs adds template literals, we do systemjs after (potential)
+      // es5 compilation so we need to ensure it stays es5
+      require.resolve('@babel/plugin-transform-template-literals'),
     ],
     babelrc: false,
     configFile: false,

--- a/packages/es-dev-server/test/integration/integration.test.js
+++ b/packages/es-dev-server/test/integration/integration.test.js
@@ -11,7 +11,13 @@ const testCases = [
   },
   {
     name: 'syntax',
-    tests: ['inlineStage4', 'importMeta', 'staticImports', 'dynamicImports'],
+    tests: [
+      'inlineStage4',
+      'importMeta',
+      'staticImports',
+      'dynamicImports',
+      'dynamicImportsString',
+    ],
   },
   {
     name: 'node-resolve',

--- a/packages/es-dev-server/test/middleware/compatibility-transform.test.js
+++ b/packages/es-dev-server/test/middleware/compatibility-transform.test.js
@@ -31,8 +31,14 @@ async function fetchText(url, userAgent) {
 }
 
 async function expectCompatibilityTransform(userAgent, features = {}) {
-  const stage4Features = await fetchText('stage-4-features.js?transform-modules', userAgent);
-  const esModules = await fetchText('module-features.js?transform-modules', userAgent);
+  const stage4Features = await fetchText(
+    `stage-4-features.js${features.esModules ? '?transform-modules' : ''}`,
+    userAgent,
+  );
+  const esModules = await fetchText(
+    `module-features.js${features.esModules ? '?transform-modules' : ''}`,
+    userAgent,
+  );
 
   expect(stage4Features).to.include(
     features.objectSpread ? '_objectSpread({}, foo);' : 'bar = { ...foo',
@@ -152,12 +158,14 @@ describe('compatibility transform middleware', () => {
     it('transforms for Chrome 62', async () => {
       await expectCompatibilityTransform(userAgents['Chrome 62'], {
         esModules: true,
+        templateLiteral: true,
       });
     });
 
     it('transforms for Chrome 63', async () => {
       await expectCompatibilityTransform(userAgents['Chrome 63'], {
         esModules: true,
+        templateLiteral: true,
       });
     });
 
@@ -188,6 +196,7 @@ describe('compatibility transform middleware', () => {
       await expectCompatibilityTransform(userAgents['Edge 18'], {
         objectSpread: true,
         esModules: true,
+        templateLiteral: true,
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,6 +82,13 @@
   dependencies:
     "@babel/types" "^7.7.0"
 
+"@babel/helper-annotate-as-pure@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz#bb3faf1e74b74bd547e867e48f551fa6b098b6ce"
+  integrity sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==
+  dependencies:
+    "@babel/types" "^7.7.4"
+
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.1.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.0.tgz#32dd9551d6ed3a5fc2edc50d6912852aa18274d9"
@@ -717,6 +724,14 @@
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-template-literals@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz#1eb6411736dd3fe87dbd20cc6668e5121c17d604"
+  integrity sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-typeof-symbol@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
@@ -909,6 +924,15 @@
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.2.tgz#550b82e5571dcd174af576e23f0adba7ffc683f7"
   integrity sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
+  integrity sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -2106,16 +2130,16 @@
     standard-version "^7.0.1"
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.9"
+  version "1.3.11"
   dependencies:
-    "@open-wc/testing-karma" "^3.2.9"
+    "@open-wc/testing-karma" "^3.2.11"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.2.9"
+  version "3.2.11"
   dependencies:
-    "@open-wc/karma-esm" "^2.11.2"
+    "@open-wc/karma-esm" "^2.11.4"
     axe-core "^3.3.1"
     karma "^4.1.0"
     karma-chrome-launcher "^2.0.0"


### PR DESCRIPTION
Apparently the module transform adds template literals in some situations, we need to compile those away for IE11.

Fixes https://github.com/open-wc/open-wc/issues/1083