### PR TITLE
fix(create): replace webpack-merge by deepmerge in testing dependencies

### DIFF
--- a/packages/create/src/generators/app-lit-element/templates/static-testing/karma.conf.js
+++ b/packages/create/src/generators/app-lit-element/templates/static-testing/karma.conf.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const { createDefaultConfig } = require('@open-wc/testing-karma');
-const merge = require('webpack-merge');
+const merge = require('deepmerge');
 
 module.exports = config => {
   config.set(

--- a/packages/create/src/generators/testing-karma-bs/templates/static/karma.bs.config.js
+++ b/packages/create/src/generators/testing-karma-bs/templates/static/karma.bs.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const merge = require('webpack-merge');
+const merge = require('deepmerge');
 const { bsSettings } = require('@open-wc/testing-karma-bs');
 const createBaseConfig = require('./karma.conf.js');
 

--- a/packages/create/src/generators/testing-karma/templates/_package.json
+++ b/packages/create/src/generators/testing-karma/templates/_package.json
@@ -7,6 +7,6 @@
   },
   "devDependencies": {
     "@open-wc/testing-karma": "^3.0.0",
-    "webpack-merge": "^4.1.5"
+    "deepmerge": "^3.2.0"
   }
 }

--- a/packages/create/src/generators/testing-karma/templates/static/karma.conf.js
+++ b/packages/create/src/generators/testing-karma/templates/static/karma.conf.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const { createDefaultConfig } = require('@open-wc/testing-karma');
-const merge = require('webpack-merge');
+const merge = require('deepmerge');
 
 module.exports = config => {
   config.set(


### PR DESCRIPTION
deepmerge  is smaller and is already a dependency of karma-esm