### PR TITLE
fix(demoing-storybook): allow stories string start-storybook.config.js

### DIFF
--- a/packages/demoing-storybook/src/build/readCommandLineArgs.js
+++ b/packages/demoing-storybook/src/build/readCommandLineArgs.js
@@ -77,7 +77,6 @@ module.exports = function readCommandLineArgs() {
   ];
 
   const args = commandLineArgs(optionDefinitions);
-  args.stories = typeof args.stories === 'string' ? [args.stories] : args.stories;
 
   let options = {
     configDir: args['config-dir'],

--- a/packages/demoing-storybook/src/shared/storiesPatternsToFiles.js
+++ b/packages/demoing-storybook/src/shared/storiesPatternsToFiles.js
@@ -6,7 +6,8 @@ const listFiles = require('./listFiles');
  * Will return all matching file paths
  */
 module.exports = async function storiesPatternsToFiles(storiesPatterns, rootDir) {
-  const listFilesPromises = storiesPatterns.map(pattern => listFiles(pattern, rootDir));
+  const patterns = typeof storiesPatterns === 'string' ? [storiesPatterns] : storiesPatterns;
+  const listFilesPromises = patterns.map(pattern => listFiles(pattern, rootDir));
   const arrayOfFilesArrays = await Promise.all(listFilesPromises);
   const files = [];
 


### PR DESCRIPTION
I only upgraded `@open-wc/storybook` in a repo where `start-storybook.config.js` was used to define stories with a string and that failed...

=> move logic to convert to array where it is actually used (and not only for main.js)