### PR TITLE
fix(demoing-storybook): make preview.js available to storybook-build

### DIFF
--- a/packages/demoing-storybook/src/shared/getAssets.js
+++ b/packages/demoing-storybook/src/shared/getAssets.js
@@ -61,8 +61,12 @@ module.exports = function getAssets({
     '</body>',
     `
       </body>
+      ${
+        fs.existsSync(previewJsPath)
+          ? `<script type="module" src="${previewJsImport}"></script>`
+          : ''
+      }
       <script type="module">
-        ${fs.existsSync(previewJsPath) ? `import '${previewJsImport}'` : ''}
         import { configure } from '${previewImport}';
 
         Promise.all([


### PR DESCRIPTION
`storybook-build` no longer references my `preview.js` settings/code, and this seems to bring it back. It doesn't make any sense, because the import statement _should_ be 100% the same, but I prefer working code to code that I understand...apparently. Let me know if you can think of a better fix or a reason for this issue. The following branch of my project exhibits the issues I ran into https://github.com/adobe/spectrum-web-components/tree/westbrook/storybook-cleanup use `yarn storybook:build && npx http-server documentation/dist/storybook` to experience the issues when comparing to https://opensource.adobe.com/spectrum-web-components/storybook/?path=/story/action-menu--icon-only You'll see the padding is off in the demo, this is due to `sp-theme` being excluded from the demo HTML.