### PR TITLE
fix(es-dev-server): don't look for config in root dir

### DIFF
--- a/packages/es-dev-server/src/command-line-args.js
+++ b/packages/es-dev-server/src/command-line-args.js
@@ -199,7 +199,7 @@ export function readCommandLineArgs(argv = process.argv, config = {}) {
 
   if (args.config) {
     // read config from user provided path
-    const configPath = path.join(process.cwd(), dashesArgs['root-dir'] || '', args.config);
+    const configPath = path.join(process.cwd(), args.config);
     if (!fs.existsSync(configPath) || !fs.statSync(configPath).isFile()) {
       throw new Error(`Did not find any config file at ${configPath}`);
     }
@@ -209,12 +209,7 @@ export function readCommandLineArgs(argv = process.argv, config = {}) {
     logDebug(`Found a config file at ${configPath}`);
   } else {
     // read default config if present
-    const defaultConfigPath = path.join(
-      process.cwd(),
-      dashesArgs['root-dir'] || '.',
-      defaultConfigDir,
-      defaultConfigName,
-    );
+    const defaultConfigPath = path.join(process.cwd(), defaultConfigDir, defaultConfigName);
 
     if (fs.existsSync(defaultConfigPath) && fs.statSync(defaultConfigPath).isFile()) {
       const fileConfig = require(defaultConfigPath);


### PR DESCRIPTION
As discussed in https://github.com/open-wc/open-wc/commit/4085898bf9fd23ab51cd86d5fe582191c30be64e#r36748834, we introduced a breaking change by looking in the root dir for a config. In hindsight, this change was not needed for achieving what we need so we should revert it.