### PR TITLE
Docs/home and intro

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -124,7 +124,7 @@ module.exports = {
   themeConfig: {
     logo: '/logo.png',
     displayAllHeaders: false,
-    sidebarDepth: 2,
+    sidebarDepth: 0,
     sidebar: {
       '/guide/': sidebar,
       '/codelabs/': sidebar,

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,7 +1,6 @@
 // .vuepress/config.js
 
 const sidebar = [
-  ['/', 'Home'],
   ['/guide/', 'Introduction'],
   {
     title: 'Guides & Docs',


### PR DESCRIPTION
- Don't show headings in sidebar for intro page
- Remove redundant home option, it's kind of a circular navigation since the home page takes you back to the "Guide" page. The logo takes you to home if people really need to go there.