### PR TITLE
docs(core): add link to slick-router routing library

### DIFF
--- a/docs/developing/routing.md
+++ b/docs/developing/routing.md
@@ -33,6 +33,11 @@ In alphabetical order:
 
   <hr>
 
+- [slick-router](https://github.com/blikblum/slick-router)
+  <NpmUsage routerName="slick-router"/>
+
+  <hr>
+
 - [vaadin-router](https://github.com/vaadin/vaadin-router)
   <NpmUsage routerName="@vaadin/router"/>
   <hr>


### PR DESCRIPTION
slick-router is a well tested, feature rich router with first class web component support

BTW: there's not an appropriate commit message scope for such PRs