### PR TITLE
ci: save all package files to workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,12 +39,12 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - attach_workspace:
-            at: ~/
       # Download and cache dependencies
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
+      - attach_workspace:
+            at: ~/
 
       # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
       - run: npm run build:types
@@ -62,12 +62,12 @@ jobs:
     steps:
       - checkout
       # Download and cache dependencies
-      - attach_workspace:
-            at: ~/
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
+      # Download and cache dependencies
+      - attach_workspace:
+            at: ~/
 
       # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
       - run: npm run build:types

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,6 @@ jobs:
       # build what needs to be build so we can use it in the next steps
       - run: npm run build
 
-      # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
-      - run: npm run build:types
-
       # persist built files and duplicate dependencies to workspace
       - persist_to_workspace:
           root: ~/
@@ -48,6 +45,10 @@ jobs:
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
+
+      # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
+      - run: npm run build:types
+
       # run lint
       - run: npm run lint
 
@@ -67,6 +68,10 @@ jobs:
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
+
+      # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
+      - run: npm run build:types
+
       - run: npm run test:bs
   deploy:
     <<: *defaults
@@ -83,6 +88,10 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: git config --global user.email circleci@circleci
       - run: git config --global user.name CircleCI
+
+      # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
+      - run: npm run build:types
+      
       - run:
           name: Publish package
           command: "./node_modules/.bin/lerna publish --message 'chore: release new versions' --yes"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
 
       # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
       - run: npm run build:types
-      
+
       - run:
           name: Publish package
           command: "./node_modules/.bin/lerna publish --message 'chore: release new versions' --yes"
@@ -113,4 +113,4 @@ workflows:
             - test-bs
           filters:
             branches:
-              only: master
+              only: westbrook/ci-types

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@open-wc/testing-helpers",
+  "name": "@d4kmor/testing-helpers",
   "version": "1.6.0",
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,17 +2257,22 @@
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.13.21.tgz#718b9ec5f9a98935fc775e577ad094ae8d8b7dea"
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
+"@open-wc/testing-helpers@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/testing-helpers/-/testing-helpers-1.6.0.tgz#bbd9fcf164685853eb448eb0c731dba20a24735e"
+  integrity sha512-T5ZcfMER9oswf49VeflO1VX+lFdAMOpBQlpQFBpI6WLid3fekbKgnPSsSdl5jOlXhhT4rGaDp8EBqVju+Fk8kg==
+
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.47"
+  version "1.3.48"
   dependencies:
-    "@open-wc/testing-karma" "^3.3.3"
+    "@open-wc/testing-karma" "^3.3.4"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.3.3"
+  version "3.3.4"
   dependencies:
-    "@open-wc/karma-esm" "^2.13.14"
+    "@open-wc/karma-esm" "^2.13.15"
     axe-core "^3.3.1"
     karma "^4.1.0"
     karma-chrome-launcher "^3.1.0"
@@ -7469,11 +7474,6 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
-
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -10111,7 +10111,7 @@ husky@3.0.0:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -12881,15 +12881,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -13021,22 +13012,6 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.50:
   version "1.1.51"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.51.tgz#70d0e054221343d2966006bfbd4d98622cc00bd0"
@@ -13141,7 +13116,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -13188,7 +13163,7 @@ npm-run-path@^3.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -14908,7 +14883,7 @@ raw-loader@^3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.2.7, rc@^1.2.8:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -16144,7 +16119,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -17262,7 +17237,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Types weren't being cached across the workspace and thus were not being published. This changes that, hopefully.

Use `- repo/packages` as opposed to `- repo/packages/*/node_modules` and `- repo/packages/*/dist` so that ALL the files in packages are cached to the workspace. There is likely a similarly successful, but slightly more optimized, list of files to cache, but want to make sure we get this fixed without a lot of side testing.