### PR TITLE
chore: align package readme files

### DIFF
--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -1,10 +1,10 @@
 # Rollup
 
+Rollup configuration to help you get started building modern web applications. You write modern javascript using the latest browser features, rollup will optimize your code for production ensure it runs on all supported browsers.
+
 [//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Configuration
-
-Rollup configuration to help you get started building modern web applications. You write modern javascript using the latest browser features, rollup will optimize your code for production ensure it runs on all supported browsers.
 
 The input for rollup is the same `index.html` you use for development. Any module scripts in your index are run through rollup and your index is updated with the output from rollup.
 

--- a/packages/building-utils/README.md
+++ b/packages/building-utils/README.md
@@ -1,17 +1,4 @@
 # Building utils
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
-Utils for `@open-wc` building packages.
-
-<script>
-  export default {
-    mounted() {
-      const editLink = document.querySelector('.edit-link a');
-      if (editLink) {
-        const url = editLink.href;
-        editLink.href = url.substr(0, url.indexOf('/master/')) + '/master/packages/building-rollup/README.md';
-      }
-    }
-  }
-</script>
+Utils for `@open-wc` building packages. This is a private package, and should not
+be depended on directly.

--- a/packages/building-webpack/README.md
+++ b/packages/building-webpack/README.md
@@ -1,10 +1,10 @@
 # Webpack
 
+Webpack configuration to help you get started building modern web applications. You write modern javascript using the latest browser features, webpack will optimize your code for production ensure it runs on all supported browsers.
+
 [//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Configuration
-
-Webpack configuration to help you get started building modern web applications. You write modern javascript using the latest browser features, webpack will optimize your code for production ensure it runs on all supported browsers.
 
 The input for webpack is the same `index.html` you use for development. Any module scripts in your index are run through webpack and your index is updated with the output from rollup.
 

--- a/packages/chai-a11y-axe/README.md
+++ b/packages/chai-a11y-axe/README.md
@@ -1,16 +1,10 @@
 # Chai A11y aXe
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 This module provides a Chai plugin to perform automated accessibility tests via axe.
 
-::: tip
-This is part of the default [open-wc testing](https://open-wc.org/testing/) recommendation
-:::
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
-## Testing for Accessibility
-
-### Chai BDD UI
+## Chai BDD UI
 
 The BDD UI works with chai's `expect` function.
 
@@ -63,7 +57,7 @@ it('accepts "done" option', done => {
 });
 ```
 
-### Chai TDD UI
+## Chai TDD UI
 
 The `isAccessible()` and `isNotAccessible()` methods work on Chai's `assert` function.
 

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -1,5 +1,7 @@
 # Create Open Web Components
 
+Web component project scaffolding.
+
 [//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Usage

--- a/packages/dedupe-mixin/README.md
+++ b/packages/dedupe-mixin/README.md
@@ -1,8 +1,8 @@
 # Dedupe Mixin
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 Automatically Deduplicate JavaScript Class Mixins
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Features
 

--- a/packages/demoing-storybook/README.md
+++ b/packages/demoing-storybook/README.md
@@ -1,12 +1,8 @@
 # Demoing via storybook
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 For demoing, documenting and showcasing different states of your Web Component, we recommend using [storybook](https://storybook.js.org/).
 
-::: tip
-This is part of the default [open-wc](https://open-wc.org/) recommendation
-:::
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 # Features
 

--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -1,12 +1,12 @@
 # ES dev server
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 A web server for development without bundling, utilizing the browser's standard module loader and efficient browser caching for simple and fast web development.
 
 ```bash
 npx es-dev-server --node-resolve --watch
 ```
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 **Quick overview**
 

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,8 +1,8 @@
 # Linting ESLint
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 Use [ESLint](https://eslint.org/) to lint your es6 code.
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Setup
 

--- a/packages/import-maps-generate/README.md
+++ b/packages/import-maps-generate/README.md
@@ -1,9 +1,9 @@
 # Generate Import Map
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 This will allow you to generate a flat [import-map](https://github.com/WICG/import-maps).
 It allows you to fix the "nested" npm problem for front end development.
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ::: warning
 Currently, only yarn.lock is supported

--- a/packages/import-maps-resolve/README.md
+++ b/packages/import-maps-resolve/README.md
@@ -1,8 +1,8 @@
 # Resolve import-maps
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 This will allow you to parse and resolve urls by a given [import-map](https://github.com/WICG/import-maps).
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Usage
 

--- a/packages/karma-esm/README.md
+++ b/packages/karma-esm/README.md
@@ -2,6 +2,8 @@
 
 Karma plugin for running tests with es modules on a wide range of browsers.
 
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
+
 Out the box es modules don't work with karma because they import their dependencies from the browser, while karma doesn't allow requesting any files it doesn't know about upfront.
 
 The `karma-esm` plugin fixes this and spins up [es-dev-server](https://open-wc.org/developing/es-dev-server.html) behind the scenes. This lets you write tests using es modules, modern javascript syntax and features, and have karma run them on all modern browsers and IE11.

--- a/packages/lit-helpers/README.md
+++ b/packages/lit-helpers/README.md
@@ -1,8 +1,8 @@
 # Lit Helpers
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 A library with helpers functions for working with [lit-html](https://lit-html.polymer-project.org/) and [lit-element](https://lit-element.polymer-project.org/)
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Installation
 

--- a/packages/polyfills-loader/README.md
+++ b/packages/polyfills-loader/README.md
@@ -2,6 +2,8 @@
 
 The polyfills loader makes it easy to manage loading polyfills and/or serving different versions of your application based on browser support. It generates a script that loads the necessary polyfills and the appropriate version of the application through on runtime feature detection.
 
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
+
 A simplified version of the loader:
 
 ```js

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,12 +1,8 @@
 # Linting Prettier
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 Use [Prettier](https://prettier.io) to format your JS, CSS and HTML code.
 
-::: tip
-This is part of the default [open-wc](https://open-wc.org/) recommendation
-:::
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Setup
 

--- a/packages/rollup-plugin-html/README.md
+++ b/packages/rollup-plugin-html/README.md
@@ -8,6 +8,8 @@ Plugin for generating HTML files from rollup.
 - Minify HTML and inline JS and CSS
 - Suitable for single page and multi-page apps
 
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
+
 Jump to:
 
 - [Installation](#installation)

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -22,6 +22,7 @@
     "demo:spa:manual-inject": "rm -rf demo/dist && rollup -c demo/spa/manual-inject.rollup.config.js --watch & yarn serve-demo",
     "demo:spa:multi-output": "rm -rf demo/dist && rollup -c demo/spa/multi-output.rollup.config.js --watch & yarn serve-demo",
     "demo:spa:template": "rm -rf demo/dist && rollup -c demo/spa/template.rollup.config.js --watch & yarn serve-demo",
+    "prepublishOnly": "../../scripts/insert-header.js",
     "serve-demo": "es-dev-server --watch --root-dir demo/dist --app-index index.html --compatibility none --open",
     "test": "npm run test:node",
     "test:node": "mocha test/**/*.test.js test/*.test.js",

--- a/packages/rollup-plugin-index-html/README.md
+++ b/packages/rollup-plugin-index-html/README.md
@@ -1,8 +1,8 @@
 # Rollup Plugin Index HTML
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 Rollup plugin to make rollup understand your index.html.
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 1. Takes in a standard index.html:
 

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/rollup-plugin-index-html",
   "main": "rollup-plugin-index-html.js",
   "scripts": {
+    "prepublishOnly": "../../scripts/insert-header.js",
     "test": "npm run test:node",
     "test:node": "mocha test/**/*.test.js test/*.test.js",
     "test:update-snapshots": "mocha test/**/*.test.js test/*.test.js --update-snapshots"

--- a/packages/semantic-dom-diff/README.md
+++ b/packages/semantic-dom-diff/README.md
@@ -1,13 +1,5 @@
 # Semantic Dom Diff
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
-## Manual Setup
-
-```bash
-npm i -D @open-wc/semantic-dom-diff
-```
-
 `semantic-dom-diff` allows diffing chunks of dom or HTML for semantic equality:
 
 - whitespace and newlines are normalized
@@ -15,6 +7,14 @@ npm i -D @open-wc/semantic-dom-diff
 - comments are removed
 - style, script and SVG contents are removed
 - tags, attributes or element's light dom can be ignored through configuration
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
+
+## Manual Setup
+
+```bash
+npm i -D @open-wc/semantic-dom-diff
+```
 
 ## Chai Plugin
 

--- a/packages/testing-helpers/README.md
+++ b/packages/testing-helpers/README.md
@@ -1,8 +1,8 @@
 # Testing Helpers
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 A library with helpers functions for testing in the browser.
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ::: warning
 

--- a/packages/testing-karma-bs/README.md
+++ b/packages/testing-karma-bs/README.md
@@ -1,5 +1,7 @@
 # Testing via Browserstack
 
+Configuration for setting up browserstack testing with karma.
+
 [//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 To make sure your project is production-ready, we recommend running tests in all the browsers you want to support.

--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -1,5 +1,7 @@
 # Testing with Karma
 
+Configuration for setting up testing with karma.
+
 [//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 We recommend karma as a general-purpose tool for testing code which runs in the browser. Karma can run a large range of browsers, including IE11. This way you are confident that your code runs correctly in all supported environments.

--- a/packages/testing-wallaby/README.md
+++ b/packages/testing-wallaby/README.md
@@ -1,8 +1,8 @@
 # Testing in IDE via Wallaby
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 Wallaby.js is a Plugin for your IDE and runs tests in real time while you are typing.
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 Using:
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,8 +1,8 @@
 # Testing
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 An opinionated package that combines and configures testing libraries to minimize the amount of ceremony required when writing tests.
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Step by step guide
 

--- a/packages/webpack-import-meta-loader/README.md
+++ b/packages/webpack-import-meta-loader/README.md
@@ -1,8 +1,8 @@
 # Webpack Helpers
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
+Webpack loader for supporting `import.meta` in webpack.
 
-If you need support to use `import.meta` within webpack this is a minimal loader to support it.
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Note
 

--- a/packages/webpack-index-html-plugin/README.md
+++ b/packages/webpack-index-html-plugin/README.md
@@ -1,8 +1,8 @@
 # Webpack Index HTML Plugin
 
-[//]: # 'AUTO INSERT HEADER PREPUBLISH'
-
 Webpack plugin to make webpack understand your index.html.
+
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 1. Takes in a standard index.html:
 

--- a/scripts/insert-header.js
+++ b/scripts/insert-header.js
@@ -10,9 +10,7 @@ function escapeRegExp(text) {
 const filePath = `${process.cwd()}/README.md`;
 const findPattern = escapeRegExp("[//]: # 'AUTO INSERT HEADER PREPUBLISH'");
 const text = `
-> Part of [Open Web Components](https://github.com/open-wc/open-wc/)
-
-Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.
+> Part of [Open Web Components](https://github.com/open-wc/open-wc/): guides, tools and libraries for modern web development and web components
 
 [![CircleCI](https://circleci.com/gh/open-wc/open-wc.svg?style=shield)](https://circleci.com/gh/open-wc/open-wc)
 [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)


### PR DESCRIPTION
The readmes for our packages were getting out of sync. Some didn't have the publish header, and some did have them but were missing the prepublish step to actually process them.

- Added missing publish headers and/or prepublish scripts
- Updated the publish header with the up to date project slogan.
- Moved the prepublish header below the project description. 
- Removed the `::tip::`, this feels like a double mention and takes up a lot of space. What do you think @daKmoR ? Does it add extra value? Maybe we should have it only for some projects, like the `configs` and not the `tools / libs` ?