### PR TITLE
fix(es-dev-server): handle url parameters with . characters (#1059)

### DIFF
--- a/packages/es-dev-server/src/middleware/history-api-fallback.js
+++ b/packages/es-dev-server/src/middleware/history-api-fallback.js
@@ -13,7 +13,9 @@
 export function createHistoryAPIFallbackMiddleware(cfg) {
   /** @type {import('koa').Middleware} */
   function historyAPIFallback(ctx, next) {
-    if (ctx.method !== 'GET' || ctx.url.includes('.')) {
+    // . character hints at a file request (could possibly check with regex for file ext)
+    const cleanUrl = ctx.url.split('?')[0].split('#')[0];
+    if (ctx.method !== 'GET' || cleanUrl.includes('.')) {
       return next();
     }
 

--- a/packages/es-dev-server/test/middleware/history-api-fallback.test.js
+++ b/packages/es-dev-server/test/middleware/history-api-fallback.test.js
@@ -55,6 +55,14 @@ describe('history api fallback middleware', () => {
       expect(responseText).to.include('Hello world!');
       expect(responseText).to.not.include('<title>My app</title>');
     });
+
+    it('does return index.html for requests that have url parameters with . characters (issue 1059)', async () => {
+      const response = await fetch(`${host}text-files/foo/bar/?baz=open.wc`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.include('<title>My app</title>');
+    });
   });
 
   describe('index not in root', () => {
@@ -111,6 +119,14 @@ describe('history api fallback middleware', () => {
 
       expect(response.status).to.equal(404);
       expect(responseText).to.not.include('<title>My app</title>');
+    });
+
+    it('does return index.html for requests that have url parameters with . characters (issue 1059)', async () => {
+      const response = await fetch(`${host}src/foo/bar/?baz=open.wc`);
+      const responseText = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(responseText).to.include('<title>My app</title>');
     });
   });
 });


### PR DESCRIPTION
Validate only the url path, not the querystring, for . characters
to detect file paths.