### PR TITLE
feat(create): update building-rollup dependency

### DIFF
--- a/packages/create/src/generators/building-rollup/templates/_package.json
+++ b/packages/create/src/generators/building-rollup/templates/_package.json
@@ -4,7 +4,7 @@
     "build": "rimraf dist && rollup -c rollup.config.js"
   },
   "devDependencies": {
-    "@open-wc/building-rollup": "^0.14.3",
+    "@open-wc/building-rollup": "^0.15.1",
     "rimraf": "^2.6.3",
     "rollup": "^1.15.4"
   }


### PR DESCRIPTION
Releases below 0 are treated as breaking changes, so we need to keep this in sync.