### PR TITLE
feat(demoing-storybook): support main.js

### DIFF
--- a/packages/demoing-storybook/README.md
+++ b/packages/demoing-storybook/README.md
@@ -89,7 +89,7 @@ The storybook server is based on [es-dev-server](https://open-wc.org/developing/
 
 ### Configuration file
 
-By default, `@open-wc/demoing-storybook` looks for config files called `main.js` in your config dir (default `.storybook`). You can modify this by using the `--config` flag.
+By default, `@open-wc/demoing-storybook` looks for config files called `main.js` in your config dir (default `.storybook`). 
 
 The config file contains the options specific to storybook and the options for `es-dev-server`. The options are camelCased versions of the CLI args. Example:
 

--- a/packages/demoing-storybook/README.md
+++ b/packages/demoing-storybook/README.md
@@ -89,16 +89,19 @@ The storybook server is based on [es-dev-server](https://open-wc.org/developing/
 
 ### Configuration file
 
-By default, `@open-wc/demoing-storybook` looks for config files called `start-storybook.config.js` and `build-storybook.config.js` in your config dir (default `.storybook`). You can modify this by using the `--config` or `-c` flag.
+By default, `@open-wc/demoing-storybook` looks for config files called `main.js` in your config dir (default `.storybook`). You can modify this by using the `--config` flag.
 
-For `start-storybook`, the config file contains the options specific to storybook and the options for `es-dev-server`. The options are camelCased versions of the CLI args. Example:
+The config file contains the options specific to storybook and the options for `es-dev-server`. The options are camelCased versions of the CLI args. Example:
 
 ```js
 module.exports = {
-  stories: './stories/*.stories.{js,mdx}',
+  stories: ['./stories/*.stories.{js,mdx}'],
   managerPath: './my-manager.js',
-  nodeResolve: true,
-  open: true,
+  outputPath: '../my-build-folder',
+  esDevServer: {
+    nodeResolve: true,
+    open: true,
+  },
 };
 ```
 

--- a/packages/demoing-storybook/demo/.storybook/build-storybook.config.js
+++ b/packages/demoing-storybook/demo/.storybook/build-storybook.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  stories: 'demo/stories/*.stories.{js,mdx}',
-};

--- a/packages/demoing-storybook/demo/.storybook/main.js
+++ b/packages/demoing-storybook/demo/.storybook/main.js
@@ -1,0 +1,8 @@
+module.exports = {
+  stories: ['../stories/**/*.stories.{js,mdx}'],
+  esDevServer: {
+    nodeResolve: true,
+    watch: true,
+    open: true,
+  },
+};

--- a/packages/demoing-storybook/demo/.storybook/start-storybook.config.js
+++ b/packages/demoing-storybook/demo/.storybook/start-storybook.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  nodeResolve: true,
-  watch: true,
-  open: true,
-  stories: 'packages/demoing-storybook/demo/stories/*.stories.{js,mdx}',
-};

--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build:start": "es-dev-server --root-dir static-storybook --app-index index.html --open",
     "prepublishOnly": "../../scripts/insert-header.js",
-    "site:build": "node src/build/cli.js --stories \"demo/stories/*.stories.{js,mdx}\" --config-dir demo/.storybook -o ../../_site/demoing-storybook",
+    "site:build": "node src/build/cli.js --config-dir demo/.storybook -o ../../_site/demoing-storybook",
     "storybook": "node src/start/cli.js -c demo/.storybook --root-dir ../../",
     "storybook:build": "node src/build/cli.js -c demo/.storybook",
     "test": "mocha test/**/*.test.js test/*.test.js",

--- a/packages/demoing-storybook/src/build/cli.js
+++ b/packages/demoing-storybook/src/build/cli.js
@@ -5,14 +5,14 @@ const path = require('path');
 
 const build = require('./build');
 const readCommandLineArgs = require('./readCommandLineArgs');
-const listFiles = require('../shared/listFiles');
 const toBrowserPath = require('../shared/toBrowserPath');
+const storiesPatternsToFiles = require('../shared/storiesPatternsToFiles');
 
 (async function main() {
   const rootDir = process.cwd();
   const config = readCommandLineArgs();
   const storiesPattern = `${process.cwd()}/${config.stories}`;
-  const storyFiles = await listFiles(storiesPattern, rootDir);
+  const storyFiles = await storiesPatternsToFiles(config.stories, rootDir);
   const storyUrls = storyFiles.map(filePath => {
     const relativeFilePath = path.relative(rootDir, filePath);
     return `./${toBrowserPath(relativeFilePath)}`;

--- a/packages/demoing-storybook/src/build/readCommandLineArgs.js
+++ b/packages/demoing-storybook/src/build/readCommandLineArgs.js
@@ -5,6 +5,39 @@ const deepmerge = require('deepmerge');
 const fs = require('fs');
 
 module.exports = function readCommandLineArgs() {
+  const tmpConfig = commandLineArgs(
+    {
+      name: 'config-dir',
+      alias: 'c',
+      type: String,
+      defaultValue: './.storybook',
+    },
+    { partial: true },
+  );
+  const mainFilePath = path.join(process.cwd(), tmpConfig['config-dir'], 'main.js');
+  const mainDir = path.dirname(mainFilePath);
+
+  let mainJs = {};
+  if (fs.existsSync(mainFilePath)) {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    mainJs = require(mainFilePath);
+    if (mainJs.stories) {
+      mainJs.stories = typeof mainJs.stories === 'string' ? [mainJs.stories] : mainJs.stories;
+      mainJs.stories = mainJs.stories.map(entry => path.join(mainDir, entry));
+    }
+    // fix relative paths if they work - otherwise let resolve handle it afterwards
+    if (mainJs.managerPath && fs.existsSync(path.join(mainDir, mainJs.managerPath))) {
+      mainJs.managerPath = path.join(mainDir, mainJs.managerPath);
+    }
+    if (mainJs.previewPath && fs.existsSync(path.join(mainDir, mainJs.previewPath))) {
+      mainJs.previewPath = path.join(mainDir, mainJs.previewPath);
+    }
+    // output-dir can be none existing
+    if (mainJs.outputDir) {
+      mainJs.outputDir = path.relative(process.cwd(), path.join(mainDir, mainJs.outputDir));
+    }
+  }
+
   const optionDefinitions = [
     {
       name: 'config-dir',
@@ -22,28 +55,30 @@ module.exports = function readCommandLineArgs() {
       name: 'output-dir',
       alias: 'o',
       type: String,
-      defaultValue: 'storybook-static',
+      defaultValue: mainJs.outputDir || 'storybook-static',
       description: 'Rollup build output directory',
     },
     {
       name: 'stories',
       alias: 's',
-      defaultValue: './stories/*.stories.{js,mdx}',
+      defaultValue: mainJs.stories || './stories/*.stories.{js,mdx}',
       description: 'List of story files e.g. --stories stories/*.stories.{js,mdx}',
     },
     {
       name: 'manager-path',
-      defaultValue: '@open-wc/storybook-prebuilt/dist/manager.js',
+      defaultValue: mainJs.managerPath || '@open-wc/storybook-prebuilt/dist/manager.js',
       description: 'Import path of a prebuilt manager file',
     },
     {
       name: 'preview-path',
-      defaultValue: '@open-wc/storybook-prebuilt/dist/preview.js',
+      defaultValue: mainJs.previewPath || '@open-wc/storybook-prebuilt/dist/preview.js',
       description: 'Import path of a prebuilt preview file',
     },
   ];
 
   const args = commandLineArgs(optionDefinitions);
+  args.stories = typeof args.stories === 'string' ? [args.stories] : args.stories;
+
   let options = {
     configDir: args['config-dir'],
     outputDir: args['output-dir'],

--- a/packages/demoing-storybook/src/shared/storiesPatternsToFiles.js
+++ b/packages/demoing-storybook/src/shared/storiesPatternsToFiles.js
@@ -1,0 +1,20 @@
+const listFiles = require('./listFiles');
+
+/**
+ * Lists all files using the specified globs, starting from the given root directory.
+ *
+ * Will return all matching file paths
+ */
+module.exports = async function storiesPatternsToFiles(storiesPatterns, rootDir) {
+  const listFilesPromises = storiesPatterns.map(pattern => listFiles(pattern, rootDir));
+  const arrayOfFilesArrays = await Promise.all(listFilesPromises);
+  const files = [];
+
+  for (const filesArray of arrayOfFilesArrays) {
+    for (const filePath of filesArray) {
+      files.push(filePath);
+    }
+  }
+
+  return files;
+};

--- a/packages/demoing-storybook/src/shared/storiesPatternsToUrls.js
+++ b/packages/demoing-storybook/src/shared/storiesPatternsToUrls.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const storiesPatternsToFiles = require('./storiesPatternsToFiles');
+const toBrowserPath = require('./toBrowserPath');
+
+/**
+ * Lists all files using the specified glob, starting from the given root directory.
+ *
+ * Will return all matching urls.
+ */
+module.exports = async function storiesPatternsToUrls(storiesPatterns, rootDir) {
+  const arrayOfFilesArrays = await storiesPatternsToFiles(storiesPatterns, rootDir);
+  return arrayOfFilesArrays.map(filePath => {
+    const relativeFilePath = path.relative(rootDir, filePath);
+    return `/${toBrowserPath(relativeFilePath)}`;
+  });
+};

--- a/packages/demoing-storybook/src/start/readCommandLineArgs.js
+++ b/packages/demoing-storybook/src/start/readCommandLineArgs.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const commandLineArgs = require('command-line-args');
 const commandLineUsage = require('command-line-usage');
 const {
@@ -6,6 +8,36 @@ const {
 } = require('es-dev-server');
 
 module.exports = function readCommandLineArgs() {
+  const tmpConfig = commandLineArgs(
+    {
+      name: 'config-dir',
+      alias: 'c',
+      type: String,
+      defaultValue: './.storybook',
+    },
+    { partial: true },
+  );
+  const mainFilePath = path.join(process.cwd(), tmpConfig['config-dir'], 'main.js');
+  const mainDir = path.dirname(mainFilePath);
+
+  let mainJs = { esDevServer: {} };
+  if (fs.existsSync(mainFilePath)) {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    mainJs = require(mainFilePath);
+    if (mainJs.stories) {
+      mainJs.stories = typeof mainJs.stories === 'string' ? [mainJs.stories] : mainJs.stories;
+      mainJs.stories = mainJs.stories.map(entry => path.join(mainDir, entry));
+    }
+    // fix relative paths if they work - otherwise let resolve handle it afterwards
+    if (mainJs.managerPath && fs.existsSync(path.join(mainDir, mainJs.managerPath))) {
+      mainJs.managerPath = path.join(mainDir, mainJs.managerPath);
+    }
+    if (mainJs.previewPath && fs.existsSync(path.join(mainDir, mainJs.previewPath))) {
+      mainJs.previewPath = path.join(mainDir, mainJs.previewPath);
+    }
+    mainJs.esDevServer = mainJs.esDevServer || {};
+  }
+
   const cliOptions = [
     {
       name: 'config-dir',
@@ -17,23 +49,25 @@ module.exports = function readCommandLineArgs() {
     {
       name: 'stories',
       alias: 's',
-      defaultValue: './stories/*.stories.{js,mdx}',
+      defaultValue: mainJs.stories || './stories/*.stories.{js,mdx}',
       description: 'List of story files e.g. --stories stories/*.stories.\\{js,mdx\\}',
     },
     {
       name: 'manager-path',
-      defaultValue: '@open-wc/storybook-prebuilt/dist/manager.js',
+      defaultValue: mainJs.managerPath || '@open-wc/storybook-prebuilt/dist/manager.js',
       description: 'Import path of a prebuilt manager file',
     },
     {
       name: 'preview-path',
-      defaultValue: '@open-wc/storybook-prebuilt/dist/preview.js',
+      defaultValue: mainJs.previewPath || '@open-wc/storybook-prebuilt/dist/preview.js',
       description: 'Import path of a prebuilt preview file',
     },
     { name: 'help', type: Boolean, description: 'See all options' },
   ];
 
   const storybookArgs = commandLineArgs(cliOptions, { partial: true });
+  storybookArgs.stories =
+    typeof storybookArgs.stories === 'string' ? [storybookArgs.stories] : storybookArgs.stories;
 
   if ('help' in storybookArgs) {
     /* eslint-disable-next-line no-console */
@@ -73,5 +107,6 @@ module.exports = function readCommandLineArgs() {
     previewPath: storybookArgs['preview-path'],
     // some args may be overwritten, as es-dev-server reads start-storybook.config.js
     ...esDevServerConfig,
+    ...mainJs.esDevServer,
   };
 };

--- a/packages/storybook-addon-web-components-knobs/package.json
+++ b/packages/storybook-addon-web-components-knobs/package.json
@@ -13,7 +13,6 @@
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",
-    "site:build": "build-storybook -c demo/.storybook -o ../../_site/demoing-storybook",
     "storybook": "start-storybook -p 9001 -c demo/.storybook",
     "storybook:build": "build-storybook -c demo/.storybook"
   },


### PR DESCRIPTION
alternative idea to 
https://github.com/open-wc/open-wc/pull/1227/

preread `main.js` and leave everything else as is... if we wanna go for that we would need to apply the same to the build