### PR TITLE
feat(classes-in-html): add classes in HTML feature

### DIFF
--- a/packages/classes-in-html/LICENSE
+++ b/packages/classes-in-html/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 open-wc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/classes-in-html/README.md
+++ b/packages/classes-in-html/README.md
@@ -1,0 +1,108 @@
+# Classes in HTML
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
+
+Complex Web Component applications often are developed by several teams across organizations. In that scenario is common
+that shared component libraries are used by teams to create an homogeneous look and feel or just to avoid creating the
+same components several times, but as those libraries evolve name collision problems between different versions of the
+same library appear because teams are not able to evolve their code at the same velocity. That causes bottlenecks in
+software delivery that should be managed by the teams and complex build systems trying to alleviate the problem.
+
+[Scoped Custom Element Registries](https://github.com/w3c/webcomponents/issues/716) is a proposal that tries to fix that
+problem, but until is ready and we could use a polyfill in those browsers that do not implement it, auto scoping the
+custom elements is a workaround.
+
+This package allows you to forget about how the custom elements are defined inside the registry. It's going to register
+them for you scoping the name if necessary avoiding the class name collision and allowing you to use different versions
+of the same component in yours.
+
+## Installation
+
+```bash
+npm i --save @open-wc/classes-in-html
+```
+
+## How it works
+
+To use this feature you must import the `html` function from `@open-wc/classes-in-html`, import the custom element
+dependency classes and use them in the template literals just like any other parameter.
+
+```js
+import { LitElement } from 'lit-element';
+import { html } from '@open-wc/classes-in-html'; // <-- import the html function
+import MyButton from './MyButton.js'; // <-- import your dependency class
+
+export default class MyElement extends LitElement {
+  static get properties() {
+    return {
+      text: String,
+    };
+  }
+
+  render() {
+    return html`<${MyButton}>${this.text}</${MyButton}>`; // <-- use them just like other parameters
+  }
+}
+```
+
+Internally the library is going to transform the template literal into another template literal which is going to be
+processed finally by `lit-html`.
+
+`<${MyButton}>${this.text}</${MyButton}>` --> `<my-button>${this.text}</my-button>`
+
+In case `my-button` was already registered, then `my-button-1` is going to be used and so on.
+
+## When to use
+
+If you are creating a custom element that depends on other custom elements then you should use `classes-in-html` to
+forget about how those custom elements on which yours depends are defined in the registry.
+
+```js
+// MyElement.js
+import { LitElement } from 'lit-element';
+import { html } from '@open-wc/classes-in-html';
+import MyButton from './MyButton.js'; // your custom element depends on it
+
+export default class MyElement extends LitElement {
+  render() {
+    return html`
+      <${MyButton}>Click me!</${MyButton}>
+    `;
+  }
+}
+```
+
+## When not to use
+
+In the case you are developing a custom element that don't depends on other custom elements then you shouldn't use it.
+The reason of that is because there is a performance penalty on using it.
+
+```js
+// MyButton.js
+import { html, LitElement } from 'lit-element';
+
+export default class MyButton extends LitElement {
+  render() {
+    return html`
+      <button><slot></slot></button>
+    `;
+  }
+}
+```
+
+## Special thanks
+
+This package is inspired by [carehtml](https://github.com/bashmish/carehtml) and I would like to thank
+[@bashmish](https://github.com/bashmish) for his work on it.
+
+<script>
+  export default {
+    mounted() {
+      const editLink = document.querySelector('.edit-link a');
+      if (editLink) {
+        const url = editLink.href;
+        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/classes-in-html/README.md';
+      }
+    }
+  }
+</script>

--- a/packages/classes-in-html/index.js
+++ b/packages/classes-in-html/index.js
@@ -1,0 +1,4 @@
+import { html as litHtml } from 'lit-html';
+import { wrap } from './src/wrap.js';
+
+export const html = wrap(litHtml);

--- a/packages/classes-in-html/package.json
+++ b/packages/classes-in-html/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@open-wc/classes-in-html",
+  "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Allows to use custom element classes inside lit-html templates.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wc/open-wc.git",
+    "directory": "packages/classes-in-hmtl"
+  },
+  "author": "open-wc",
+  "homepage": "https://github.com/open-wc/open-wc/",
+  "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js"
+  },
+  "files": [
+    "*.d.ts",
+    "*.js",
+    "src"
+  ],
+  "keywords": [
+    "lit-html",
+    "lit-element",
+    "web components",
+    "utils",
+    "helpers"
+  ],
+  "peerDependencies": {
+    "lit-html": "^1.0.0"
+  },
+  "devDependencies": {
+    "@open-wc/testing": "^2.4.2"
+  },
+  "module": "index.js"
+}

--- a/packages/classes-in-html/src/cache.js
+++ b/packages/classes-in-html/src/cache.js
@@ -1,0 +1,28 @@
+const stringsCache = new WeakMap();
+
+export const getFromCache = (strings, values) => {
+  if (values.length === 0) {
+    return [strings];
+  }
+
+  const cached = stringsCache.get(strings);
+  if (!cached) {
+    return undefined; // cache failure
+  }
+
+  if (strings === cached.strings) {
+    return [strings, ...values];
+  }
+
+  for (let i = 0; i < cached.keys.length; i += 1) {
+    if (values[cached.keys[i][0]] !== cached.keys[i][1]) {
+      return undefined; // cache failure
+    }
+  }
+
+  return [cached.strings, ...cached.indexes.map(index => values[index])];
+};
+
+export const toCache = (key, { keys = {}, indexes = [], strings }) => {
+  stringsCache.set(key, { keys, indexes, strings });
+};

--- a/packages/classes-in-html/src/transform.js
+++ b/packages/classes-in-html/src/transform.js
@@ -1,0 +1,87 @@
+import { getFromCache, toCache } from './cache.js';
+
+const registeredElements = new Map();
+
+const toDashCase = name => {
+  const dashCaseLetters = [];
+
+  for (let i = 0, letter = name[0]; i < name.length; i += 1, letter = name[i]) {
+    const letterLowerCase = letter.toLowerCase();
+
+    if (letter !== letterLowerCase && i !== 0) {
+      dashCaseLetters.push('-');
+    }
+
+    dashCaseLetters.push(letterLowerCase);
+  }
+
+  return dashCaseLetters.join('');
+};
+
+const incrementTagName = (tag, counter, start = 1) => {
+  const newName = counter === start ? tag : `${tag}-${counter}`;
+  const elementRegistered = !!customElements.get(newName);
+
+  if (elementRegistered) {
+    return incrementTagName(tag, counter + 1, start);
+  }
+
+  return newName;
+};
+
+const getClassUniqueTag = klass => {
+  let tag = registeredElements.get(klass);
+  if (tag) {
+    return tag;
+  }
+
+  const name = klass.name && klass.name.replace(/[^a-zA-Z0-9]/g, '');
+
+  if (name) {
+    tag = toDashCase(name);
+    if (tag.indexOf('-') === -1) {
+      tag = `c-${tag}`;
+    }
+    tag = incrementTagName(tag, 1);
+  } else {
+    tag = incrementTagName('c', 1, 0);
+  }
+
+  customElements.define(tag, class extends klass {});
+  registeredElements.set(klass, tag);
+
+  return tag;
+};
+
+const isCustomElement = element => element.prototype instanceof HTMLElement;
+
+export const transform = (strings, values) => {
+  const cached = getFromCache(strings, values);
+  if (cached) {
+    return cached;
+  }
+
+  const keys = [];
+  const indexes = [];
+  const newValues = [];
+  const newStrings = [strings[0]];
+
+  values.forEach((value, index) => {
+    if (isCustomElement(value)) {
+      keys.push([index, value]);
+      newStrings[newStrings.length - 1] += getClassUniqueTag(value) + strings[index + 1];
+    } else {
+      indexes.push(index);
+      newValues.push(value);
+      newStrings.push(strings[index + 1]);
+    }
+  });
+
+  toCache(strings, {
+    keys,
+    indexes,
+    strings: keys.length > 0 ? newStrings : strings,
+  });
+
+  return [newStrings, ...newValues];
+};

--- a/packages/classes-in-html/src/wrap.js
+++ b/packages/classes-in-html/src/wrap.js
@@ -1,0 +1,3 @@
+import { transform } from './transform.js';
+
+export const wrap = f => (strings, ...values) => f(...transform(strings, values));

--- a/packages/classes-in-html/test/cache.test.js
+++ b/packages/classes-in-html/test/cache.test.js
@@ -1,0 +1,74 @@
+import { expect } from '@open-wc/testing';
+import { getFromCache, toCache } from '../src/cache.js';
+
+describe('cache', () => {
+  it("should return [strings] if 'values' are empty", () => {
+    const strings = ['sample'];
+    const values = [];
+
+    const when = getFromCache(strings, values);
+
+    expect(when).to.be.an('array');
+    expect(when[0]).to.be.equals(strings);
+    expect(when.length).to.be.equals(1);
+  });
+
+  it("should return undefined if 'strings' is not registered", () => {
+    const strings = ['sample'];
+    const values = ['A'];
+
+    const when = getFromCache(strings, values);
+
+    expect(when).to.be.undefined;
+  });
+
+  it("should return the same 'strings' and 'values' when cached strings are the same than provided strings", () => {
+    const strings = ['sample'];
+    const values = ['A'];
+    toCache(strings, { strings });
+
+    const [newStrings, ...newValues] = getFromCache(strings, values);
+
+    expect(newStrings).to.be.equal(strings);
+    expect(newValues).to.be.deep.equal(values);
+  });
+
+  it('should return undefined if there is a cache failure', () => {
+    const ClassA = class extends HTMLElement {};
+    const ClassB = class extends HTMLElement {};
+    const strings = ['<', '>', '</', '>'];
+    const values = [ClassB, 'text sample', ClassB];
+    toCache(strings, {
+      keys: [
+        [0, ClassA],
+        [2, ClassA],
+      ],
+      indexes: [1],
+      strings: ['<x-a>', '</x-a>'],
+    });
+
+    const when = getFromCache(strings, values);
+
+    expect(when).to.be.undefined;
+  });
+
+  it("should return the cached 'string' with the transformed 'values' if cache matches", () => {
+    const ClassA = class extends HTMLElement {};
+    const strings = ['<', '>', '</', '>'];
+    const values = [ClassA, 'text sample', ClassA];
+    const transformedStrings = ['<x-a>', '</x-a>'];
+    toCache(strings, {
+      keys: [
+        [0, ClassA],
+        [2, ClassA],
+      ],
+      indexes: [1],
+      strings: transformedStrings,
+    });
+
+    const [newStrings, ...newValues] = getFromCache(strings, values);
+
+    expect(newStrings).to.be.equal(transformedStrings);
+    expect(newValues).to.be.deep.equal(['text sample']);
+  });
+});

--- a/packages/classes-in-html/test/transform.test.js
+++ b/packages/classes-in-html/test/transform.test.js
@@ -1,0 +1,200 @@
+import { expect } from '@open-wc/testing';
+import { transform } from '../src/transform.js';
+import { toCache } from '../src/cache.js';
+
+const testHtml = (strings, ...values) => [strings, values];
+const getNameForCEClass = klass => transform(['', ''], [klass])[0][0];
+
+describe('transform', () => {
+  it('registers names for Custom Element classes in values and concatenates strings with those names', () => {
+    class MyTulip extends HTMLElement {}
+
+    const [strings, ...values] = transform(
+      ...testHtml`<${MyTulip} id="${'my-id'}">${'my text'}</${MyTulip}>`,
+    );
+    expect(strings).to.deep.equal(['<my-tulip id="', '">', '</my-tulip>']);
+    expect(values).to.deep.equal(['my-id', 'my text']);
+    expect(customElements.get('my-tulip').prototype instanceof MyTulip).to.be.true;
+  });
+
+  it('should return the cached value if there is a match', () => {
+    const ClassA = class extends HTMLElement {};
+    const strings = ['<', '>', '</', '>'];
+    const values = [ClassA, 'text sample', ClassA];
+    const transformedStrings = ['<x-a>', '</x-a>'];
+    toCache(strings, {
+      keys: [
+        [0, ClassA],
+        [2, ClassA],
+      ],
+      indexes: [1],
+      strings: transformedStrings,
+    });
+
+    const [newStrings, ...newValues] = transform(strings, values);
+
+    expect(newStrings).to.be.equal(transformedStrings);
+    expect(newValues).to.be.deep.equal(['text sample']);
+  });
+
+  it('should replace the cached value if there is a cache failure', () => {
+    const ClassA = class extends HTMLElement {};
+    const ClassB = class extends HTMLElement {};
+    const strings = ['<', '>', '</', '>'];
+    const values = [ClassA, 'text sample', ClassA];
+    toCache(strings, {
+      keys: [
+        [0, ClassB],
+        [2, ClassB],
+      ],
+      indexes: [1],
+      strings: ['<class-b>', '</class-b>'],
+    });
+
+    const [newStrings, ...newValues] = transform(strings, values);
+
+    expect(newStrings).to.be.deep.equal(['<class-a>', '</class-a>']);
+    expect(newValues).to.be.deep.equal(['text sample']);
+  });
+
+  it("should return the cached value while classes don't change", () => {
+    const ClassA = class extends HTMLElement {};
+    const strings = ['<', '>', '</', '>'];
+
+    const [stringsA, ...valuesA] = transform(strings, [ClassA, 'text sample', ClassA]);
+    const [stringsB, ...valuesB] = transform(strings, [ClassA, 'another text sample', ClassA]);
+
+    expect(stringsA).to.be.equal(stringsB);
+    expect(valuesA).to.be.deep.equal(['text sample']);
+    expect(valuesB).to.be.deep.equal(['another text sample']);
+  });
+
+  describe('concatenation', () => {
+    it('concatenates element names with no other expressions', () => {
+      class MyViolet extends HTMLElement {}
+
+      const [strings, ...values] = transform(...testHtml`<${MyViolet}></${MyViolet}>`);
+      expect(strings).to.deep.equal(['<my-violet></my-violet>']);
+      expect(values).to.deep.equal([]);
+      expect(customElements.get('my-violet').prototype instanceof MyViolet).to.be.true;
+    });
+
+    it('concatenates element names with a text node expression', () => {
+      class MyDaisy extends HTMLElement {}
+
+      const [strings, ...values] = transform(...testHtml`<${MyDaisy}>${'my text'}</${MyDaisy}>`);
+      expect(strings).to.deep.equal(['<my-daisy>', '</my-daisy>']);
+      expect(values).to.deep.equal(['my text']);
+      expect(customElements.get('my-daisy').prototype instanceof MyDaisy).to.be.true;
+      const [strings2, ...values2] = transform(...testHtml`<${MyDaisy}>my text</${MyDaisy}>`);
+      expect(strings2).to.deep.equal(['<my-daisy>my text</my-daisy>']);
+      expect(values2).to.deep.equal([]);
+    });
+
+    it('concatenates element names with an attribute value expression', () => {
+      class MySunflower extends HTMLElement {}
+
+      const [strings, ...values] = transform(
+        ...testHtml`<${MySunflower} id="${'my-id'}"></${MySunflower}>`,
+      );
+      expect(strings).to.deep.equal(['<my-sunflower id="', '"></my-sunflower>']);
+      expect(values).to.deep.equal(['my-id']);
+      expect(customElements.get('my-sunflower').prototype instanceof MySunflower).to.be.true;
+      const [strings2, ...values2] = transform(
+        ...testHtml`<${MySunflower} id="my-id"></${MySunflower}>`,
+      );
+      expect(strings2).to.deep.equal(['<my-sunflower id="my-id"></my-sunflower>']);
+      expect(values2).to.deep.equal([]);
+    });
+
+    it('keeps untouched when there are no expressions', () => {
+      const [strings, ...values] = transform(...testHtml`<my-rose></my-rose>`);
+      expect(strings).to.deep.equal(['<my-rose></my-rose>']);
+      expect(values).to.deep.equal([]);
+      expect(customElements.get('my-rose')).to.be.undefined;
+    });
+
+    it('ignores unrelated classes', () => {
+      class MyMagnolia {}
+
+      const [strings, ...values] = transform(...testHtml`<${MyMagnolia}></${MyMagnolia}>`);
+      expect(strings).to.deep.equal(['<', '></', '>']);
+      expect(values).to.deep.equal([MyMagnolia, MyMagnolia]);
+      expect(customElements.get('my-magnolia')).to.not.exist;
+      const [strings2, ...values2] = transform(...testHtml`<${MyMagnolia}/>`);
+      expect(strings2).to.deep.equal(['<', '/>']);
+      expect(values2).to.deep.equal([MyMagnolia]);
+    });
+  });
+
+  describe('name generator', () => {
+    it('derives a name from the constructor by transforming it to dash-case', () => {
+      class MyCrocus extends HTMLElement {}
+
+      expect(getNameForCEClass(MyCrocus)).to.equal('my-crocus');
+      expect(customElements.get('my-crocus').prototype instanceof MyCrocus).to.be.true;
+    });
+
+    it('does not register the same class twice', () => {
+      class MyIris extends HTMLElement {}
+
+      expect(getNameForCEClass(MyIris)).to.equal('my-iris');
+      expect(getNameForCEClass(MyIris)).to.equal('my-iris');
+      expect(customElements.get('my-iris').prototype instanceof MyIris).to.be.true;
+    });
+
+    it('adds an incremented index to the name if the same constructor name is encountered', () => {
+      const name1 = (() => {
+        class MyPrimrose extends HTMLElement {}
+
+        return getNameForCEClass(MyPrimrose);
+      })();
+      const name2 = (() => {
+        class MyPrimrose extends HTMLElement {}
+
+        return getNameForCEClass(MyPrimrose);
+      })();
+      expect(name1).to.equal('my-primrose');
+      expect(name2).to.equal('my-primrose-2');
+    });
+
+    it('adds an incremented index to the name if the same name was registered natively before', () => {
+      customElements.define('my-hibiscus', class extends HTMLElement {});
+      const name2 = (() => {
+        class MyHibiscus extends HTMLElement {}
+
+        return getNameForCEClass(MyHibiscus);
+      })();
+      expect(name2).to.equal('my-hibiscus-2');
+      customElements.define('my-hibiscus-3', class extends HTMLElement {});
+      const name4 = (() => {
+        class MyHibiscus extends HTMLElement {}
+
+        return getNameForCEClass(MyHibiscus);
+      })();
+      expect(name4).to.equal('my-hibiscus-4');
+    });
+
+    it('adds a prefix "c-" if constructor name in dash-case has no dash', () => {
+      const name1 = (() => {
+        class Moonflower extends HTMLElement {}
+
+        return getNameForCEClass(Moonflower);
+      })();
+      const name2 = (() => {
+        class Moonflower extends HTMLElement {}
+
+        return getNameForCEClass(Moonflower);
+      })();
+      expect(name1).to.equal('c-moonflower');
+      expect(name2).to.equal('c-moonflower-2');
+      customElements.define('c-moonflower-3', class extends HTMLElement {});
+      const name4 = (() => {
+        class Moonflower extends HTMLElement {}
+
+        return getNameForCEClass(Moonflower);
+      })();
+      expect(name4).to.equal('c-moonflower-4');
+    });
+  });
+});

--- a/packages/classes-in-html/test/wrap.test.js
+++ b/packages/classes-in-html/test/wrap.test.js
@@ -1,0 +1,40 @@
+import { expect } from '@open-wc/testing';
+import { wrap } from '../src/wrap.js';
+
+describe('wrap', () => {
+  it('passes strings and values as tagged templates expect', () => {
+    let calledCount = 0;
+    let calledArgs;
+    const html = wrap((...args) => {
+      calledCount += 1;
+      calledArgs = args;
+    });
+    class MyLily extends HTMLElement {}
+
+    html`<${MyLily} id="${'my-id'}">${'my text'}</${MyLily}>`;
+    expect(calledCount).to.equal(1);
+    expect(calledArgs).to.deep.equal([['<my-lily id="', '">', '</my-lily>'], 'my-id', 'my text']);
+  });
+
+  it('integrates with lit-html', async () => {
+    const { html: litHtml, TemplateResult, render } = await import('lit-html');
+
+    const html = wrap(litHtml);
+    class MyAzalea extends HTMLElement {}
+
+    const template = html`<${MyAzalea} id="${'my-id'}">${'my text'}</${MyAzalea}>`;
+    expect(template).to.be.instanceof(TemplateResult);
+
+    const fixture = document.createElement('div');
+    document.body.appendChild(fixture);
+    render(template, fixture);
+
+    const el = fixture.children[0];
+
+    expect(el).to.be.instanceof(MyAzalea);
+    expect(el.getAttribute('id')).to.equal('my-id');
+    expect(el.textContent).to.equal('my text');
+
+    document.body.removeChild(fixture);
+  });
+});

--- a/packages/lit-helpers/README.md
+++ b/packages/lit-helpers/README.md
@@ -29,7 +29,7 @@ render(
     <div
       ...=${spread({
         'my-attribute': 'foo',
-        '?my-boolean-attribute': true
+        '?my-boolean-attribute': true,
         '.myProperty': { foo: 'bar' },
         '@my-event': () => console.log('my-event fired'),
       })}
@@ -92,7 +92,7 @@ renderSpread({ foo: 'buz', lorem: 'ipsum' });
 renderSpread({ foo: 'buz' });
 
 // result: <div>
-renderSpread({ foo: undefined' });
+renderSpread({ foo: undefined });
 ```
 
 ## Live binding


### PR DESCRIPTION
This PR is based on [carehtml](https://www.npmjs.com/package/carehtml), but it adds a cache because of [this](https://github.com/Polymer/lit-html/pull/274#issuecomment-420078190).

With this PR we are able to use the next syntax inside our LitElement components

```js
import { html as leHtml, LitElement } from 'lit-element';
import { wrap } from '@open-wc/lit-helpers';

const html = wrap(leHtml);

class MyButton extends LitElement {
  render() {
    return html`
      <button><slot></slot></button>
    `;
  }
}

class MyElement extends LitElement {
  render() {
    return html`
      <${MyButton} @click="${e => console.log(e)}">Click me!</${MyButton}>
    `;
  }
}
```