### PR TITLE
ci: include node_modules in workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
+              - repo/node_modules
               - repo/packages/*/node_modules
               - repo/packages/*/dist
   test-local:
@@ -59,6 +60,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      # Download and cache dependencies
       - attach_workspace:
             at: ~/
       # Download and cache dependencies


### PR DESCRIPTION
🙈 Missed a dependency on the deploy step!

Running the CI now to see whether it looks better to have this in the workspace or to load the cache in the deploy step.