### PR TITLE
Point package.json homepages to specific directories in monorepo

### DIFF
--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/building-rollup"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/building-rollup",
   "main": "index.js",
   "scripts": {
     "demo:build": "rimraf dist && rollup -c demo/js/rollup.config.js",

--- a/packages/building-utils/package.json
+++ b/packages/building-utils/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/building-utils"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/building-utils",
   "scripts": {
     "test": "npm run test:node",
     "test:node": "mocha test/**/*.test.js test/*.test.js",

--- a/packages/building-webpack/package.json
+++ b/packages/building-webpack/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/building-webpack"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/building-webpack",
   "main": "index.js",
   "scripts": {
     "demo:build": "webpack --mode production --config demo/js/webpack.config.js",

--- a/packages/chai-a11y-axe/package.json
+++ b/packages/chai-a11y-axe/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/chai-a11y-axe"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/chai-a11y-axe",
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"

--- a/packages/codelabs/package.json
+++ b/packages/codelabs/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/codelabs"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/codelabs",
   "scripts": {
     "site:build": "node build-codelabs.js"
   },

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/create"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/create",
   "bin": {
     "create-open-wc": "./dist/create.js"
   },

--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/building-storybook"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/demoing-storybook",
   "main": "index.js",
   "bin": {
     "start-storybook": "src/start/cli.js",

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/es-dev-server"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/es-dev-server",
   "main": "./dist/es-dev-server.js",
   "bin": {
     "es-dev-server": "./dist/cli.js"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/eslint-config"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/eslint-config",
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"

--- a/packages/import-maps-generate/package.json
+++ b/packages/import-maps-generate/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/import-maps-generate"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/import-maps-generate",
   "main": "dist/generate.js",
   "bin": {
     "generate": "./dist/generate.js",

--- a/packages/import-maps-resolve/package.json
+++ b/packages/import-maps-resolve/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/import-maps-resolve"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/import-maps-resolve",
   "main": "dist/index.js",
   "scripts": {
     "build": "babel src --out-dir dist --copy-files --include-dotfiles",

--- a/packages/karma-esm/package.json
+++ b/packages/karma-esm/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/karma-esm"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/karma-esm",
   "main": "./karma-esm.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",

--- a/packages/lit-helpers/package.json
+++ b/packages/lit-helpers/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/lit-helpers"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/lit-helpers",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/polyfills-loader"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/packages/polyfills-loader",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/polyfills-loader",
   "main": "index.js",
   "engines": {
     "node": ">=0.10.0"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/prettier-config"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/prettier-config",
   "main": "prettier.config.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/webpack-index-html-plugin"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/rollup-plugin-index-html",
   "main": "rollup-plugin-index-html.js",
   "scripts": {
     "test": "npm run test:node",

--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/scoped-elements"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/scoped-elements",
   "scripts": {
     "demo-build:before-nesting": "rollup -c demo/before-nesting/rollup.config.js",
     "demo-build:no-scope": "rollup -c demo/no-scope/rollup.config.js",

--- a/packages/semantic-dom-diff/package.json
+++ b/packages/semantic-dom-diff/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/semantic-dom-diff"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/semantic-dom-diff",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/storybook-addon-web-components-knobs/package.json
+++ b/packages/storybook-addon-web-components-knobs/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/storybook-addon-web-components-knobs"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/storybook-addon-web-components-knobs",
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/testing-helpers"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing-helpers",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/testing-karma-bs/package.json
+++ b/packages/testing-karma-bs/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/testing-karma-bs"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing-karma-bs",
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",

--- a/packages/testing-karma/package.json
+++ b/packages/testing-karma/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/testing-karma"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing-karma",
   "main": "testing-karma.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"

--- a/packages/testing-wallaby/package.json
+++ b/packages/testing-wallaby/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/testing-wallaby"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing-wallaby",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/testing"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/webpack-import-meta-loader/package.json
+++ b/packages/webpack-import-meta-loader/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/webpack-import-meta-loader"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/webpack-import-meta-loader",
   "main": "webpack-import-meta-loader.js",
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",

--- a/packages/webpack-index-html-plugin/package.json
+++ b/packages/webpack-index-html-plugin/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/webpack-index-html-plugin"
   },
   "author": "open-wc",
-  "homepage": "https://github.com/open-wc/open-wc/",
+  "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/webpack-index-html-plugin",
   "main": "webpack-index-html-plugin.js",
   "scripts": {
     "test": "mocha test/**/*.test.js test/*.test.js",


### PR DESCRIPTION
This way the "homepage" at at npmjs.com (e.g. https://www.npmjs.com/package/es-dev-server) will lead to the package-specific directory instead of the top-level monorepo. Useful for e.g. finding the CHANGELOG.