### PR TITLE
fix(create): update building-rollup due to terser vulnerability

### DIFF
--- a/packages/create/src/generators/building-rollup/templates/_package.json
+++ b/packages/create/src/generators/building-rollup/templates/_package.json
@@ -4,7 +4,7 @@
     "build": "rimraf dist && rollup -c rollup.config.js"
   },
   "devDependencies": {
-    "@open-wc/building-rollup": "^0.15.1",
+    "@open-wc/building-rollup": "^0.21.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.15.4"
   }


### PR DESCRIPTION
The building-rollup template still has version of building-rollup to ^0.15.0 --> latest matching is 0.15.4 which still relies on 0.4.x of rollup-plugin-terser which has a vulnerability.

The fix by you guys (updating the terser plugin) was done [here](https://github.com/open-wc/open-wc/pull/1124/files) and then later released as [0.16.0](https://github.com/open-wc/open-wc/blob/%40open-wc/building-rollup%400.16.0/packages/building-rollup/CHANGELOG.md#0160-2019-12-13) but the `create` package that provides package.json template wasn't updated to 0.16.x yet

So when I did `npm init @open-wc` and pick "building" with "rollup" and later pushed my stuff to github I got the security alert from GitHub that serialize-javascript has a vulnerability.