### PR TITLE
fix(demoing-storybook): fixes story file listing

### DIFF
--- a/packages/demoing-storybook/src/shared/listFiles.js
+++ b/packages/demoing-storybook/src/shared/listFiles.js
@@ -1,10 +1,23 @@
 const glob = require('glob');
 const fs = require('fs');
+const path = require('path');
 
+/**
+ * Lists all files using the specified glob, starting from the given root directory.
+ *
+ * Will return all matching file paths fully resolved.
+ */
 module.exports = function listFiles(fromGlob, rootDir) {
   return new Promise(resolve => {
     glob(fromGlob, { cwd: rootDir }, (er, files) => {
-      resolve(files.filter(filePath => !fs.lstatSync(filePath).isDirectory()));
+      // remember, each filepath returned is relative to rootDir
+      resolve(
+        files
+          // fully resolve the filename relative to rootDir
+          .map(filePath => path.resolve(rootDir, filePath))
+          // filter out directories
+          .filter(filePath => !fs.lstatSync(filePath).isDirectory()),
+      );
     });
   });
 };


### PR DESCRIPTION
Changes in #1152 modified how file listing is done. This does however not capture all cases correctly.

Since the glob path passed to `listFiles` no longer has `rootDir` prepended to it, and since `glob` itself does not fully resolve the paths it returns relative to the `cwd` option, the paths are no longer correctly resolving in all cases.

This PR resolves each path against the root dir, before doing the directory check.