### PR TITLE
fix(demoing-storybook): allow custom-elements.json in rootdir

### DIFF
--- a/packages/demoing-storybook/src/build/build.js
+++ b/packages/demoing-storybook/src/build/build.js
@@ -35,7 +35,7 @@ function copyCustomElementsJsonPlugin(outputRootDir) {
   return {
     async generateBundle() {
       const files = await listFiles(
-        `!(node_modules|web_modules|bower_components|${outputRootDir})/**/custom-elements.json`,
+        `{,!(node_modules|web_modules|bower_components|${outputRootDir})/**/}custom-elements.json`,
         process.cwd(),
       );
 


### PR DESCRIPTION
`!(node_modules|web_modules|bower_components|${outputRootDir})/**/custom-elements.json` will miss `custom-elements.json` files that are in the `rootDir` when building storybook. Update to `{,!(node_modules|web_modules|bower_components|${outputRootDir})/**/}custom-elements.json` to correct this.