### PR TITLE
fix(testing-karma): use an os-agnostic pathResolver

### DIFF
--- a/packages/testing-karma/src/create-default-config.js
+++ b/packages/testing-karma/src/create-default-config.js
@@ -125,7 +125,7 @@ module.exports = config => ({
     // only warn about unused snapshots when running all tests
     limitUnusedSnapshotsInWarning: config.grep ? 0 : -1,
     pathResolver(basePath, suiteName) {
-      return path.join(basePath, '__snapshots__', `${suiteName}.md`);
+      return `${basePath}/__snapshots__/${suiteName}.md`;
     },
   },
 

--- a/packages/testing-karma/src/create-default-config.js
+++ b/packages/testing-karma/src/create-default-config.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 function getCompatibility() {
   if (process.argv.find(arg => arg.includes('--legacy'))) {
     /* eslint-disable-next-line no-console */


### PR DESCRIPTION
This will make the pathResolver os agnostic. Previously, on Windows, the pathResolver would use `\` characters as delimiters for the path urls.