### PR TITLE
Fix/resolve module imports

### DIFF
--- a/packages/es-dev-server/src/utils/resolve-module-imports.js
+++ b/packages/es-dev-server/src/utils/resolve-module-imports.js
@@ -184,11 +184,16 @@ async function resolveModuleImportsWithConfig(importer, source, cfg) {
       lastIndex = end;
     } else if (dynamicImportIndex >= 0) {
       // dynamic import
-      const dynamicStart = start + 1;
-      const dynamicEnd = end - 1;
+      const subSource = source.substring(start, end);
+      let stringSymbol;
+      if (subSource.includes('`')) stringSymbol = '`';
+      if (subSource.includes('"')) stringSymbol = '"';
+      if (subSource.includes("'")) stringSymbol = "'";
+
+      const dynamicStart = source.indexOf(stringSymbol, start) + 1;
+      const dynamicEnd = source.indexOf(stringSymbol, dynamicStart);
 
       const [importee, importeeSuffix] = getImportee(source.substring(dynamicStart, dynamicEnd));
-      const stringSymbol = source[dynamicStart - 1];
       const isStringLiteral = [`\``, "'", '"'].includes(stringSymbol);
       const concatenatedString =
         stringSymbol === `\`` || importee.includes("'") || importee.includes('"');

--- a/packages/es-dev-server/src/utils/resolve-module-imports.js
+++ b/packages/es-dev-server/src/utils/resolve-module-imports.js
@@ -184,23 +184,17 @@ async function resolveModuleImportsWithConfig(importer, source, cfg) {
       lastIndex = end;
     } else if (dynamicImportIndex >= 0) {
       // dynamic import
-      const subSource = source.substring(start, end);
-      let stringSymbol;
-      if (subSource.includes('`')) stringSymbol = '`';
-      if (subSource.includes('"')) stringSymbol = '"';
-      if (subSource.includes("'")) stringSymbol = "'";
-
+      const literals = [`\``, "'", '"'];
+      const stringSymbol = literals.find(char => source.substring(start, end).includes(char));
       const dynamicStart = source.indexOf(stringSymbol, start) + 1;
       const dynamicEnd = source.indexOf(stringSymbol, dynamicStart);
-
       const [importee, importeeSuffix] = getImportee(source.substring(dynamicStart, dynamicEnd));
-      const isStringLiteral = [`\``, "'", '"'].includes(stringSymbol);
+      const isStringLiteral = literals.includes(stringSymbol);
       const concatenatedString =
         stringSymbol === `\`` || importee.includes("'") || importee.includes('"');
       const resolvedimportee = isStringLiteral
         ? await maybeResolveImport(importer, importee, concatenatedString, cfg)
         : importee;
-
       resolvedSource += `${source.substring(
         lastIndex,
         dynamicStart,

--- a/packages/es-dev-server/test/snapshots/resolve-module-imports/dynamic-imports-formatted.js
+++ b/packages/es-dev-server/test/snapshots/resolve-module-imports/dynamic-imports-formatted.js
@@ -1,0 +1,21 @@
+
+      import '../node_modules/my-module/index.js';
+
+      function lazyLoad() {
+        return import(
+          '../node_modules/my-module-2/my-module-2.js'
+          );
+      }
+
+      () => import(
+        `../node_modules/my-module`
+      );
+
+      function lazyLoad2() {
+        return import(      "../node_modules/my-module-2/my-module-2.js");
+      }
+
+      import('../node_modules/my-module/index.js');
+
+      import('./local-module.js');
+    

--- a/packages/es-dev-server/test/utils/resolve-module-imports.test.js
+++ b/packages/es-dev-server/test/utils/resolve-module-imports.test.js
@@ -152,6 +152,33 @@ describe('resolve-module-imports', () => {
     );
   });
 
+  it('resolves dynamic imports literal not first character', async () => {
+    await expectMatchesSnapshot(
+      'dynamic-imports-formatted',
+      `
+      import 'my-module';
+
+      function lazyLoad() {
+        return import(
+          'my-module-2'
+          );
+      }
+
+      () => import(
+        \`my-module\`
+      );
+
+      function lazyLoad2() {
+        return import(      "my-module-2");
+      }
+
+      import('my-module');
+
+      import('./local-module.js');
+    `,
+    );
+  });
+
   it('does not touch import.meta.url', async () => {
     await expectMatchesSnapshot(
       'import-meta',


### PR DESCRIPTION
First fix for 
https://github.com/open-wc/open-wc/issues/1319

something like : 
`import(
        'module'
);`
will work now but when a litteral char is used in a comment it will still cause issues (didn't want to resort currently to regex for speed reasons).
Still failing example :
`import(
     /* a comment with a literal ' inside*/
     'module''
)`