### PR TITLE
docs: fix typo in semantic-dom-diff readme

### DIFF
--- a/packages/semantic-dom-diff/README.md
+++ b/packages/semantic-dom-diff/README.md
@@ -269,11 +269,11 @@ it('renders correctly', async () => {
       foo
     </div>
   `,
-    { ignoreChildren: ['my-custom-element'] },
+    { ignoreChildren: ['my-custom-input'] },
   );
 
   expect(el).dom.to.equalSnapshot({
-    ignoreChildren: ['my-custom-element'],
+    ignoreChildren: ['my-custom-input'],
   });
 });
 ```


### PR DESCRIPTION
In "Ignoring children" section the element name in markup is different from the passed to option