### PR TITLE
fix(demoing-storybook): pass outputdir to config generator

### DIFF
--- a/packages/demoing-storybook/src/build/build.js
+++ b/packages/demoing-storybook/src/build/build.js
@@ -27,12 +27,10 @@ async function buildManager(outputDir, assets) {
 async function buildPreview(outputDir, assets) {
   const configs = createCompatibilityConfig({
     input: 'noop',
+    outputDir,
     extensions: [...DEFAULT_EXTENSIONS, 'mdx'],
     plugins: { indexHTML: false },
   });
-
-  configs[0].output.dir = path.join(outputDir, 'legacy');
-  configs[1].output.dir = outputDir;
 
   configs[0].plugins.unshift(
     indexHTML({

--- a/packages/demoing-storybook/src/build/readCommandLineArgs.js
+++ b/packages/demoing-storybook/src/build/readCommandLineArgs.js
@@ -1,5 +1,4 @@
 const commandLineArgs = require('command-line-args');
-const path = require('path');
 
 module.exports = function readCommandLineArgs() {
   const optionDefinitions = [
@@ -14,7 +13,7 @@ module.exports = function readCommandLineArgs() {
       name: 'output-dir',
       alias: 'o',
       type: String,
-      defaultValue: path.join(process.cwd(), 'storybook-static'),
+      defaultValue: 'storybook-static',
       description: 'Rollup build output directory',
     },
     {
@@ -25,6 +24,6 @@ module.exports = function readCommandLineArgs() {
     },
   ];
   const storybookServerConfig = commandLineArgs(optionDefinitions);
-
+  console.log('storybookServerConfig', storybookServerConfig);
   return storybookServerConfig;
 };


### PR DESCRIPTION
When building with storybook, it was always outputting `dist/sw.js`. This is because we aren't passing the output directory to the config generator.