### PR TITLE
chore: update  shady-css-scoped-element version

### DIFF
--- a/packages/building-utils/package.json
+++ b/packages/building-utils/package.json
@@ -49,7 +49,7 @@
     "regenerator-runtime": "^0.13.3",
     "resolve": "^1.11.1",
     "rimraf": "^3.0.0",
-    "shady-css-scoped-element": "^0.0.1",
+    "shady-css-scoped-element": "^0.0.2",
     "systemjs": "^4.0.0",
     "terser": "^4.6.4",
     "valid-url": "^1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3093,16 +3093,16 @@
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.43"
+  version "1.3.45"
   dependencies:
-    "@open-wc/testing-karma" "^3.2.43"
+    "@open-wc/testing-karma" "^3.3.1"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.2.43"
+  version "3.3.1"
   dependencies:
-    "@open-wc/karma-esm" "^2.13.10"
+    "@open-wc/karma-esm" "^2.13.12"
     axe-core "^3.3.1"
     karma "^4.1.0"
     karma-chrome-launcher "^3.1.0"
@@ -17130,10 +17130,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shady-css-scoped-element@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/shady-css-scoped-element/-/shady-css-scoped-element-0.0.1.tgz#e386ff2228bb3677376985a34d65101372ed66dc"
-  integrity sha512-86NPanHuXXTayw0psXbqMBU11rptlhAU17N3ZVxWYm6/KxMc02M/l6gGAEUb2Jff7W3Ur/ARWufPKmm/nNOU2g==
+shady-css-scoped-element@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/shady-css-scoped-element/-/shady-css-scoped-element-0.0.2.tgz#c538fcfe2317e979cd02dfec533898b95b4ea8fe"
+  integrity sha512-Dqfl70x6JiwYDujd33ZTbtCK0t52E7+H2swdWQNSTzfsolSa6LJHnTpN4T9OpJJEq4bxuzHRLFO9RBcy/UfrMQ==
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
In order to use the latest version of `shady-css-scoped-element` as per this issue https://github.com/open-wc/open-wc/issues/1377

cc. @jrobinson01 