### PR TITLE
Fix incorrect links in README

### DIFF
--- a/packages/demoing-storybook/README.md
+++ b/packages/demoing-storybook/README.md
@@ -33,7 +33,7 @@ This is part of the default [open-wc](https://open-wc.org/) recommendation
 ## Demo
 
 ::: tip
-Don't take our word for it but look at [the documentation of a demo card](/demoing-storybook/?path=/docs/demo-card-docs--simple) and [the documentation of the knobs decorator](/demoing-storybook/?path=/docs/decorators-withwebcomponentknobs--example-output).
+Don't take our word for it but look at [the documentation of a demo card](https://open-wc.org/demoing-storybook/?path=/docs/demo-card-docs--simple) and [the documentation of the knobs decorator](https://open-wc.org/demoing-storybook/?path=/docs/decorators-withwebcomponentknobs--example-output).
 :::
 
 ## Setup


### PR DESCRIPTION
Not sure if/how these links worked before but thinking they should be linked to (Open WC)[https://open-wc.org]