### PR TITLE
feat(testing-helpers): add waitUntil helper

### DIFF
--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -155,6 +155,39 @@ Waits for `x` ms via `setTimeout`;
 await aTimeout(10); // would wait 10ms
 ```
 
+### waitUntil
+
+Waits until the given condition returns true. This is useful when elements do async work.
+
+`waitUntil` can slow down the execution of tests, it should only be used when you don't have any other more reliable hooks.
+
+```js
+import { fixture, waitUntil } from '@open-wc/testing-helpers';
+
+const element = await fixture(
+  html`
+    <my-element></my-element>
+  `,
+);
+
+// wait until some async property is set
+await waitUntil(() => element.someAsyncProperty, 'Element did not become ready');
+
+// wait until some child element is rendered
+await waitUntil(
+  () => element.shadowRoot.querySelector('my-child-element'),
+  'Element did not render children',
+);
+```
+
+`waitUntil` has a default timeout of 2000ms and a polling interval of 50ms. This can be customized:
+
+```js
+await waitUntil(predicate, 'Element should become visible', { interval: 10, timeout: 10000 });
+```
+
+The predicate can return a promise.
+
 ### elementUpdated
 
 If you want to test attribute and property changes, and an easy way to wait for those changes to propagate, you can import the `elementUpdated` helper (also available directly in the `testing` package)

--- a/packages/testing-helpers/index.js
+++ b/packages/testing-helpers/index.js
@@ -7,6 +7,7 @@ export {
   defineCE,
   aTimeout,
   nextFrame,
+  waitUntil,
 } from './src/helpers.js';
 export { litFixture, litFixtureSync } from './src/litFixture.js';
 export { stringFixture, stringFixtureSync } from './src/stringFixture.js';

--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -130,3 +130,49 @@ export function oneEvent(element, eventName) {
     element.addEventListener(eventName, listener);
   });
 }
+
+/**
+ * Waits until the given predicate returns a truthy value. Calls and awaits the predicate
+ * function at the given interval time. Can be used to poll until a certain condition is true.
+ *
+ * @example
+ * ```js
+ * import { fixture, waitUntil } from '@open-wc/testing-helpers';
+ *
+ * const element = await fixture(html`<my-element></my-element>`);
+ *
+ * await waitUntil(() => element.someAsyncProperty, 'element should become ready');
+ * ```
+ *
+ * @param {() => boolean | Promise<boolean>} predicate - predicate function which is called each poll interval.
+ *   The predicate is awaited, so it can return a promise.
+ * @param {string} [message] an optional message to display when the condition timed out
+ * @param {{ interval?: number, timeout?: number }} [options] timeout and polling interval
+ */
+export function waitUntil(predicate, message, options = {}) {
+  const { interval = 50, timeout = 2000 } = options;
+
+  return new Promise((resolve, reject) => {
+    let timeoutId;
+
+    setTimeout(() => {
+      clearTimeout(timeoutId);
+      reject(new Error(message ? `Timeout: ${message}` : 'waitUntil timed out'));
+    }, timeout);
+
+    async function nextInterval() {
+      try {
+        if (await predicate()) {
+          resolve();
+        } else {
+          timeoutId = setTimeout(() => {
+            nextInterval();
+          }, interval);
+        }
+      } catch (error) {
+        reject(error);
+      }
+    }
+    nextInterval();
+  });
+}

--- a/packages/testing-helpers/test/helpers.test.js
+++ b/packages/testing-helpers/test/helpers.test.js
@@ -1,5 +1,6 @@
 import { expect } from './setup.js';
 import { defineCE, oneEvent, triggerFocusFor, triggerBlurFor, fixture } from '../index.js';
+import { waitUntil, aTimeout } from '../src/helpers.js';
 
 describe('Helpers', () => {
   it('provides defineCE() to register a unique new element', async () => {
@@ -67,5 +68,31 @@ describe('Helpers', () => {
     await triggerBlurFor(el.inputElement);
     expect(el.blurCount).to.be.within(0, 1);
     expect(el !== document.activeElement).to.be.true;
+  });
+
+  it('provides waitUntil to await async state', async () => {
+    let foo = false;
+    let resolved = false;
+    waitUntil(() => foo).then(() => {
+      resolved = true;
+    });
+
+    await aTimeout(100);
+    expect(resolved).to.be.false;
+    foo = true;
+    await aTimeout(100);
+
+    expect(resolved).to.be.true;
+  });
+
+  it('can customize the error message and timeout time', async () => {
+    let thrown = false;
+    try {
+      await waitUntil(() => false, 'false should become true', { timeout: 10 });
+    } catch (error) {
+      expect(error.message).to.equal('Timeout: false should become true');
+      thrown = true;
+    }
+    expect(thrown).to.be.true;
   });
 });

--- a/packages/testing/index.js
+++ b/packages/testing/index.js
@@ -17,6 +17,7 @@ export {
   fixtureSync,
   fixtureCleanup,
   elementUpdated,
+  waitUntil,
 } from '@open-wc/testing-helpers/index.js';
 
 // @ts-ignore


### PR DESCRIPTION
Async rendering is quite a hassle, this helper helps manage this declaratively in tests and demos. I have a version of this that I use a lot in my own code.