### PR TITLE
fix(karma-esm): add close body tag when injecting code to import tests

### DIFF
--- a/packages/karma-esm/src/setup-es-dev-server.js
+++ b/packages/karma-esm/src/setup-es-dev-server.js
@@ -51,7 +51,8 @@ async function fetchKarmaHTML(karmaHost, name) {
         .join(',')}])
         .then(() => window.__karma__.loaded())
         .catch(() => window.__karma__.error())
-    </script>`,
+    </script>
+    </body>`,
   );
   return { body };
 }


### PR DESCRIPTION
The close body tag is being removed from final output when replacing it by script to inject tests. Browser automatically inserts but better safe than sorry.