### PR TITLE
docs: make navbar more easily navigable

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -16,7 +16,6 @@ const sidebar = [
       '/developing/routing',
       ['/developing/ide', 'IDE'],
       '/guide/component-libraries',
-      '/guide/dedupe-mixin',
     ],
   },
   {
@@ -89,6 +88,7 @@ const sidebar = [
           '/developing/es-dev-server',
           ['/init/', 'Generators'],
           '/developing/lit-helpers',
+          '/guide/dedupe-mixin',
         ],
       },
       {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -6,6 +6,7 @@ const sidebar = [
   {
     title: 'Guides & Docs',
     collapsable: true,
+    sidebarDepth: 0,
     children: [
       '/developing/best-practices',
       ['/codelabs/', 'Codelabs'],
@@ -24,7 +25,8 @@ const sidebar = [
     children: [
       {
         title: 'Linting',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: [
           ['/linting/', 'Getting started'],
           '/linting/linting-eslint',
@@ -34,13 +36,15 @@ const sidebar = [
       },
       {
         title: 'Developing',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: ['/developing/'],
       },
 
       {
         title: 'Testing',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: [
           ['/testing/', 'Getting started'],
           '/testing/testing',
@@ -51,7 +55,8 @@ const sidebar = [
       },
       {
         title: 'Building apps for production',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: [
           ['/building/', 'Getting started'],
           '/building/building-rollup',
@@ -60,12 +65,14 @@ const sidebar = [
       },
       {
         title: 'Deploying apps',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: [['/publishing/', 'Getting started']],
       },
       {
         title: 'Demoing',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: [['/demoing/', 'Getting started']],
       },
     ],
@@ -76,7 +83,8 @@ const sidebar = [
     children: [
       {
         title: 'Developing',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: [
           '/developing/es-dev-server',
           ['/init/', 'Generators'],
@@ -85,7 +93,8 @@ const sidebar = [
       },
       {
         title: 'Testing',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: [
           '/testing/testing-helpers',
           '/testing/testing-chai-a11y-axe',
@@ -96,7 +105,8 @@ const sidebar = [
       },
       {
         title: 'Building',
-        collapsable: true,
+        collapsable: false,
+        sidebarDepth: 0,
         children: ['/building/rollup-plugin-index-html', '/building/webpack-index-html-plugin'],
       },
     ],
@@ -131,7 +141,7 @@ module.exports = {
         ['', 'Faq'],
         {
           title: 'Deep dives',
-          collapsable: true,
+          collapsable: false,
           children: [
             'events',
             'rerender',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -78,7 +78,7 @@ const sidebar = [
     ],
   },
   {
-    title: 'Tools',
+    title: 'Tools & Libraries',
     collapsable: true,
     children: [
       {

--- a/docs/.vuepress/public/demoing/demo/custom-elements.json
+++ b/docs/.vuepress/public/demoing/demo/custom-elements.json
@@ -47,13 +47,18 @@
           "type": "Length"
         },
         {
-          "name": "--demo-wc-card-front-color",
+          "name": "--demo-wc-card-font-color",
           "description": "Font color for the front",
           "type": "Color"
         },
         {
-          "name": "--demo-wc-card-back-color",
-          "description": "Font color for the back",
+          "name": "--demo-wc-card-header-color-front",
+          "description": "Header color for the front",
+          "type": "Color"
+        },
+        {
+          "name": "--demo-wc-card-header-color-back",
+          "description": "Header color for the back",
           "type": "Color"
         }
       ]


### PR DESCRIPTION
- Make the nested menus non-collapsible. This makes it easier to see what's available and to jump between sections.
- Don't show page headings in the nav bar. It's a cool feature, but on some pages you really lose an overview of where you are. Our pages are usually pretty concise.
- Rename Tools to Tools & Libraries
- Move DedupeMixin to Tools & Libraries