### PR TITLE
Fix/storybook build crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ dist
 build-stats.json
 stats.html
 .rpt2_cache
-static-storybook
+storybook-static
 
 ## we already store snapshots globally
 packages/**/__snapshots__
@@ -43,3 +43,4 @@ local.log
 
 ## generated codelabs
 docs/.vuepress/public/codelabs
+

--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -73,6 +73,7 @@ function createConfig(_options, legacy) {
       // run code through babel
       options.plugins.babel &&
         babel({
+          exclude: options.babelExclude,
           extensions: options.extensions,
           plugins: [
             require.resolve('@babel/plugin-syntax-dynamic-import'),
@@ -122,7 +123,10 @@ function createConfig(_options, legacy) {
         }),
 
       // only minify if in production
-      production && terser(),
+      production &&
+        terser({
+          exclude: options.terserExclude,
+        }),
 
       production &&
         options.plugins.workbox &&

--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -63,6 +63,7 @@ module.exports = function createBasicConfig(_options) {
       // run code through babel
       options.plugins.babel &&
         babel({
+          exclude: options.babelExclude,
           extensions: options.extensions,
           plugins: [
             require.resolve('@babel/plugin-syntax-dynamic-import'),
@@ -112,7 +113,10 @@ module.exports = function createBasicConfig(_options) {
         }),
 
       // only minify if in production
-      production && terser(),
+      production &&
+        terser({
+          exclude: options.terserExclude,
+        }),
 
       production && options.plugins.workbox && generateSW(getWorkboxConfig(options.outputDir)),
     ],

--- a/packages/demoing-storybook/src/build/build.js
+++ b/packages/demoing-storybook/src/build/build.js
@@ -102,10 +102,14 @@ async function buildPreview(outputDir, previewPath, assets, storyFiles) {
     }),
   );
 
+  // build sequentially instead of parallel because terser is multi
+  // threaded and will max out CPUs
   // @ts-ignore
-  const bundles = await Promise.all([rollup(configs[0]), rollup(configs[1])]);
-  await bundles[0].write(configs[0].output);
-  await bundles[1].write(configs[1].output);
+  const modernBundle = await rollup(configs[0]);
+  // @ts-ignore
+  const legacyBundle = await rollup(configs[1]);
+  await modernBundle.write(configs[0].output);
+  await legacyBundle.write(configs[1].output);
 }
 
 module.exports = async function build({

--- a/packages/demoing-storybook/src/build/build.js
+++ b/packages/demoing-storybook/src/build/build.js
@@ -42,8 +42,17 @@ async function buildPreview(outputDir, previewPath, assets, storyFiles) {
     input: 'noop',
     outputDir,
     extensions: [...DEFAULT_EXTENSIONS, 'mdx'],
+    babelExclude: ['**/@open-wc/storybook-prebuilt/**/*'],
+    terserExclude: ['storybook-preview*'],
     plugins: { indexHTML: false },
   });
+
+  // force storybook preview into it's own chunk so that we can skip minifying it
+  const manualChunks = {
+    'storybook-preview': [require.resolve('@open-wc/storybook-prebuilt/dist/preview.js')],
+  };
+  configs[0].manualChunks = manualChunks;
+  configs[1].manualChunks = manualChunks;
 
   const transformMdxPlugin = {
     transform(code, id) {


### PR DESCRIPTION
This skips babel and terser for the storybook prebuilt, since that's already es5 and minified. 

It also runs the builds in sequence instead of in parallel, this is because terser takes up the majority of the build time and it's already multi threaded. Running two builds with terser in parallel is therefore not necessary, and potentially problematic.

I'm hoping this fixes https://github.com/open-wc/open-wc/issues/1203