### PR TITLE
Add default watcher to createMiddlewares

### DIFF
--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -32,7 +32,7 @@ const defaultCompressOptions = {
  * @param {import('chokidar').FSWatcher} fileWatcher
  * @returns {import('koa').Middleware[]}
  */
-export function createMiddlewares(config, fileWatcher =  chokidar.watch([])) {
+export function createMiddlewares(config, fileWatcher = chokidar.watch([])) {
   const {
     appIndex,
     appIndexDir,

--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -1,6 +1,7 @@
 import koaStatic from 'koa-static';
 import koaEtag from 'koa-etag';
 import koaCompress from 'koa-compress';
+import chokidar from 'chokidar';
 import { createBasePathMiddleware } from './middleware/base-path.js';
 import { createHistoryAPIFallbackMiddleware } from './middleware/history-api-fallback.js';
 import { createCompatibilityTransformMiddleware } from './middleware/compatibility-transform.js';
@@ -15,7 +16,6 @@ import { createResponseTransformMiddleware } from './middleware/response-transfo
 import { createResolveModuleImports } from './utils/resolve-module-imports.js';
 import { createCompatibilityTransform } from './utils/compatibility-transform.js';
 import { logDebug } from './utils/utils.js';
-import chokidar from 'chokidar';
 
 const defaultCompressOptions = {
   filter(contentType) {

--- a/packages/es-dev-server/src/create-middlewares.js
+++ b/packages/es-dev-server/src/create-middlewares.js
@@ -15,6 +15,7 @@ import { createResponseTransformMiddleware } from './middleware/response-transfo
 import { createResolveModuleImports } from './utils/resolve-module-imports.js';
 import { createCompatibilityTransform } from './utils/compatibility-transform.js';
 import { logDebug } from './utils/utils.js';
+import chokidar from 'chokidar';
 
 const defaultCompressOptions = {
   filter(contentType) {
@@ -31,7 +32,7 @@ const defaultCompressOptions = {
  * @param {import('chokidar').FSWatcher} fileWatcher
  * @returns {import('koa').Middleware[]}
  */
-export function createMiddlewares(config, fileWatcher) {
+export function createMiddlewares(config, fileWatcher =  chokidar.watch([])) {
   const {
     appIndex,
     appIndexDir,

--- a/packages/es-dev-server/src/create-server.js
+++ b/packages/es-dev-server/src/create-server.js
@@ -3,6 +3,7 @@ import path from 'path';
 import httpServer from 'http';
 import http2Server from 'http2';
 import fs from 'fs';
+import chokidar from 'chokidar';
 import { createMiddlewares } from './create-middlewares.js';
 
 /**
@@ -13,7 +14,7 @@ import { createMiddlewares } from './create-middlewares.js';
  * @param {import('chokidar').FSWatcher} fileWatcher
  * @returns {{ app: import('koa'), server: import('http').Server | import('http2').Http2SecureServer }}
  */
-export function createServer(cfg, fileWatcher) {
+export function createServer(cfg, fileWatcher =  chokidar.watch([])) {
   const middlewares = createMiddlewares(cfg, fileWatcher);
 
   const app = new Koa();

--- a/packages/es-dev-server/src/create-server.js
+++ b/packages/es-dev-server/src/create-server.js
@@ -14,7 +14,7 @@ import { createMiddlewares } from './create-middlewares.js';
  * @param {import('chokidar').FSWatcher} fileWatcher
  * @returns {{ app: import('koa'), server: import('http').Server | import('http2').Http2SecureServer }}
  */
-export function createServer(cfg, fileWatcher =  chokidar.watch([])) {
+export function createServer(cfg, fileWatcher = chokidar.watch([])) {
   const middlewares = createMiddlewares(cfg, fileWatcher);
 
   const app = new Koa();


### PR DESCRIPTION
Add default watcher to createMiddlewares
This will make the module function properly without a warning when used as a middleware.

Fixes #1315