### PR TITLE
fix(karma-esm): Implement import map support

### DIFF
--- a/packages/karma-esm/README.md
+++ b/packages/karma-esm/README.md
@@ -65,7 +65,7 @@ module.exports = {
 | compatibility    | string  | Compatibility level to run the `es-dev-server` with.                                                          |
 | coverageExclude  | array   | Extra glob patterns of tests to exclude from coverage.                                                        |
 | babelConfig      | string  | Custom babel configuration file to run on served code.                                                        |
-| moduleDirs       | string  | Directories to resolve modules from. Defaults to `node_modules`                                               |
+| moduleDirs       | array   | Directories to resolve modules from. Defaults to `node_modules`                                               |
 | babel            | boolean | Whether to pick up a babel configuration file in your project.                                                |
 | fileExtensions   | array   | Custom file extensions to serve as es modules.                                                                |
 | polyfills        | object  | Polyfill configuration.                                                                                       |
@@ -81,6 +81,26 @@ It transforms: `import foo from 'bar'` to: `import foo from './node_modules/bar/
 ### coverage
 
 Due to a bug in karma, the test coverage reporter causes browser logs to appear twice which can be annoying
+
+### importMap
+
+Allows to control the behavior of ES imports according to the (in progress) [spec](https://github.com/WICG/import-maps).
+Since this feature is not enabled by default, is necessary to launch Chrome with `--enable-experimental-web-platform-features` flag.
+
+In karma.config.js add:
+
+```js
+customLaunchers: {
+  ChromeHeadlessNoSandbox: {
+    base: 'ChromeHeadless',
+    flags: [
+      '--no-sandbox', //default karma-esm configuration
+      '--disable-setuid-sandbox', //default karma-esm configuration
+      '--enable-experimental-web-platform-features' // necessary when using importMap option
+    ],
+  },
+}
+```
 
 ### compatibility
 

--- a/packages/karma-esm/demo/import-map/import-map.json
+++ b/packages/karma-esm/demo/import-map/import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "lodash-es": "/base/node_modules/lodash-es/lodash.js",
-    "chai": "/base/node_modules/chai/index.js"
+    "chai/": "/base/node_modules/chai/"
   }
 }

--- a/packages/karma-esm/demo/import-map/karma.config.js
+++ b/packages/karma-esm/demo/import-map/karma.config.js
@@ -19,7 +19,11 @@ module.exports = config => {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',
-        flags: ['--no-sandbox', '--disable-setuid-sandbox'],
+        flags: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--enable-experimental-web-platform-features',
+        ],
       },
     },
 

--- a/packages/karma-esm/src/setup-es-dev-server.js
+++ b/packages/karma-esm/src/setup-es-dev-server.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const portfinder = require('portfinder');
 const chokidar = require('chokidar');
 const fetch = require('node-fetch');
@@ -8,13 +9,35 @@ const regexpScriptSrcGlobal = /<script type="module"[^>]*src="([^"]*)"/gm;
 const regexpScriptSrc = /<script type="module"[^>]*src="([^"]*)"/m;
 
 /**
+ * Load importMap content from a filepath
+ * @param {string} path
+ * @returns {Promise<string>}
+ */
+async function loadImportMap(path) {
+  return new Promise((resolve, reject) => {
+    if (!path) {
+      resolve('');
+      return;
+    }
+    fs.readFile(path, 'utf8', (err, data) => {
+      if (err) {
+        reject(new Error(`Unable to load importMap: ${err}`));
+        return;
+      }
+      resolve(data);
+    });
+  });
+}
+
+/**
  * Fetches the original test HTML file from karma and injects code to ensure all tests
  * are loaded before running karma.
  * @param {string} karmaHost
  * @param {string} name
+ * @param {string} importMap
  * @returns {Promise<{ body: string}>}
  */
-async function fetchKarmaHTML(karmaHost, name) {
+async function fetchKarmaHTML(karmaHost, name, importMap) {
   // fetch the original html source from karma, so that it injects test files
   // @ts-ignore
   const response = await fetch(`${karmaHost}/${name}.html?bypass-es-dev-server`);
@@ -25,6 +48,16 @@ async function fetchKarmaHTML(karmaHost, name) {
     regexpKarmaLoaded,
     '// disabled by karma-esm\n // window.__karma__.loaded();',
   );
+
+  if (importMap) {
+    body = body.replace(
+      '</head>',
+      `<script type="importmap">
+      ${importMap}
+    </script>
+    </head>`,
+    );
+  }
 
   // extract all test file sources
   const matches = body.match(regexpScriptSrcGlobal);
@@ -62,14 +95,14 @@ async function fetchKarmaHTML(karmaHost, name) {
  * es-dev-server serving logic, so that modules are resolved and babel or compatibility mode
  * can process the html and test files.
  */
-function createServeKarmaHtml(karmaHost) {
+function createServeKarmaHtml(karmaHost, importMap) {
   return async function serveKarmaHtml({ url }) {
     if (url.startsWith('/context.html')) {
-      return fetchKarmaHTML(karmaHost, 'context');
+      return fetchKarmaHTML(karmaHost, 'context', importMap);
     }
 
     if (url.startsWith('/debug.html')) {
-      return fetchKarmaHTML(karmaHost, 'debug');
+      return fetchKarmaHTML(karmaHost, 'debug', importMap);
     }
 
     return null;
@@ -81,6 +114,7 @@ async function setupDevServer(karmaConfig, esmConfig, watch, babelConfig, karmaE
     typeof esmConfig.port === 'number' ? esmConfig.port : await portfinder.getPortPromise();
   const karmaHost = `${karmaConfig.protocol}//${karmaConfig.hostname}:${karmaConfig.port}`;
   const devServerHost = `${karmaConfig.protocol}//${karmaConfig.hostname}:${devServerPort}`;
+  const importMap = await loadImportMap(esmConfig.importMap);
 
   const esDevServerConfig = createConfig({
     port: devServerPort,
@@ -100,7 +134,7 @@ async function setupDevServer(karmaConfig, esmConfig, watch, babelConfig, karmaE
     // @ts-ignore
     middlewares: esmConfig.middlewares || esmConfig.customMiddlewares,
     preserveSymlinks: esmConfig.preserveSymlinks,
-    responseTransformers: [createServeKarmaHtml(karmaHost)],
+    responseTransformers: [createServeKarmaHtml(karmaHost, importMap)],
     debug: esmConfig.debug,
     watch: false,
     babelConfig,


### PR DESCRIPTION
Currently importMap option passed to karma-esm is ignored (#1127)

This PR loads the importMap data and inject into karma debug and context files

It also fixes how chai path in test importmap is defined

The last part try to pass the flags to enable import map support in chrome based on [SO](https://stackoverflow.com/a/51070140). ~~This is not working~~. Using `--enable-experimental-web-platform-features` flag works

If i run Karma with Chrome and enable manually the importmap support it works
