### PR TITLE
Feat/storybook dynamic stories

### DIFF
--- a/packages/demoing-storybook/src/build/build.js
+++ b/packages/demoing-storybook/src/build/build.js
@@ -154,13 +154,13 @@ async function buildManager({ outputDir, assets }) {
 
 async function buildPreview({
   outputDir,
-  assets,
+  assets: { iframeHTML },
   previewPath,
   storiesPatterns,
   rollupConfigDecorator,
 }) {
   const { html, storyFiles } = await injectStories({
-    iframeHTML: assets.iframeHTML,
+    iframeHTML,
     previewImport: previewPath,
     storiesPatterns,
     absolutePath: false,

--- a/packages/demoing-storybook/src/build/cli.js
+++ b/packages/demoing-storybook/src/build/cli.js
@@ -1,33 +1,13 @@
 #!/usr/bin/env node
-
-/* eslint-disable no-console */
-const path = require('path');
-
 const build = require('./build');
 const readCommandLineArgs = require('./readCommandLineArgs');
-const toBrowserPath = require('../shared/toBrowserPath');
-const storiesPatternsToFiles = require('../shared/storiesPatternsToFiles');
 
 (async function main() {
-  const rootDir = process.cwd();
   const config = readCommandLineArgs();
-  const storiesPattern = `${process.cwd()}/${config.stories}`;
-  const storyFiles = await storiesPatternsToFiles(config.stories, rootDir);
-  const storyUrls = storyFiles.map(filePath => {
-    const relativeFilePath = path.relative(rootDir, filePath);
-    return `./${toBrowserPath(relativeFilePath)}`;
-  });
-
-  if (storyUrls.length === 0) {
-    console.log(`We could not find any stories for the provided pattern "${storiesPattern}".
-      You can override it by doing "--stories ./your-pattern.js`);
-    process.exit(1);
-  }
 
   await build({
     storybookConfigDir: config.configDir,
-    storyFiles,
-    storyUrls,
+    storiesPatterns: config.stories,
     outputDir: config.outputDir,
     managerPath: require.resolve(config.managerPath),
     previewPath: require.resolve(config.previewPath),

--- a/packages/demoing-storybook/src/shared/getAssets.js
+++ b/packages/demoing-storybook/src/shared/getAssets.js
@@ -2,13 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const toBrowserPath = require('./toBrowserPath');
 
-module.exports = function getAssets({
-  storybookConfigDir,
-  rootDir,
-  previewImport,
-  managerImport,
-  storyUrls,
-}) {
+module.exports = function getAssets({ storybookConfigDir, rootDir, managerImport }) {
   const managerIndexPath = path.join(__dirname, 'index.html');
   const iframePath = path.join(__dirname, 'iframe.html');
   const managerHeadPath = path.join(process.cwd(), storybookConfigDir, 'manager-head.html');
@@ -39,26 +33,15 @@ module.exports = function getAssets({
     iframeHTML = iframeHTML.replace('</body>', `${previewBody}</body>`);
   }
 
-  iframeHTML = iframeHTML.replace(
-    '</body>',
-    `
-      </body>
-      ${
-        fs.existsSync(previewJsPath)
-          ? `<script type="module" src="${previewJsImport}"></script>`
-          : ''
-      }
-      <script type="module">
-        import { configure } from '${previewImport}';
-
-        Promise.all([
-          ${storyUrls.map(url => `import('${url}')`).join(',\n')}
-        ]).then(stories => {
-          configure(() => stories, {});
-        });
-      </script>
-    `,
-  );
+  if (fs.existsSync(previewJsPath)) {
+    iframeHTML = iframeHTML.replace(
+      '</body>',
+      `
+  <script type="module" src="${previewJsImport}"></script>
+  </body>
+  `,
+    );
+  }
 
   return {
     indexHTML,

--- a/packages/demoing-storybook/src/shared/injectStories.js
+++ b/packages/demoing-storybook/src/shared/injectStories.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+const storiesPatternsToUrls = require('./storiesPatternsToUrls');
+
+/**
+ * @param {object} args
+ * @param {string} args.iframeHTML
+ * @param {string} args.previewImport
+ * @param {string[]} args.storiesPatterns
+ * @param {string} args.rootDir
+ * @param {boolean} args.absolutePath
+ */
+async function injectStories({
+  iframeHTML,
+  previewImport,
+  storiesPatterns,
+  rootDir,
+  absolutePath,
+}) {
+  const { files, urls } = await storiesPatternsToUrls({
+    storiesPatterns,
+    rootDir,
+    absolutePath,
+  });
+  if (urls.length === 0) {
+    console.warn(
+      `We could not find any stories for the provided pattern(s) "${storiesPatterns}". You can configure this in your main.js configuration file.`,
+    );
+  }
+
+  const newIframeHtml = iframeHTML.replace(
+    '</body>',
+    `
+<script type="module">
+  import { configure } from '${previewImport}';
+  ${urls.map((url, i) => `import * as story${i} from '${url}'`).join(';\n  ')}
+
+  configure(() => [
+    ${urls.map((_, i) => `story${i}`).join(',\n    ')}
+  ], {});
+  </script>
+</body>
+`,
+  );
+
+  return { html: newIframeHtml, storyFiles: files, storyUrls: urls };
+}
+
+module.exports = { injectStories };

--- a/packages/demoing-storybook/src/shared/storiesPatternsToUrls.js
+++ b/packages/demoing-storybook/src/shared/storiesPatternsToUrls.js
@@ -7,10 +7,12 @@ const toBrowserPath = require('./toBrowserPath');
  *
  * Will return all matching urls.
  */
-module.exports = async function storiesPatternsToUrls(storiesPatterns, rootDir) {
-  const arrayOfFilesArrays = await storiesPatternsToFiles(storiesPatterns, rootDir);
-  return arrayOfFilesArrays.map(filePath => {
+module.exports = async function storiesPatternsToUrls({ storiesPatterns, rootDir, absolutePath }) {
+  const files = await storiesPatternsToFiles(storiesPatterns, rootDir);
+  const urls = files.map(filePath => {
     const relativeFilePath = path.relative(rootDir, filePath);
-    return `/${toBrowserPath(relativeFilePath)}`;
+    return `${absolutePath ? '' : '.'}/${toBrowserPath(relativeFilePath)}`;
   });
+
+  return { files, urls };
 };

--- a/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
+++ b/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
@@ -1,15 +1,53 @@
-module.exports = function createServeStorybookTransformer(assets) {
-  return function serveStorybookTransformer({ url }) {
+const { injectStories } = require('../../shared/injectStories');
+const { createOrderedExports } = require('../../shared/createOrderedExports');
+
+/**
+ * @param {object} args
+ * @param {object} args.assets
+ * @param {string} args.assets.indexHTML
+ * @param {string} args.assets.iframeHTML
+ * @param {string} args.previewImport
+ * @param {string[]} args.storiesPatterns
+ * @param {string} args.rootDir
+ */
+function createServeStorybookTransformer({ assets, previewImport, storiesPatterns, rootDir }) {
+  const servedStoryUrls = new Set();
+  const { indexHTML, iframeHTML } = assets;
+
+  return async function serveStorybookTransformer({ url, status, body }) {
     const cleanURL = url.split('?')[0].split('#')[0];
 
     if (cleanURL === '/iframe.html') {
-      return { body: assets.iframeHTML, contentType: 'text/html' };
+      const { html, storyUrls } = await injectStories({
+        iframeHTML,
+        previewImport,
+        storiesPatterns,
+        absolutePath: true,
+        rootDir,
+      });
+
+      storyUrls.forEach(s => {
+        servedStoryUrls.add(s);
+      });
+
+      return { body: html, contentType: 'text/html' };
     }
 
     if (cleanURL === '/' || cleanURL === '/index.html') {
-      return { body: assets.indexHTML, contentType: 'text/html' };
+      return { body: indexHTML, contentType: 'text/html' };
+    }
+
+    if (status === 200 && servedStoryUrls.has(cleanURL)) {
+      const orderedExports = await createOrderedExports(body);
+      if (!orderedExports) {
+        return null;
+      }
+
+      return { body: `${body}\n\n${orderedExports}` };
     }
 
     return null;
   };
-};
+}
+
+module.exports = createServeStorybookTransformer;

--- a/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
+++ b/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
@@ -7,7 +7,7 @@ const { createOrderedExports } = require('../../shared/createOrderedExports');
  * @param {string} args.assets.indexHTML
  * @param {string} args.assets.iframeHTML
  * @param {string} args.previewImport
- * @param {string[]} args.storiesPatterns
+ * @param {string[]} args.storiesPatterns glob patterns of story files
  * @param {string} args.rootDir
  */
 function createServeStorybookTransformer({ assets, previewImport, storiesPatterns, rootDir }) {

--- a/packages/es-dev-server/src/middleware/polyfills-loader.js
+++ b/packages/es-dev-server/src/middleware/polyfills-loader.js
@@ -94,7 +94,9 @@ export function createPolyfillsLoaderMiddleware(cfg) {
 
     // return cached index.html if it did not change
     const data = indexHTMLData.get(uaCompat.browserTarget + ctx.url);
-    if (data && data.lastModified === lastModified) {
+    // if there is no lastModified cached, the HTML file is not served from the
+    // file system
+    if (data && data.lastModified && lastModified && data.lastModified === lastModified) {
       ctx.body = data.indexHTML;
       return undefined;
     }

--- a/packages/es-dev-server/src/utils/setup-browser-reload.js
+++ b/packages/es-dev-server/src/utils/setup-browser-reload.js
@@ -18,5 +18,7 @@ function onFileChanged() {
  * @param {SetupBrowserReloadConfig} cfg
  */
 export function setupBrowserReload(cfg) {
-  cfg.fileWatcher.addListener('change', debounce(onFileChanged, cfg.watchDebounce));
+  const onChange = debounce(onFileChanged, cfg.watchDebounce);
+  cfg.fileWatcher.addListener('change', onChange);
+  cfg.fileWatcher.addListener('unlink', onChange);
 }


### PR DESCRIPTION
This changes looking for stories dynamic, doing a lookup for stories each time iframe.html is served. This way when you refresh, you always get the latest stories which are added/removed/renamed.

It also makes es-dev-server trigger a reload on file names, and makes the story imports into static imports to prevent rollup from creating many separate chunks.

Fixes #1275
Fixes #1179