### PR TITLE
feat(scoped-elements): add createElement capability (#1270)

### DIFF
--- a/packages/scoped-elements/README.md
+++ b/packages/scoped-elements/README.md
@@ -74,13 +74,13 @@ To demonstrate, we made three demos:
      at [...]/node_modules/page-b/node_modules/feature-a/feature-a.js:3:16
    ```
 
-3. [with-scope](https://open-wc.org/scoped-elements/demo/with-scope/) [[code](https://github.com/open-wc/open-wc/tree/master/packages/scoped-elements/demo/with-scope)] This example successfully fixes the problem by using `createScopedHtml` on both **Page A** and **Page B**.
+3. [with-scope](https://open-wc.org/scoped-elements/demo/with-scope/) [[code](https://github.com/open-wc/open-wc/tree/master/packages/scoped-elements/demo/with-scope)] This example successfully fixes the problem by using `createScope` on both **Page A** and **Page B**.
 
 ## How it works
 
-`createScopedHtml` defines your custom element classes and creates a unique scoped tag for each of them if you need to use multiple versions of an element. In case those classes were already defined, it will return the previously defined tag.
+`createScope` defines your custom element classes and creates a unique scoped tag for each of them if you need to use multiple versions of an element. In case those classes were already defined, it will return the previously defined tag.
 
-Then, the `html` function provided by the `createScopedHtml` method transforms the template literal into another one replacing the tags used by the user by the ones defined by the custom elements. Finally, the transformed template literal is going to be processed by `lit-html`.
+Then, the `html` function provided by the `createScope` method transforms the template literal into another one replacing the tags used by the user by the ones defined by the custom elements. Finally, the transformed template literal is going to be processed by `lit-html`.
 
 `<my-button>${this.text}</my-button>`
 
@@ -89,12 +89,27 @@ becomes:
 
 To know when a tag name has been auto-defined by scoped elements, the suffix `-se` will be added to the tag name provided by the developer. In addition, this suffix allows scoped-elements and traditional self-defined elements to coexist, avoiding name collision.
 
+In some situations is necessary to create an element using `document.createElement()`, but as our elements are scoped and we don't know how they are defined we can't use that function directly.
+
+However, `createScope()` provides a `createElement()` function that knows how our elements are defined, so we can use this function to create our scoped elements.
+
+```js
+import { createScope } from '@open-wc/scoped-elements';
+import MyButton from './MyButton.js';
+
+const { createElement } = createScope({
+  'my-button': MyButton,
+});
+
+const $button = createElement('my-button');
+```
+
 ## Usage
 
-1. Import `createScopedHtml` from `@open-wc/scoped-elements`.
+1. Import `createScope` from `@open-wc/scoped-elements`.
 
    ```js
-   import { createScopedHtml } from '@open-wc/scoped-elements';
+   import { createScope } from '@open-wc/scoped-elements';
    ```
 
 2. Import the classes of the components you want to use.
@@ -104,11 +119,10 @@ To know when a tag name has been auto-defined by scoped elements, the suffix `-s
    import MyPanel from './MyPanel.js';
    ```
 
-3. Create the `html` function and define the tags you want to use for your
-   components.
+3. Create the scope with the tags you want to use for your components and obtaining the `html` and `createElement` functions.
 
    ```js
-   const html = createScopedHtml({
+   const { html, createElement } = createScope({
      'my-button': MyButton,
      'my-panel': MyPanel,
    });
@@ -117,6 +131,12 @@ To know when a tag name has been auto-defined by scoped elements, the suffix `-s
 4. Use your components in your html.
 
    ```js
+   connectedCallback() {
+     super.connectedCallback();
+
+     this.$button = createElement('my-button');
+   }
+
    render() {
      return html`
        <my-panel class="panel">
@@ -130,11 +150,11 @@ To know when a tag name has been auto-defined by scoped elements, the suffix `-s
 
 ```js
 import { css, LitElement } from 'lit-element';
-import { createScopedHtml } from '@open-wc/scoped-elements';
+import { createScope } from '@open-wc/scoped-elements';
 import MyButton from './MyButton.js';
 import MyPanel from './MyPanel.js';
 
-const html = createScopedHtml({
+const { html } = createScope({
   'my-button': MyButton, // <-- binds the element to a tag in your html
   'my-panel': MyPanel,
 });
@@ -211,9 +231,10 @@ export default class MyElement extends LitElement {
    ✅ this.shadowRoot.querySelector('.panel');
    ```
 
-7. Using `scoped-elements` may result in a performance degradation of up to 8%.
-8. Loading of duplicate/similar source code (most breaking releases are not a total rewrite) should always be a temporary solution.
-9. Often, temporary solutions tend to become more permanent. Be sure to focus on keeping the lifecycle of nested dependencies short.
+7. You can not use `document.createElement()` to create scoped elements, but you can use the `createElement` function provided by `createScope` instead.
+8. Using `scoped-elements` may result in a performance degradation of up to 8%.
+9. Loading of duplicate/similar source code (most breaking releases are not a total rewrite) should always be a temporary solution.
+10. Often, temporary solutions tend to become more permanent. Be sure to focus on keeping the lifecycle of nested dependencies short.
 
 ## Performance
 

--- a/packages/scoped-elements/demo/with-scope/node_modules/page-a/index.js
+++ b/packages/scoped-elements/demo/with-scope/node_modules/page-a/index.js
@@ -1,9 +1,9 @@
 import { render } from 'lit-html';
-import { createScopedHtml } from '../../../../index.js';
+import { createScope } from '../../../../index.js';
 import { FeatureA } from 'feature-a/index.js';
 import { FeatureB } from 'feature-b/index.js';
 
-const html = createScopedHtml({
+const { html } = createScope({
   'feature-a': FeatureA,
   'feature-b': FeatureB,
 });

--- a/packages/scoped-elements/demo/with-scope/node_modules/page-b/index.js
+++ b/packages/scoped-elements/demo/with-scope/node_modules/page-b/index.js
@@ -1,9 +1,9 @@
 import { render } from 'lit-html';
-import { createScopedHtml } from '../../../../index.js';
+import { createScope } from '../../../../index.js';
 import { FeatureA } from 'feature-a/index.js';
 import { FeatureB } from 'feature-b/index.js';
 
-const html = createScopedHtml({
+const { html } = createScope({
   'feature-a': FeatureA,
   'feature-b': FeatureB,
 });

--- a/packages/scoped-elements/index.js
+++ b/packages/scoped-elements/index.js
@@ -1,1 +1,1 @@
-export { createScopedHtml } from './src/scoped-html.js';
+export { createScopedHtml, createScope } from './src/scoped-html.js';

--- a/packages/scoped-elements/src/scoped-html.js
+++ b/packages/scoped-elements/src/scoped-html.js
@@ -1,14 +1,41 @@
 /* eslint-disable prefer-spread */
 import { html } from 'lit-html';
 import { transform } from './transform.js';
+import { registerElement } from './scoped-elements.js';
 
-export const createScopedHtml = tags =>
+/** @typedef {import('lit-html').TemplateResult} TemplateResult */
+
+/**
+ * Creates an elements scope.
+ * @param tags Map with tag names and element classes to be scoped.
+ * @returns {{html(strings: TemplateStringsArray, ...values: unknown[]): TemplateResult, createElement(tagName: string, options?: ElementCreationOptions): Element}}
+ */
+export const createScope = tags => ({
   // eslint-disable-next-line func-names
-  function() {
+  html() {
     // eslint-disable-next-line prefer-rest-params
     const args = Array.apply(null, arguments);
     const strings = args[0];
     const values = args.slice(1);
 
     return html.apply(null, [].concat([transform(strings, tags)], values));
-  };
+  },
+  createElement(tagName, options) {
+    const klass = tags[tagName];
+
+    if (klass) {
+      return document.createElement(registerElement(tagName, klass), options);
+    }
+
+    return document.createElement(tagName, options);
+  },
+});
+
+/**
+ * @deprecated Use createScope instead
+ */
+export const createScopedHtml = tags => {
+  const { html: scopedHtml } = createScope(tags);
+
+  return scopedHtml;
+};

--- a/packages/scoped-elements/test/scoped-html.test.js
+++ b/packages/scoped-elements/test/scoped-html.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@open-wc/testing';
 import { render } from 'lit-html';
-import { createScopedHtml } from '../src/scoped-html.js';
+import { createScopedHtml, createScope } from '../src/scoped-html.js';
 import { SUFFIX } from '../src/tag.js';
 
 describe('createScopedHtml', () => {
@@ -43,5 +43,72 @@ describe('createScopedHtml', () => {
 
     expect(customElements.get(`ithor-planet-${SUFFIX}`)).to.be.undefined;
     expect(customElements.get(`taris-planet-${SUFFIX}`)).to.not.be.undefined;
+  });
+});
+
+describe('createScope', () => {
+  describe('html', () => {
+    it('passes strings and values as tagged templates expect', () => {
+      class Kamino extends HTMLElement {}
+      class AhchTo extends HTMLElement {}
+
+      const $div = document.createElement('div');
+      const data = 'text sample';
+      const { html } = createScope({
+        'kamino-planet': Kamino,
+        'ahch-to-planet': AhchTo,
+      });
+      const template = html`
+        <kamino-planet>${data}</kamino-planet><ahch-to-planet>${data}</ahch-to-planet>
+      `;
+
+      render(template, $div);
+
+      expect($div.innerHTML).to.be.equal(
+        '<!---->\n        ' +
+          `<kamino-planet-${SUFFIX}><!---->text sample<!----></kamino-planet-${SUFFIX}>` +
+          `<ahch-to-planet-${SUFFIX}><!---->text sample<!----></ahch-to-planet-${SUFFIX}>` +
+          '\n      <!---->',
+      );
+    });
+
+    it('defers the definition of components until they are used', () => {
+      class Anoat extends HTMLElement {}
+      class Christophsis extends HTMLElement {}
+
+      const { html } = createScope({
+        'anoat-planet': Anoat,
+        'christophsis-planet': Christophsis,
+      });
+
+      html`
+        <christophsis-planet></christophsis-planet>
+      `;
+
+      expect(customElements.get(`anoat-planet-${SUFFIX}`)).to.be.undefined;
+      expect(customElements.get(`christophsis-planet-${SUFFIX}`)).to.not.be.undefined;
+    });
+  });
+
+  describe('createElement', () => {
+    class CatoNeimoidia extends HTMLElement {}
+
+    const { createElement } = createScope({
+      'cato-neimoidia-planet': CatoNeimoidia,
+    });
+
+    it('should be able to create a globally defined element', () => {
+      const $div = createElement('div');
+
+      expect($div).to.not.be.undefined;
+      expect($div instanceof Element).to.be.true;
+    });
+
+    it('should be able to create an scoped element', () => {
+      const $el = createElement('cato-neimoidia-planet');
+
+      expect($el).to.not.be.undefined;
+      expect($el instanceof CatoNeimoidia).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
Adds the capability to create scoped elements by it's tag name.

```js
import { createScope } from '@open-wc/scoped-elements';
import MyButton from './MyButton.js';

const { createElement } = createScope({
  'my-button': MyButton,
});

const $button = createElement('my-button');
```