### PR TITLE
fix: don't precache legacy files and polyfills

### DIFF
--- a/packages/building-utils/get-workbox-config.js
+++ b/packages/building-utils/get-workbox-config.js
@@ -5,6 +5,7 @@ const path = require('path');
 module.exports = function getWorkboxConfig(outputDir) {
   const workboxConfigPath = path.join(process.cwd(), 'workbox-config.js');
   const defaultWorboxConfig = {
+    exclude: [/polyfills\/.*.js/, /legacy\/.*.js/],
     navigateFallback: '/index.html',
     // where to output the generated sw
     swDest: path.join(process.cwd(), outputDir, 'sw.js'),

--- a/packages/building-utils/get-workbox-config.js
+++ b/packages/building-utils/get-workbox-config.js
@@ -5,7 +5,7 @@ const path = require('path');
 module.exports = function getWorkboxConfig(outputDir) {
   const workboxConfigPath = path.join(process.cwd(), 'workbox-config.js');
   const defaultWorboxConfig = {
-    exclude: [/polyfills\/.*.js/, /legacy\/.*.js/],
+    globIgnores: ['/polyfills/*.js', '/legacy/*.js'],
     navigateFallback: '/index.html',
     // where to output the generated sw
     swDest: path.join(process.cwd(), outputDir, 'sw.js'),

--- a/packages/building-webpack/modern-and-legacy-config.js
+++ b/packages/building-webpack/modern-and-legacy-config.js
@@ -156,6 +156,7 @@ function createConfig(options, legacy) {
       production &&
         options.plugins.workbox &&
         new GenerateSW({
+          exclude: [/polyfills\/.*.js/, /legacy\/.*.js/],
           // for spa client side routing, always return index.html
           navigateFallback: '/index.html',
           // where to output the generated sw

--- a/packages/building-webpack/modern-config.js
+++ b/packages/building-webpack/modern-config.js
@@ -141,6 +141,7 @@ module.exports = userOptions => {
       production &&
         options.plugins.workbox &&
         new GenerateSW({
+          exclude: [/polyfills\/.*.js/, /legacy\/.*.js/],
           // for spa client side routing, always return index.html
           navigateFallback: '/index.html',
           // where to output the generated sw


### PR DESCRIPTION
fixes https://github.com/open-wc/open-wc/issues/1360

This should be a non breaking change, since the legacy files/polyfills should never be requested in the first place (since those browsers dont support service worker), and on a new deploy workbox will clean outdated caches