### PR TITLE
docs(demoing-storybook): config property name correction

### DIFF
--- a/packages/demoing-storybook/README.md
+++ b/packages/demoing-storybook/README.md
@@ -96,7 +96,7 @@ module.exports = {
   },
 
   // Rollup build output directory (build-storybook only)
-  outputPath: '../dist',
+  outputDir: '../dist',
   // Configuration for rollup (build-storybook only)
   rollup: config => {
     return config;


### PR DESCRIPTION
Porting over my implementation to `main.js` and caught what is probably just a typo?

`outputPath` -> `outputDir`