### PR TITLE
fix(testing): export "waitUntil" type

### DIFF
--- a/packages/testing/index.d.ts
+++ b/packages/testing/index.d.ts
@@ -15,6 +15,7 @@ export { fixture } from '@open-wc/testing-helpers/index.js';
 export { fixtureSync } from '@open-wc/testing-helpers/index.js';
 export { fixtureCleanup } from '@open-wc/testing-helpers/index.js';
 export { elementUpdated } from '@open-wc/testing-helpers/index.js';
+export { waitUntil } from '@open-wc/testing-helpers/index.js';
 
 import chai from 'chai';
 


### PR DESCRIPTION
This type is currently missing, which requires the reliance on both `@open-wc/testing` and `@open-wc/testing-helpers` in a TS environment. Annoying.