### PR TITLE
chore: add script for updating a dependency in the monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:bs": "karma start karma.bs.conf.js --coverage",
     "test:node": "lerna run test:node",
     "test:update-snapshots": "lerna run test:update-snapshots",
+    "update-dependency": "node scripts/update-dependency.js && yarn format",
     "vuepress:build": "vuepress build docs",
     "vuepress:copy-static": "cp -f packages/demoing-storybook/demo/custom-elements.json docs/.vuepress/public/demoing/demo/custom-elements.json",
     "vuepress:start": "vuepress dev docs"
@@ -52,6 +53,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-wc": "^1.2.0",
+    "fs-extra": "^8.1.0",
     "husky": "3.0.0",
     "lerna": "3.4.3",
     "lint-staged": "^9.2.0",

--- a/scripts/update-dependency.js
+++ b/scripts/update-dependency.js
@@ -1,0 +1,68 @@
+/* eslint-disable import/no-extraneous-dependencies, no-param-reassign, no-console */
+const fs = require('fs-extra');
+const path = require('path');
+
+/**
+ * Script to update a single dependency on the monorepo. Example:
+ *
+ * yarn update-dependency rollup ^1.2.3
+ */
+
+const isDefined = _ => !!_;
+const dependencyFields = ['dependencies', 'devDependencies', 'peerDependencies'];
+
+const [, , pkg, version] = process.argv;
+
+if (!pkg || !version) {
+  throw new Error(
+    'Package and version must be specified. For example: yarn update-dependency rollup ^1.2.3',
+  );
+}
+
+function forEachParallel(items, callback) {
+  return Promise.all(items.map(callback));
+}
+
+async function run() {
+  const basedir = path.resolve(__dirname, '..');
+  const dirs = await fs.readdir(path.join(basedir, 'packages'));
+
+  const rootPackageJsonPath = path.join(basedir, 'package.json');
+  const readRootPackageJsonTask = fs.readJSON(rootPackageJsonPath, 'utf-8');
+
+  // read all project package.json
+  let packageJsons = await Promise.all(
+    dirs.map(async dir => {
+      const packageJsonPath = path.join(basedir, 'packages', dir, 'package.json');
+      if (!(await fs.pathExists(packageJsonPath))) return null;
+      const content = await fs.readJSON(packageJsonPath, 'utf-8');
+      return { content, path: packageJsonPath };
+    }),
+  );
+  packageJsons = packageJsons.filter(isDefined);
+
+  // read root package json
+  const rootPackageJson = await readRootPackageJsonTask;
+  packageJsons.push({ content: rootPackageJson, path: rootPackageJsonPath });
+
+  // update package.json files
+  await forEachParallel(packageJsons, async ({ content: packageJson, path: packageJsonPath }) => {
+    let changed = false;
+
+    for (const field of dependencyFields) {
+      if (packageJson[field] && pkg in packageJson[field]) {
+        packageJson[field][pkg] = version;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      console.log('updating package.json in ', packageJsonPath);
+      await fs.writeJSON(packageJsonPath, packageJson, { spaces: 2 });
+    }
+  });
+}
+
+run().catch(e => {
+  console.error(e);
+});


### PR DESCRIPTION
We have linter which enforces the same version of a dependency across the monorepo. This adds a script to easily update a dependency across all packages.