### PR TITLE
feat(es-dev-server): add module dedupe option

### DIFF
--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -87,7 +87,7 @@ es-dev-server requires node v10 or higher
 | -------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | compatibility        | string        | Compatibility mode for older browsers. Can be: `auto`, `always`, `min`, `max` or `none` Default `auto`                          |
 | node-resolve         | boolean       | Resolve bare import imports using node resolve                                                                                  |
-| dedupe               | boolean/array | Deduplicates all or specified packages' modules                                                                                 |
+| dedupe               | boolean/array | Deduplicates all modules, or modules from specified packages if the value is an array                                           |
 | preserve-symlinks    | boolean       | Preserve symlinks when resolving modules. Set to true, if using tools that rely on symlinks, such as `npm link`. Default false. |
 | module-dirs          | string/array  | Directories to resolve modules from. Used by node-resolve                                                                       |
 | babel                | boolean       | Transform served code through babel. Requires .babelrc                                                                          |

--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -11,8 +11,9 @@ npx es-dev-server --node-resolve --watch
 **Quick overview**
 
 - efficient browser caching for fast reloads
-- [transform code on older browsers for compatibility](#Compatibility%20mode)
-- [resolve bare module imports for use in the browser](#Node%20resolve) (`--node-resolve`)
+- [transform code on older browsers for compatibility](#compatibility-mode)
+- [resolve bare module imports for use in the browser](#node-resolve) (`--node-resolve`)
+- [deduplicate multiple installations of the same package](#dedupe)
 - auto reload the browser on file changes with the (`--watch`)
 - history API fallback for SPA routing with the (`--app-index index.html`)
 
@@ -43,7 +44,7 @@ Add scripts to your `package.json`, modify the flags as needed:
 ```json
 {
   "scripts": {
-    "start": "es-dev-server --app-index index.html --node-resolve --watch --open"
+    "start": "es-dev-server --app-index index.html --node-resolve --dedupe --watch --open"
   }
 }
 ```
@@ -82,17 +83,18 @@ es-dev-server requires node v10 or higher
 
 ### Code transformation
 
-| name                 | type         | description                                                                                                                     |
-| -------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| compatibility        | string       | Compatibility mode for older browsers. Can be: `auto`, `always`, `min`, `max` or `none` Default `auto`                          |
-| node-resolve         | number       | Resolve bare import imports using node resolve                                                                                  |
-| preserve-symlinks    | boolean      | Preserve symlinks when resolving modules. Set to true, if using tools that rely on symlinks, such as `npm link`. Default false. |
-| module-dirs          | string/array | Directories to resolve modules from. Used by node-resolve                                                                       |
-| babel                | boolean      | Transform served code through babel. Requires .babelrc                                                                          |
-| file-extensions      | number/array | Extra file extensions to use when transforming code.                                                                            |
-| babel-exclude        | number/array | Patterns of files to exclude from babel compilation.                                                                            |
-| babel-modern-exclude | number/array | Patterns of files to exclude from babel compilation on modern browsers.                                                         |
-| babel-module-exclude | number/array | Patterns of files to exclude from babel compilation for modules only.                                                           |
+| name                 | type          | description                                                                                                                     |
+| -------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| compatibility        | string        | Compatibility mode for older browsers. Can be: `auto`, `always`, `min`, `max` or `none` Default `auto`                          |
+| node-resolve         | boolean       | Resolve bare import imports using node resolve                                                                                  |
+| dedupe               | boolean/array | Deduplicates all or specified packages' modules                                                                                 |
+| preserve-symlinks    | boolean       | Preserve symlinks when resolving modules. Set to true, if using tools that rely on symlinks, such as `npm link`. Default false. |
+| module-dirs          | string/array  | Directories to resolve modules from. Used by node-resolve                                                                       |
+| babel                | boolean       | Transform served code through babel. Requires .babelrc                                                                          |
+| file-extensions      | number/array  | Extra file extensions to use when transforming code.                                                                            |
+| babel-exclude        | number/array  | Patterns of files to exclude from babel compilation.                                                                            |
+| babel-modern-exclude | number/array  | Patterns of files to exclude from babel compilation on modern browsers.                                                         |
+| babel-module-exclude | number/array  | Patterns of files to exclude from babel compilation for modules only.                                                           |
 
 Most commands have an alias/shorthand. You can view them by using `--help`.
 
@@ -137,6 +139,26 @@ import foo from './node_modules/bar/bar.js';
 Because we use [es-module-lexer](https://github.com/guybedford/es-module-lexer) for blazing fast analysis, we can do this without noticeable impact on performance.
 
 In future, we are hoping that [import maps](https://github.com/WICG/import-maps) will make this step unnecessary.
+
+## Dedupe
+
+When your dependencies depend on different versions of the same package, package managers like yarn or npm may end up installing multiple versions of the same package with nested `node_modules` directories. This can create problems when modules expect to be singletons on the page, or when it includes side-effects such as custom element registration which can only be run once.
+
+You can use the `dedupe` option to ensure a particular package is only loaded once by resolving from the root of the package instead of relative to the originating module.
+
+When `dedupe` is a boolean, all packages are deduplicated:
+
+```bash
+es-dev-server --dedupe
+```
+
+When it is an array, only the specified packages are deduplicated. An array can only be set from a config:
+
+```javascript
+module.exports = {
+  dedupe: ['foo', 'bar'],
+};
+```
 
 ## Folder structure
 

--- a/packages/es-dev-server/demo/dedupe/index.html
+++ b/packages/es-dev-server/demo/dedupe/index.html
@@ -1,0 +1,19 @@
+<html>
+
+<head>
+  <base href="/packages/es-dev-server/demo/dedupe/">
+</head>
+
+<body>
+  <img width="100" src="../logo.png">
+
+  <h1>Dedupe demo</h1>
+  <p>A demo which demonstrated deduplicating imports</p>
+
+  <div id="test"></div>
+
+  <script type="module" src="./index.js"></script>
+
+</body>
+
+</html>

--- a/packages/es-dev-server/demo/dedupe/index.js
+++ b/packages/es-dev-server/demo/dedupe/index.js
@@ -1,0 +1,9 @@
+import { html as htmlRoot } from '../../../../node_modules/lit-html/lit-html.js';
+import { cache as cacheRoot } from '../../../../node_modules/lit-html/directives/cache.js';
+import { html as htmlBare } from 'lit-html';
+import { cache as cacheBare } from 'lit-html/directives/cache.js';
+
+document.getElementById('test').innerHTML = `
+  <p>Deduplicated bare import: ${htmlRoot === htmlBare}</p>
+  <p>Deduplicated nested bare import: ${cacheRoot === cacheBare}</p>
+`;

--- a/packages/es-dev-server/demo/dedupe/server.js
+++ b/packages/es-dev-server/demo/dedupe/server.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = {
+  rootDir: path.resolve(__dirname, '../../../../'),
+  appIndex: 'packages/es-dev-server/demo/dedupe/index.html',
+  nodeResolve: true,
+  dedupe: true,
+};

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -26,6 +26,7 @@
     "prepublishOnly": "npm run build && ../../scripts/insert-header.js",
     "start:babel": "yarn build && node dist/cli.js -c demo/babel/server.js --open --watch",
     "start:base-path": "yarn build && node dist/cli.js -c demo/base-path/server.js",
+    "start:dedupe": "yarn build && node dist/cli.js -c demo/dedupe/server.js --open --watch",
     "start:http2": "yarn build && node dist/cli.js -c demo/http2/server.js",
     "start:import-map": "yarn build && node dist/cli.js -c demo/import-map/server.js",
     "start:node-resolve": "yarn build && node dist/cli.js -c demo/node-resolve/server.js --open --watch",

--- a/packages/es-dev-server/src/command-line-args.js
+++ b/packages/es-dev-server/src/command-line-args.js
@@ -96,6 +96,13 @@ export const commandLineOptions = [
     description: 'Resolve bare import imports using node resolve.',
   },
   {
+    name: 'dedupe',
+    alias: 'd',
+    type: Boolean,
+    description:
+      'Dedupe modules by resolving them always from the root, ensuring only one version of a package is ever resolved.',
+  },
+  {
     name: 'preserve-symlinks',
     type: Boolean,
     description:
@@ -215,6 +222,11 @@ export function readCommandLineArgs(argv = process.argv, config = {}) {
   }
 
   let { open } = options;
+
+  if ('dedupe' in options) {
+    options.dedupeModules = options.dedupe;
+    delete options.dedupe;
+  }
 
   // open can be a boolean nor a string. if it's a boolean from command line args,
   // it's passed as null. so if it's not a string or boolean type, we check for the

--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -46,6 +46,7 @@ export function createMiddlewares(config, fileWatcher) {
     extraFileExtensions,
     moduleDirectories,
     nodeResolve,
+    dedupeModules,
     preserveSymlinks,
     readUserBabelConfig,
     rootDir,
@@ -139,6 +140,7 @@ export function createMiddlewares(config, fileWatcher) {
         babelModernExclude,
         babelModuleExclude,
         nodeResolve,
+        dedupeModules,
         preserveSymlinks,
       }),
     );

--- a/packages/es-dev-server/src/middleware/compatibility-transform.js
+++ b/packages/es-dev-server/src/middleware/compatibility-transform.js
@@ -18,6 +18,7 @@ import { getUserAgentCompat } from '../utils/user-agent-compat.js';
  * @property {string[]} moduleDirectories
  * @property {boolean} readUserBabelConfig
  * @property {boolean} nodeResolve
+ * @property {(path: string) => boolean} dedupeModules
  * @property {string} compatibilityMode
  * @property {object} [customBabelConfig]
  * @property {string[]} extraFileExtensions

--- a/packages/es-dev-server/src/utils/compatibility-transform.js
+++ b/packages/es-dev-server/src/utils/compatibility-transform.js
@@ -19,6 +19,7 @@ import { logDebug } from './utils.js';
  * @property {string[]} moduleDirectories
  * @property {boolean} readUserBabelConfig
  * @property {boolean} nodeResolve
+ * @property {(path: string) => boolean} dedupeModules
  * @property {string} compatibilityMode
  * @property {object} [customBabelConfig]
  * @property {string[]} extraFileExtensions
@@ -186,6 +187,7 @@ export function createCompatibilityTransform(cfg) {
         fileExtensions,
         moduleDirectories: cfg.moduleDirectories,
         preserveSymlinks: cfg.preserveSymlinks,
+        dedupeModules: cfg.dedupeModules,
       });
     }
 

--- a/packages/es-dev-server/test/fixtures/simple/node_modules/my-module-2/node_modules/my-module/index.js
+++ b/packages/es-dev-server/test/fixtures/simple/node_modules/my-module-2/node_modules/my-module/index.js
@@ -1,0 +1,3 @@
+console.log('my-module.js');
+
+export const message = 'my-module.js';

--- a/packages/es-dev-server/test/fixtures/simple/node_modules/my-module-2/node_modules/my-module/package.json
+++ b/packages/es-dev-server/test/fixtures/simple/node_modules/my-module-2/node_modules/my-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-module",
+  "main": "index.js"
+}

--- a/packages/es-dev-server/test/fixtures/simple/node_modules/my-module-2/node_modules/non-dedupable/package.json
+++ b/packages/es-dev-server/test/fixtures/simple/node_modules/my-module-2/node_modules/non-dedupable/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "non-dedupable",
+  "main": "index.js"
+}

--- a/packages/es-dev-server/test/snapshots/resolve-module-imports/deduped-node_modules.js
+++ b/packages/es-dev-server/test/snapshots/resolve-module-imports/deduped-node_modules.js
@@ -1,0 +1,4 @@
+
+      import '../my-module/index.js';
+      import '../my-module/bar/index.js';
+    

--- a/packages/es-dev-server/test/snapshots/resolve-module-imports/nested-node_modules.js
+++ b/packages/es-dev-server/test/snapshots/resolve-module-imports/nested-node_modules.js
@@ -1,0 +1,4 @@
+
+      import './node_modules/my-module/index.js';
+      import './node_modules/my-module/bar/index.js';
+    

--- a/packages/es-dev-server/test/snapshots/resolve-module-imports/none-dedupable.js
+++ b/packages/es-dev-server/test/snapshots/resolve-module-imports/none-dedupable.js
@@ -1,0 +1,3 @@
+
+      import './node_modules/non-dedupable/index.js';
+    

--- a/packages/es-dev-server/test/snapshots/resolve-module-imports/relative-deduped-node_modules.js
+++ b/packages/es-dev-server/test/snapshots/resolve-module-imports/relative-deduped-node_modules.js
@@ -1,0 +1,3 @@
+
+      import './my-module-2.js';
+    

--- a/packages/es-dev-server/test/utils/resolve-module-imports.test.js
+++ b/packages/es-dev-server/test/utils/resolve-module-imports.test.js
@@ -263,9 +263,7 @@ describe('resolve-module-imports', () => {
       await resolveModuleImports(baseDir, sourceFileName, 'import "nope";', defaultConfig);
     } catch (error) {
       thrown = true;
-      expect(error.message).to.equal(
-        `Could not resolve "import { ... } from 'nope';" in "./src/foo.js".`,
-      );
+      expect(error.message).to.equal(`Could not resolve import "nope" in "./src/foo.js".`);
     }
 
     expect(thrown).to.equal(true);
@@ -303,6 +301,19 @@ describe('resolve-module-imports', () => {
       'relative-deduped-node_modules',
       `
       import './my-module-2';
+    `,
+      {
+        sourceFileName: path.resolve(baseDir, 'node_modules', 'my-module-2', 'foo.js'),
+        dedupeModules: () => true,
+      },
+    );
+  });
+
+  it('falls back to resolving relatively when a module could not be resolved from root', async () => {
+    await expectMatchesSnapshot(
+      'none-dedupable',
+      `
+      import 'non-dedupable';
     `,
       {
         sourceFileName: path.resolve(baseDir, 'node_modules', 'my-module-2', 'foo.js'),

--- a/packages/es-dev-server/test/utils/resolve-module-imports.test.js
+++ b/packages/es-dev-server/test/utils/resolve-module-imports.test.js
@@ -13,14 +13,20 @@ const defaultConfig = {
   fileExtensions: ['.mjs', '.js'],
   moduleDirectories: ['node_modules'],
   preserveSymlinks: false,
+  dedupeModules: () => false,
 };
 
 async function expectMatchesSnapshot(name, source, configOverrides = {}) {
   const file = path.resolve(snapshotsDir, `${name}.js`);
-  const resolvedSource = await resolveModuleImports(baseDir, sourceFileName, source, {
-    ...defaultConfig,
-    ...configOverrides,
-  });
+  const resolvedSource = await resolveModuleImports(
+    baseDir,
+    configOverrides.sourceFileName || sourceFileName,
+    source,
+    {
+      ...defaultConfig,
+      ...configOverrides,
+    },
+  );
 
   if (updateSnapshots) {
     fs.writeFileSync(file, resolvedSource, 'utf-8');
@@ -263,5 +269,45 @@ describe('resolve-module-imports', () => {
     }
 
     expect(thrown).to.equal(true);
+  });
+
+  it('resolves nested node_modules', async () => {
+    await expectMatchesSnapshot(
+      'nested-node_modules',
+      `
+      import 'my-module';
+      import 'my-module/bar/index.js';
+    `,
+      {
+        sourceFileName: path.resolve(baseDir, 'node_modules', 'my-module-2', 'foo.js'),
+      },
+    );
+  });
+
+  it('resolves from root node_modules when dedupe is enabled', async () => {
+    await expectMatchesSnapshot(
+      'deduped-node_modules',
+      `
+      import 'my-module';
+      import 'my-module/bar/index.js';
+    `,
+      {
+        sourceFileName: path.resolve(baseDir, 'node_modules', 'my-module-2', 'foo.js'),
+        dedupeModules: () => true,
+      },
+    );
+  });
+
+  it('does not resolve relative imports from root when dedupe is enabled', async () => {
+    await expectMatchesSnapshot(
+      'relative-deduped-node_modules',
+      `
+      import './my-module-2';
+    `,
+      {
+        sourceFileName: path.resolve(baseDir, 'node_modules', 'my-module-2', 'foo.js'),
+        dedupeModules: () => true,
+      },
+    );
   });
 });


### PR DESCRIPTION
This adds a `dedupe` option to go along with https://github.com/open-wc/open-wc/pull/1000. The implementation is actually identical to the rollup implementation, because we're both using the same resolve package underneath. There are some limitations I'd like to see different, but I'd rather keep both options in sync and try to fix them on rollup's side too.

TODO:
- [x] Add tests
- [x] Update docs
- [x] Figure out how to handle duplicates not in root
- [x] Figure out relative imports