### PR TITLE
fix building module resolves

### DIFF
--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -75,8 +75,8 @@ function createConfig(_options, legacy) {
         babel({
           extensions: options.extensions,
           plugins: [
-            '@babel/plugin-syntax-dynamic-import',
-            '@babel/plugin-syntax-import-meta',
+            require.resolve('@babel/plugin-syntax-dynamic-import'),
+            require.resolve('@babel/plugin-syntax-import-meta'),
             /**
              * This can be removed when https://github.com/babel/babel/pull/10811 is released
              */
@@ -87,9 +87,9 @@ function createConfig(_options, legacy) {
             [require.resolve('@babel/plugin-proposal-optional-chaining'), { loose: true }],
             // rollup rewrites import.meta.url, but makes them point to the file location after bundling
             // we want the location before bundling
-            ['bundled-import-meta', { importStyle: 'baseURI' }],
+            [require.resolve('babel-plugin-bundled-import-meta'), { importStyle: 'baseURI' }],
             production && [
-              'template-html-minifier',
+              require.resolve('babel-plugin-template-html-minifier'),
               {
                 modules: {
                   'lit-html': ['html'],
@@ -108,7 +108,7 @@ function createConfig(_options, legacy) {
 
           presets: [
             [
-              '@babel/preset-env',
+              require.resolve('@babel/preset-env'),
               {
                 targets: legacy ? ['ie 11'] : findSupportedBrowsers(),
                 // preset-env compiles template literals for safari 12 due to a small bug which

--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -65,8 +65,8 @@ module.exports = function createBasicConfig(_options) {
         babel({
           extensions: options.extensions,
           plugins: [
-            '@babel/plugin-syntax-dynamic-import',
-            '@babel/plugin-syntax-import-meta',
+            require.resolve('@babel/plugin-syntax-dynamic-import'),
+            require.resolve('@babel/plugin-syntax-import-meta'),
             /**
              * This can be removed when https://github.com/babel/babel/pull/10811 is released
              */
@@ -77,9 +77,9 @@ module.exports = function createBasicConfig(_options) {
             [require.resolve('@babel/plugin-proposal-optional-chaining'), { loose: true }],
             // rollup rewrites import.meta.url, but makes them point to the file location after bundling
             // we want the location before bundling
-            'bundled-import-meta',
+            require.resolve('babel-plugin-bundled-import-meta'),
             production && [
-              'template-html-minifier',
+              require.resolve('babel-plugin-template-html-minifier'),
               {
                 modules: {
                   'lit-html': ['html'],
@@ -98,7 +98,7 @@ module.exports = function createBasicConfig(_options) {
 
           presets: [
             [
-              '@babel/preset-env',
+              require.resolve('@babel/preset-env'),
               {
                 targets: findSupportedBrowsers(),
                 // preset-env compiles template literals for safari 12 due to a small bug which

--- a/packages/building-webpack/modern-and-legacy-config.js
+++ b/packages/building-webpack/modern-and-legacy-config.js
@@ -76,8 +76,8 @@ function createConfig(options, legacy) {
 
             options: {
               plugins: [
-                '@babel/plugin-syntax-dynamic-import',
-                '@babel/plugin-syntax-import-meta',
+                require.resolve('@babel/plugin-syntax-dynamic-import'),
+                require.resolve('@babel/plugin-syntax-import-meta'),
                 /**
                  * This can be removed when https://github.com/babel/babel/pull/10811 is released
                  */
@@ -87,7 +87,7 @@ function createConfig(options, legacy) {
                 ],
                 [require.resolve('@babel/plugin-proposal-optional-chaining'), { loose: true }],
                 production && [
-                  'template-html-minifier',
+                  require.resolve('babel-plugin-template-html-minifier'),
                   {
                     modules: {
                       'lit-html': ['html'],
@@ -103,12 +103,12 @@ function createConfig(options, legacy) {
                   },
                 ],
                 // webpack does not support import.meta.url yet, so we rewrite them in babel
-                ['bundled-import-meta', { importStyle: 'baseURI' }],
+                [require.resolve('babel-plugin-bundled-import-meta'), { importStyle: 'baseURI' }],
               ].filter(_ => !!_),
 
               presets: [
                 [
-                  '@babel/preset-env',
+                  require.resolve('@babel/preset-env'),
                   {
                     targets: legacy ? ['ie 11'] : findSupportedBrowsers(),
                     // preset-env compiles template literals for safari 12 due to a small bug which

--- a/packages/building-webpack/modern-config.js
+++ b/packages/building-webpack/modern-config.js
@@ -76,8 +76,8 @@ module.exports = userOptions => {
             loader: 'babel-loader',
             options: {
               plugins: [
-                '@babel/plugin-syntax-dynamic-import',
-                '@babel/plugin-syntax-import-meta',
+                require.resolve('@babel/plugin-syntax-dynamic-import'),
+                require.resolve('@babel/plugin-syntax-import-meta'),
                 /**
                  * This can be removed when https://github.com/babel/babel/pull/10811 is released
                  */
@@ -87,7 +87,7 @@ module.exports = userOptions => {
                 ],
                 [require.resolve('@babel/plugin-proposal-optional-chaining'), { loose: true }],
                 production && [
-                  'template-html-minifier',
+                  require.resolve('babel-plugin-template-html-minifier'),
                   {
                     modules: {
                       'lit-html': ['html'],
@@ -103,12 +103,12 @@ module.exports = userOptions => {
                   },
                 ],
                 // webpack does not support import.meta.url yet, so we rewrite them in babel
-                ['bundled-import-meta', { importStyle: 'baseURI' }],
+                [require.resolve('babel-plugin-bundled-import-meta'), { importStyle: 'baseURI' }],
               ].filter(_ => !!_),
 
               presets: [
                 [
-                  '@babel/preset-env',
+                  require.resolve('@babel/preset-env'),
                   {
                     targets: findSupportedBrowsers(),
                     // preset-env compiles template literals for safari 12 due to a small bug which


### PR DESCRIPTION
Module resolution in configuration files needs to use `require.resolve` when referencing modules, if they are to be correctly resolved at the point of configuration script execution. This PR adds these calls to correctly resolve modules according to node resolution scope used in `building-rollup` and `building-webpack` configurations.