### PR TITLE
fix(demoing-storybook): fix serving preview with a custom root dir

### DIFF
--- a/packages/demoing-storybook/src/build/build.js
+++ b/packages/demoing-storybook/src/build/build.js
@@ -164,6 +164,7 @@ module.exports = async function build({
 }) {
   const assets = createAssets({
     storybookConfigDir,
+    rootDir: process.cwd(),
     managerPath,
     previewImport: previewPath,
     storyUrls,

--- a/packages/demoing-storybook/src/shared/getAssets.js
+++ b/packages/demoing-storybook/src/shared/getAssets.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const toBrowserPath = require('./toBrowserPath');
 
 function createContentHash(content) {
   return crypto
@@ -9,12 +10,20 @@ function createContentHash(content) {
     .digest('hex');
 }
 
-module.exports = function getAssets({ storybookConfigDir, managerPath, previewImport, storyUrls }) {
+module.exports = function getAssets({
+  storybookConfigDir,
+  rootDir,
+  managerPath,
+  previewImport,
+  storyUrls,
+}) {
   const managerIndexPath = path.join(__dirname, 'index.html');
   const iframePath = path.join(__dirname, 'iframe.html');
   const managerHeadPath = path.join(process.cwd(), storybookConfigDir, 'manager-head.html');
   const previewBodyPath = path.join(process.cwd(), storybookConfigDir, 'preview-body.html');
   const previewHeadPath = path.join(process.cwd(), storybookConfigDir, 'preview-head.html');
+  const previewJsPath = path.join(process.cwd(), storybookConfigDir, 'preview.js');
+  const previewJsImport = `./${toBrowserPath(path.relative(rootDir, previewJsPath))}`;
 
   let managerCode = fs.readFileSync(require.resolve(managerPath), 'utf-8');
   const managerSourceMap = fs.readFileSync(require.resolve(`${managerPath}.map`), 'utf-8');
@@ -52,8 +61,8 @@ module.exports = function getAssets({ storybookConfigDir, managerPath, previewIm
     '</body>',
     `
       </body>
-      <script type="module" src="./${storybookConfigDir}/preview.js"></script>
       <script type="module">
+        ${fs.existsSync(previewJsPath) ? `import '${previewJsImport}'` : ''}
         import { configure } from '${previewImport}';
 
         Promise.all([

--- a/packages/demoing-storybook/src/start/cli.js
+++ b/packages/demoing-storybook/src/start/cli.js
@@ -25,7 +25,7 @@ async function run() {
   const previewImport = toBrowserPath(previewPathRelative);
   const storyUrls = await storiesPatternsToUrls(config.stories, rootDir);
 
-  const assets = getAssets({ storybookConfigDir, managerPath, previewImport, storyUrls });
+  const assets = getAssets({ storybookConfigDir, rootDir, managerPath, previewImport, storyUrls });
   config.babelExclude = [...(config.babelExclude || []), assets.managerScriptUrl];
 
   config.babelModuleExclude = [...(config.babelModuleExclude || []), assets.managerScriptUrl];


### PR DESCRIPTION
Resolve the location of `preview.js` and then resolve it relative to the web server root dir.

Also, fixes https://github.com/open-wc/open-wc/issues/1183