### PR TITLE
fix(demoing-storybook): always load user preview.js before stories

### DIFF
--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -22,6 +22,7 @@
     "build:start": "es-dev-server --root-dir static-storybook --app-index index.html --open",
     "prepublishOnly": "../../scripts/insert-header.js",
     "site:build": "node src/build/cli.js --config-dir demo/.storybook -o ../../_site/demoing-storybook",
+    "start": "npm run storybook",
     "storybook": "node src/start/cli.js -c demo/.storybook --root-dir ../../",
     "storybook:build": "node src/build/cli.js -c demo/.storybook",
     "test": "mocha test/**/*.test.js test/*.test.js",

--- a/packages/demoing-storybook/src/build/build.js
+++ b/packages/demoing-storybook/src/build/build.js
@@ -156,12 +156,14 @@ async function buildPreview({
   outputDir,
   assets: { iframeHTML },
   previewPath,
+  previewConfigImport,
   storiesPatterns,
   rollupConfigDecorator,
 }) {
   const { html, storyFiles } = await injectStories({
     iframeHTML,
     previewImport: previewPath,
+    previewConfigImport,
     storiesPatterns,
     absolutePath: false,
     rootDir: process.cwd(),
@@ -218,13 +220,22 @@ module.exports = async function build({
 
   const assets = createAssets({
     storybookConfigDir,
-    rootDir: process.cwd(),
     managerImport,
   });
+
+  const previewConfigPath = path.join(process.cwd(), storybookConfigDir, 'preview.js');
+  const previewConfigImport = fs.existsSync(previewConfigPath) ? previewConfigPath : undefined;
 
   await fs.remove(outputDir);
   await fs.mkdirp(outputDir);
 
   await buildManager({ outputDir, assets });
-  await buildPreview({ outputDir, assets, storiesPatterns, previewPath, rollupConfigDecorator });
+  await buildPreview({
+    outputDir,
+    assets,
+    storiesPatterns,
+    previewPath,
+    previewConfigImport,
+    rollupConfigDecorator,
+  });
 };

--- a/packages/demoing-storybook/src/shared/getAssets.js
+++ b/packages/demoing-storybook/src/shared/getAssets.js
@@ -1,15 +1,12 @@
 const fs = require('fs');
 const path = require('path');
-const toBrowserPath = require('./toBrowserPath');
 
-module.exports = function getAssets({ storybookConfigDir, rootDir, managerImport }) {
+module.exports = function getAssets({ storybookConfigDir, managerImport }) {
   const managerIndexPath = path.join(__dirname, 'index.html');
   const iframePath = path.join(__dirname, 'iframe.html');
   const managerHeadPath = path.join(process.cwd(), storybookConfigDir, 'manager-head.html');
   const previewBodyPath = path.join(process.cwd(), storybookConfigDir, 'preview-body.html');
   const previewHeadPath = path.join(process.cwd(), storybookConfigDir, 'preview-head.html');
-  const previewJsPath = path.join(process.cwd(), storybookConfigDir, 'preview.js');
-  const previewJsImport = `./${toBrowserPath(path.relative(rootDir, previewJsPath))}`;
 
   let indexHTML = fs.readFileSync(managerIndexPath, 'utf-8');
   if (fs.existsSync(managerHeadPath)) {
@@ -31,16 +28,6 @@ module.exports = function getAssets({ storybookConfigDir, rootDir, managerImport
   if (fs.existsSync(previewBodyPath)) {
     const previewBody = fs.readFileSync(previewBodyPath, 'utf-8');
     iframeHTML = iframeHTML.replace('</body>', `${previewBody}</body>`);
-  }
-
-  if (fs.existsSync(previewJsPath)) {
-    iframeHTML = iframeHTML.replace(
-      '</body>',
-      `
-  <script type="module" src="${previewJsImport}"></script>
-  </body>
-  `,
-    );
   }
 
   return {

--- a/packages/demoing-storybook/src/shared/injectStories.js
+++ b/packages/demoing-storybook/src/shared/injectStories.js
@@ -5,6 +5,7 @@ const storiesPatternsToUrls = require('./storiesPatternsToUrls');
  * @param {object} args
  * @param {string} args.iframeHTML
  * @param {string} args.previewImport
+ * @param {string} [args.previewConfigImport]
  * @param {string[]} args.storiesPatterns
  * @param {string} args.rootDir
  * @param {boolean} args.absolutePath
@@ -12,6 +13,7 @@ const storiesPatternsToUrls = require('./storiesPatternsToUrls');
 async function injectStories({
   iframeHTML,
   previewImport,
+  previewConfigImport,
   storiesPatterns,
   rootDir,
   absolutePath,
@@ -31,6 +33,7 @@ async function injectStories({
     '</body>',
     `
 <script type="module">
+  ${previewConfigImport ? `import '${previewConfigImport}';` : ''}
   import { configure } from '${previewImport}';
   ${urls.map((url, i) => `import * as story${i} from '${url}'`).join(';\n  ')}
 

--- a/packages/demoing-storybook/src/start/cli.js
+++ b/packages/demoing-storybook/src/start/cli.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-console, no-param-reassign */
 const { createConfig, startServer } = require('es-dev-server');
 const path = require('path');
+const fs = require('fs');
 
 const readCommandLineArgs = require('./readCommandLineArgs');
 const createServeStorybookTransformer = require('./transformers/createServeStorybookTransformer');
@@ -22,14 +23,15 @@ async function run() {
   const previewImport = toBrowserPath(previewPathRelative);
   const managerImport = toBrowserPath(managerPathRelative);
 
-  const assets = getAssets({
-    storybookConfigDir,
-    rootDir,
-    managerImport,
-  });
+  const previewConfigPath = path.join(process.cwd(), storybookConfigDir, 'preview.js');
+  let previewConfigImport;
+  if (fs.existsSync(previewConfigPath)) {
+    previewConfigImport = `/${toBrowserPath(path.relative(rootDir, previewConfigPath))}`;
+  }
+
+  const assets = getAssets({ storybookConfigDir, managerImport });
 
   config.babelModernExclude = [...(config.babelModernExclude || []), '**/storybook-prebuilt/**'];
-
   config.fileExtensions = [...(config.fileExtensions || []), '.mdx'];
 
   config.responseTransformers = [
@@ -38,6 +40,7 @@ async function run() {
     createServeStorybookTransformer({
       assets,
       previewImport,
+      previewConfigImport,
       storiesPatterns: config.stories,
       rootDir,
     }),

--- a/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
+++ b/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
@@ -7,10 +7,17 @@ const { createOrderedExports } = require('../../shared/createOrderedExports');
  * @param {string} args.assets.indexHTML
  * @param {string} args.assets.iframeHTML
  * @param {string} args.previewImport
+ * @param {string} args.previewConfigImport
  * @param {string[]} args.storiesPatterns glob patterns of story files
  * @param {string} args.rootDir
  */
-function createServeStorybookTransformer({ assets, previewImport, storiesPatterns, rootDir }) {
+function createServeStorybookTransformer({
+  assets,
+  previewImport,
+  previewConfigImport,
+  storiesPatterns,
+  rootDir,
+}) {
   const servedStoryUrls = new Set();
   const { indexHTML, iframeHTML } = assets;
 
@@ -21,6 +28,7 @@ function createServeStorybookTransformer({ assets, previewImport, storiesPattern
       const { html, storyUrls } = await injectStories({
         iframeHTML,
         previewImport,
+        previewConfigImport,
         storiesPatterns,
         absolutePath: true,
         rootDir,


### PR DESCRIPTION
We always had a race condition where the user's preview.js could be loaded before the user's stories. With the recent change of changing dynamic imports into static imports, this race condition is more likely to occur.

Moving this to a regular import makes the stories wait for the user's preview configuration.