### PR TITLE
feat(building-utils): shady css scoped polyfill (v2)

### DIFF
--- a/packages/building-utils/index-html/create-index-html.js
+++ b/packages/building-utils/index-html/create-index-html.js
@@ -38,7 +38,7 @@ const { cleanImportPath } = require('./utils');
 /**
  * @typedef {object} PolyfillInstruction
  * @property {string} name name of the polyfill
- * @property {string} path polyfill path
+ * @property {string|Array<string>} path polyfill path
  * @property {string} [test] expression which should evaluate to true to load the polyfill
  * @property {boolean} [nomodule] whether to inject the polyfills as a script with nomodule attribute
  * @property {boolean} [module] wether to load the polyfill with type module
@@ -51,6 +51,7 @@ const { cleanImportPath } = require('./utils');
  * @property {boolean} [coreJs] whether to polyfill core-js polyfills
  * @property {boolean} [regeneratorRuntime] whether to add regenerator runtime
  * @property {boolean} [webcomponents] whether to polyfill webcomponents
+ * @property {boolean} [customStyles] whether to polyfill customStyles
  * @property {boolean} [fetch] whether to polyfill fetch
  * @property {boolean} [intersectionObserver] whether to polyfill intersection observer
  * @property {boolean} [dynamicImport] whether to polyfill dynamic import

--- a/packages/building-utils/index-html/create-index-html.js
+++ b/packages/building-utils/index-html/create-index-html.js
@@ -51,7 +51,7 @@ const { cleanImportPath } = require('./utils');
  * @property {boolean} [coreJs] whether to polyfill core-js polyfills
  * @property {boolean} [regeneratorRuntime] whether to add regenerator runtime
  * @property {boolean} [webcomponents] whether to polyfill webcomponents
- * @property {boolean} [customStyles] whether to polyfill customStyles
+ * @property {boolean} [shadyCSS] whether to polyfill shadyCSS
  * @property {boolean} [fetch] whether to polyfill fetch
  * @property {boolean} [intersectionObserver] whether to polyfill intersection observer
  * @property {boolean} [dynamicImport] whether to polyfill dynamic import

--- a/packages/building-utils/index-html/polyfills.js
+++ b/packages/building-utils/index-html/polyfills.js
@@ -122,7 +122,7 @@ function getPolyfills(config) {
     }
   }
 
-  if (config.polyfills.webcomponents && !config.polyfills.customStyles) {
+  if (config.polyfills.webcomponents && !config.polyfills.shadyCSS) {
     try {
       instructions.push({
         name: 'webcomponents',
@@ -163,27 +163,30 @@ function getPolyfills(config) {
     }
   }
 
-  if (config.polyfills.customStyles && !config.polyfills.webcomponents) {
-    // customStyles isn't going to work without webcomponents.
+  if (config.polyfills.shadyCSS && !config.polyfills.webcomponents) {
+    // shadyCSS isn't going to work without webcomponents.
     throw new Error(
       'configured to polyfill custom-styles, which depends on webcomponents. add `webcomponents:true` to your polyfills config.',
     );
   }
-  if (config.polyfills.customStyles && config.polyfills.webcomponents) {
-    // customStyles polyfill *must* load after the webcomponents polyfill or it doesn't work.
+  if (config.polyfills.shadyCSS && config.polyfills.webcomponents) {
+    // shadyCSS polyfill *must* load after the webcomponents polyfill or it doesn't work.
     // to get around that, concat the two together.
     try {
       instructions.push({
-        name: 'custom-styles',
+        name: 'shady-css',
         test: "!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype)",
         path: [
           require.resolve('@webcomponents/webcomponentsjs/webcomponents-bundle.js'),
           require.resolve('@webcomponents/shadycss/custom-style-interface.min.js'),
+          require.resolve(
+            '@webcomponents/shady-css-scoped-element/shady-css-scoped-element.min.js',
+          ),
         ],
       });
     } catch (error) {
       throw new Error(
-        'configured to polyfill shadycss, but no pollyfills found. Install with "npm i -D @webcomponents/shadycss"',
+        'configured to polyfill shadycss, but no pollyfills found. Install with "npm i -D @webcomponents/shadycss" and "npm i -D @webcomponents/shady-scoped-css-element"',
       );
     }
   }

--- a/packages/building-utils/package.json
+++ b/packages/building-utils/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.3.3",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@webcomponents/shadycss": "^1.9.1",
-    "@webcomponents/shady-css-scoped-element": "^0.0.1",
+    "shady-css-scoped-element": "^0.0.1",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "arrify": "^2.0.1",
     "browserslist": "^4.5.6",

--- a/packages/building-utils/package.json
+++ b/packages/building-utils/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@babel/core": "^7.3.3",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+    "@webcomponents/shadycss": "^1.9.1",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "arrify": "^2.0.1",
     "browserslist": "^4.5.6",

--- a/packages/building-utils/package.json
+++ b/packages/building-utils/package.json
@@ -28,6 +28,7 @@
     "@babel/core": "^7.3.3",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@webcomponents/shadycss": "^1.9.1",
+    "@webcomponents/shady-css-scoped-element": "^0.0.1",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "arrify": "^2.0.1",
     "browserslist": "^4.5.6",

--- a/packages/es-dev-server/src/middleware/compile-middleware.js
+++ b/packages/es-dev-server/src/middleware/compile-middleware.js
@@ -138,7 +138,9 @@ export function createCompileMiddleware(cfg) {
       // browser
       if (error instanceof ResolveSyntaxError) {
         logError(
-          `Could not resolve module imports in ${ctx.url}: Unable to parse the module, this can be due to experimental syntax or a bug in the parser.`,
+          `Could not resolve module imports in ${
+            ctx.url
+          }: Unable to parse the module, this can be due to experimental syntax or a bug in the parser.`,
         );
         return undefined;
       }

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -34,6 +34,7 @@
     "parse5": "^5.1.0"
   },
   "devDependencies": {
+    "@webcomponents/shadycss": "^1.9.1",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "chai": "^4.2.0",
     "intersection-observer": "^0.7.0",

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@webcomponents/shadycss": "^1.9.1",
+    "@webcomponents/shady-css-scoped-element": "^0.0.1",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "chai": "^4.2.0",
     "intersection-observer": "^0.7.0",

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@webcomponents/shadycss": "^1.9.1",
-    "@webcomponents/shady-css-scoped-element": "^0.0.1",
+    "shady-css-scoped-element": "^0.0.1",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "chai": "^4.2.0",
     "intersection-observer": "^0.7.0",

--- a/packages/rollup-plugin-index-html/rollup-plugin-index-html.js
+++ b/packages/rollup-plugin-index-html/rollup-plugin-index-html.js
@@ -81,7 +81,7 @@ module.exports = (pluginConfig = {}) => {
     },
 
     resolveId(source, importer) {
-      // if this is an inline entry keep it, load() will take ca,re of it
+      // if this is an inline entry keep it, load() will take care of it
       if (typeof findInlineEntryId(source) === 'number') {
         return source;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,6 +1991,30 @@
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.13.21.tgz#718b9ec5f9a98935fc775e577ad094ae8d8b7dea"
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
+"@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
+  version "1.1.58"
+  dependencies:
+    "@open-wc/testing-karma" "^3.1.33"
+    "@types/node" "^11.13.0"
+    karma-browserstack-launcher "^1.0.0"
+
+"@open-wc/testing-karma@file:./packages/testing-karma":
+  version "3.1.33"
+  dependencies:
+    "@open-wc/karma-esm" "^2.5.8"
+    axe-core "^3.3.1"
+    istanbul-instrumenter-loader "^3.0.0"
+    karma "^4.0.0"
+    karma-chrome-launcher "^2.0.0"
+    karma-coverage-istanbul-reporter "^2.0.0"
+    karma-mocha "^1.0.0"
+    karma-mocha-reporter "^2.0.0"
+    karma-mocha-snapshot "^0.2.1"
+    karma-snapshot "^0.6.0"
+    karma-source-map-support "^1.3.0"
+    karma-sourcemap-loader "^0.3.0"
+    mocha "^6.2.0"
+
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -14433,6 +14457,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shady-css-scoped-element@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/shady-css-scoped-element/-/shady-css-scoped-element-0.0.1.tgz#e386ff2228bb3677376985a34d65101372ed66dc"
+  integrity sha512-86NPanHuXXTayw0psXbqMBU11rptlhAU17N3ZVxWYm6/KxMc02M/l6gGAEUb2Jff7W3Ur/ARWufPKmm/nNOU2g==
 
 shallowequal@^1.0.2:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,30 +1991,6 @@
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.13.21.tgz#718b9ec5f9a98935fc775e577ad094ae8d8b7dea"
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
-"@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.1.55"
-  dependencies:
-    "@open-wc/testing-karma" "^3.1.30"
-    "@types/node" "^11.13.0"
-    karma-browserstack-launcher "^1.0.0"
-
-"@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.1.30"
-  dependencies:
-    "@open-wc/karma-esm" "^2.5.5"
-    axe-core "^3.3.1"
-    istanbul-instrumenter-loader "^3.0.0"
-    karma "^4.0.0"
-    karma-chrome-launcher "^2.0.0"
-    karma-coverage-istanbul-reporter "^2.0.0"
-    karma-mocha "^1.0.0"
-    karma-mocha-reporter "^2.0.0"
-    karma-mocha-snapshot "^0.2.1"
-    karma-snapshot "^0.6.0"
-    karma-source-map-support "^1.3.0"
-    karma-sourcemap-loader "^0.3.0"
-    mocha "^6.2.0"
-
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -3131,6 +3107,11 @@
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
+
+"@webcomponents/shadycss@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.9.1.tgz#d769fbadfa504f11b84caeef26701f89070ec49a"
+  integrity sha512-IaZOnWOKXHghqk/WfPNDRIgDBi3RsVPY2IFAw6tYiL9UBGvQRy5R6uC+Fk7qTZsReTJ0xh5MTT8yAcb3MUR4mQ==
 
 "@webcomponents/webcomponentsjs@^1.2.0":
   version "1.3.3"


### PR DESCRIPTION
picks up where https://github.com/open-wc/open-wc/pull/809 left off. The only change between this branch and the prior branch is that the shady-css-scoped-element is published as an independent package instead of by webcomponents/polyfills.