### PR TITLE
fix(karma-esm): modifies snapshot path to use pathResolver if configured

### DIFF
--- a/packages/karma-esm/src/esm-middleware.js
+++ b/packages/karma-esm/src/esm-middleware.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-inner-declarations, no-console */
+const path = require('path');
 const request = require('request');
 const { virtualFilePrefix } = require('es-dev-server');
 const { createEsmConfig } = require('./esm-config.js');
@@ -55,8 +56,16 @@ function esmMiddlewareFactory(config, karmaEmitter) {
           '/inline-module-',
           virtualFilePrefix,
         ];
-        // for some files we need to overwrite and serve from karma instead
-        const urlsForKarma = ['/base/__snapshots__'];
+
+        // snapshot files should be served from karma
+        let snapshotPath = '/base/__snapshots__';
+        // if we have a snapshot config which lets us resolve paths, use it instead of the default
+        if (karmaConfig.snapshot && karmaConfig.snapshot.pathResolver) {
+          snapshotPath = path.dirname(karmaConfig.snapshot.pathResolver('/base', 'fake-suite'));
+        }
+
+        // some files we need to overwrite and serve from karma instead
+        const urlsForKarma = [snapshotPath];
 
         const [url, params] = req.url.split('?');
 


### PR DESCRIPTION
The `karma-esm` configuration today has special case handling for serving snapshot markdown files directly from the `karma` web server rather than the `es-dev-server`. This is to allow the `karma-snapshot` plugin to do its thing and rewrite the Markdown files to JS.

However, the current implementation assumes a fixed path for the snapshot folder, but the `karma-snapshot` plugin supports rewriting this path using the `pathResolver` configuration.

This change will use that same `pathResolver` configuration to calculate the snapshot folder path if the config is present, otherwise will fallback to the previous assumed path.