### PR TITLE
chore(scoped-elements): write valid html in example

### DIFF
--- a/packages/scoped-elements/README.md
+++ b/packages/scoped-elements/README.md
@@ -121,7 +121,7 @@ To know when a tag name has been auto-defined by scoped elements, the suffix `-s
      return html`
        <my-panel class="panel">
          <my-button>${this.text}</my-button>
-       </my-panel}>
+       </my-panel>
      `;
    }
    ```


### PR DESCRIPTION
Removed `}` from item number 4 in `Usage` section of `README.md`