### PR TITLE
fix(node-resolve): support packages with 'jsnext:main' hint

### DIFF
--- a/packages/es-dev-server/src/utils/resolve-module-imports.js
+++ b/packages/es-dev-server/src/utils/resolve-module-imports.js
@@ -62,7 +62,7 @@ async function nodeResolve(rootDir, sourceFilePath, importPath, cfg) {
     preserveSymlinks: cfg.preserveSymlinks,
     packageFilter(packageJson) {
       /* eslint-disable no-param-reassign */
-      packageJson.main = packageJson.module || packageJson.main;
+      packageJson.main = packageJson.module || packageJson['jsnext:main'] || packageJson.main;
       return packageJson;
     },
   };


### PR DESCRIPTION
There are still packages that have not been updated to use the "module" attribute and still use the "jsnext:main" attribute. es-dev-server v1.32.0 has broken the support for these packages.

For example: https://github.com/moment/moment/blob/master/package.json