### PR TITLE
Feat/rollup html improvements

### DIFF
--- a/packages/rollup-plugin-html/README.md
+++ b/packages/rollup-plugin-html/README.md
@@ -46,7 +46,26 @@ export default {
 
 ### Input from file
 
-During development, you will already have an HTML file which imports your application's modules. You can use give this same file to the plugin using the `inputPath` option, which will bundle any modules inside and output the same HTML minified optimized.
+During development, you will probably already have an HTML file which imports your application's modules. You can use this same file as the input of the html plugin, which will bundle any modules inside and output the same HTML minified optimized.
+
+To do this, you can set the html file as input for rollup:
+
+<details>
+
+<summary>Show example</summary>
+
+```js
+import html from '@open-wc/rollup-plugin-html';
+export default {
+  input: 'index.html',
+  output: { dir: 'dist' },
+  plugins: [html()],
+};
+```
+
+</details>
+
+You can also set the `inputPath` property on the html plugin. This is useful if you are generating multiple html files, which each have their own entrypoints:
 
 <details>
 
@@ -59,6 +78,9 @@ export default {
   plugins: [
     html({
       inputPath: 'index.html',
+    }),
+    html({
+      inputPath: 'another-index.html',
     }),
   ],
 };

--- a/packages/rollup-plugin-html/README.md
+++ b/packages/rollup-plugin-html/README.md
@@ -353,8 +353,6 @@ To do this, create one parent `@open-wc/rollup-plugin-html` instance and use `ad
 
 Each output defines a unique name, this can be used to retreive the correct bundle from `bundles` argument when creating the HTML template.
 
-The HTML file will be output into the directory of the last build. If your builds will be output into separate directories, you need to make sure the main directory in the last.
-
 ```js
 import html from '@open-wc/rollup-plugin-html';
 
@@ -383,16 +381,53 @@ export default {
   input: './app.js',
   output: [
     {
+      format: 'es',
+      dir: 'dist',
+      plugins: [htmlPlugin.addOutput('modern')],
+    },
+    {
       format: 'system',
-      dir: 'dist/legacy',
+      dir: 'dist',
       plugins: [htmlPlugin.addOutput('legacy')],
     },
-    // Note: the modern build should always be last, as the HTML file will be output into
-    // this directory
+  ],
+  plugins: [htmlPlugin],
+};
+```
+
+</details>
+
+If your outputs use different outputs directories, you need to set the `outputBundleName` option to specify which build to use to output the HTML file.
+
+<details>
+<summary>View example</summary>
+
+```js
+import html from '@open-wc/rollup-plugin-html';
+
+const htmlPlugin = html({
+  name: 'index.html',
+  inject: false,
+  outputBundleName: 'modern',
+  template({ bundles }) {
+    return `
+      ...
+    `;
+  },
+});
+
+export default {
+  input: './app.js',
+  output: [
     {
       format: 'es',
       dir: 'dist',
       plugins: [htmlPlugin.addOutput('modern')],
+    },
+    {
+      format: 'system',
+      dir: 'dist',
+      plugins: [htmlPlugin.addOutput('legacy')],
     },
   ],
   plugins: [htmlPlugin],
@@ -422,6 +457,12 @@ Path to the HTML file to use as input. Modules in this file are bundled and the 
 Type: `string`
 
 Same as `inputPath`, but provides the HTML as a string directly.
+
+### outputBundleName
+
+Type: `string`
+
+When using multiple build outputs, this is the name of the build that will be used to emit the generated HTML file.
 
 ### dir
 
@@ -480,7 +521,7 @@ export interface PluginOptions {
   name?: string;
   inputPath?: string;
   inputHtml?: string;
-  dir?: string;
+  outputBundleName?: string;
   publicPath?: string;
   inject?: boolean;
   minify?: boolean | object | MinifyFunction;

--- a/packages/rollup-plugin-html/rollup-plugin-html.js
+++ b/packages/rollup-plugin-html/rollup-plugin-html.js
@@ -6,6 +6,7 @@
 /** @typedef {import('rollup').OutputBundle} OutputBundle */
 /** @typedef {import('rollup').OutputChunk} OutputChunk */
 /** @typedef {import('rollup').EmittedFile} EmittedFile */
+/** @typedef {import('rollup').EmitFile} EmitFile */
 /** @typedef {import('./src/types').PluginOptions} PluginOptions */
 /** @typedef {import('./src/types').InputHtmlData} InputHtmlData */
 /** @typedef {import('./src/types').GeneratedBundle} GeneratedBundle */
@@ -18,12 +19,7 @@ const { getInputHtmlData } = require('./src/getInputHtmlData');
 const { getEntrypointBundles } = require('./src/getEntrypointBundles');
 const { getOutputHtml } = require('./src/getOutputHtml');
 const { extractModules } = require('./src/extractModules');
-const {
-  createError,
-  getMainOutputDir,
-  addRollupInput,
-  shouldReadInputFromRollup,
-} = require('./src/utils');
+const { createError, addRollupInput, shouldReadInputFromRollup } = require('./src/utils');
 
 const watchMode = process.env.ROLLUP_WATCH === 'true';
 const defaultFileName = 'index.html';
@@ -39,10 +35,6 @@ function rollupPluginHtml(pluginOptions) {
     ...(pluginOptions || {}),
   };
 
-  /** @type {string[]} */
-  const multiOutputNames = [];
-  let multiOutput = false;
-  let outputCount = 0;
   /** @type {string} */
   let inputHtml;
   /** @type {string[]} */
@@ -56,15 +48,23 @@ function rollupPluginHtml(pluginOptions) {
   /** @type {TransformFunction[]} */
   let externalTransformFns = [];
 
+  // variables for multi build
+  /** @type {string[]} */
+  const multiOutputNames = [];
+  // function emit asset, used when the outputName option is
+  // used to explicitly configure which output build to emit
+  // assets from
+  /** @type {Function} */
+  let deferredEmitHtmlFile;
+
   /**
+   * @param {string} mainOutputDir
    * @returns {Promise<EmittedFile>}
    */
-  async function createHtmlAsset() {
+  async function createHtmlAsset(mainOutputDir) {
     if (generatedBundles.length === 0) {
       throw createError('Cannot output HTML when no bundles have been generated');
     }
-
-    const mainOutputDir = getMainOutputDir(pluginOptions, generatedBundles);
 
     const entrypointBundles = getEntrypointBundles({
       pluginOptions,
@@ -167,9 +167,12 @@ function rollupPluginHtml(pluginOptions) {
      * @param {OutputBundle} bundle
      */
     async generateBundle(options, bundle) {
-      if (multiOutput) return;
+      if (multiOutputNames.length !== 0) return;
+      if (!options.dir) {
+        throw createError('Output must have a dir option set.');
+      }
       generatedBundles.push({ name: 'default', options, bundle });
-      this.emitFile(await createHtmlAsset());
+      this.emitFile(await createHtmlAsset(options.dir));
     },
 
     getHtmlFileName() {
@@ -193,13 +196,11 @@ function rollupPluginHtml(pluginOptions) {
       if (!name || multiOutputNames.includes(name)) {
         throw createError('Each output must have a unique name');
       }
+
       multiOutputNames.push(name);
 
-      multiOutput = true;
-      outputCount += 1;
-
       return {
-        name: `rollup-plugin-html-multi-output-${outputCount}`,
+        name: `rollup-plugin-html-multi-output-${multiOutputNames.length}`,
 
         /**
          * Stores output bundle, and emits output HTML file if all builds
@@ -208,10 +209,63 @@ function rollupPluginHtml(pluginOptions) {
          * @param {OutputBundle} bundle
          */
         async generateBundle(options, bundle) {
-          generatedBundles.push({ name, options, bundle });
-          if (generatedBundles.length === outputCount) {
-            this.emitFile(await createHtmlAsset());
-          }
+          return new Promise(resolve => {
+            if (!options.dir) {
+              throw createError(`Output ${name} must have a dir option set.`);
+            }
+
+            generatedBundles.push({ name, options, bundle });
+
+            if (pluginOptions.outputBundleName) {
+              if (!multiOutputNames.includes(pluginOptions.outputBundleName)) {
+                throw createError(
+                  `outputName is set to ${pluginOptions.outputBundleName} but there was no ` +
+                    "output added with this name. Used .addOutput('name') to add it.",
+                );
+              }
+
+              if (pluginOptions.outputBundleName === name) {
+                // we need to emit the asset from this output's asset tree, but not all build outputs have
+                // finished building yet. create a function to be called later to emit the final output
+                // when all builds are finished
+                const { dir } = options;
+                deferredEmitHtmlFile = () =>
+                  createHtmlAsset(dir).then(asset => {
+                    this.emitFile(asset);
+                    resolve();
+                  });
+              }
+            }
+
+            if (generatedBundles.length === multiOutputNames.length) {
+              // this is the last build, emit the HTML file
+              if (deferredEmitHtmlFile) {
+                // emit to another build output's asset tree
+                deferredEmitHtmlFile().then(() => {
+                  resolve();
+                });
+                return;
+              }
+
+              const outputDirs = new Set(generatedBundles.map(b => b.options.dir));
+              if (outputDirs.size !== 1) {
+                throw createError(
+                  `Multiple rollup build outputs have a different output directory set.` +
+                    ' Set the outputName property to indicate which build should be used to emit the generated HTML file.',
+                );
+              }
+
+              // emit asset from this output
+              createHtmlAsset(options.dir).then(asset => {
+                resolve();
+                this.emitFile(asset);
+              });
+              return;
+            }
+
+            // no work to be done for this build output
+            resolve();
+          });
         },
       };
     },

--- a/packages/rollup-plugin-html/src/getInputHtmlData.js
+++ b/packages/rollup-plugin-html/src/getInputHtmlData.js
@@ -1,3 +1,4 @@
+/** @typedef {import('rollup').InputOptions} InputOptions */
 /** @typedef {import('./types').PluginOptions} PluginOptions */
 /** @typedef {import('./types').InputHtmlData} InputHtmlData */
 
@@ -7,10 +8,11 @@ const { createError } = require('./utils');
 
 /**
  * @param {PluginOptions} pluginOptions
- * @param {string} rootDir
+ * @param {string} [rollupInput]
+ * @param {string} [rootDir]
  * @returns {InputHtmlData}
  */
-function getInputHtmlData(pluginOptions, rootDir = process.cwd()) {
+function getInputHtmlData(pluginOptions, rollupInput, rootDir = process.cwd()) {
   if (pluginOptions.inputHtml) {
     return {
       name: pluginOptions.name,
@@ -19,17 +21,18 @@ function getInputHtmlData(pluginOptions, rootDir = process.cwd()) {
     };
   }
 
-  if (!pluginOptions.inputPath) {
-    throw createError('Input must have either a path or content.');
+  if (!pluginOptions.inputPath && !rollupInput) {
+    throw createError('Internal plugin error, missing input while getInputHtmlData is called.');
   }
 
-  const htmlPath = path.resolve(rootDir, pluginOptions.inputPath);
+  const inputPath = /** @type {string} */ (pluginOptions.inputPath || rollupInput);
+  const htmlPath = path.resolve(rootDir, inputPath);
   if (!fs.existsSync) {
     throw createError(`Could not find HTML input file at: ${htmlPath}`);
   }
   const htmlDir = path.dirname(htmlPath);
   const inputHtml = fs.readFileSync(htmlPath, 'utf-8');
-  const name = pluginOptions.name || path.basename(pluginOptions.inputPath);
+  const name = pluginOptions.name || path.basename(inputPath);
   return { name, rootDir: htmlDir, inputHtml };
 }
 

--- a/packages/rollup-plugin-html/src/types.d.ts
+++ b/packages/rollup-plugin-html/src/types.d.ts
@@ -4,7 +4,7 @@ export interface PluginOptions {
   name?: string;
   inputPath?: string;
   inputHtml?: string;
-  dir?: string;
+  outputBundleName?: string;
   publicPath?: string;
   inject?: boolean;
   minify?: boolean | object | MinifyFunction;

--- a/packages/rollup-plugin-html/src/utils.js
+++ b/packages/rollup-plugin-html/src/utils.js
@@ -78,9 +78,23 @@ function addRollupInput(inputOptions, inputModuleIds) {
   throw createError(`Unknown rollup input type. Supported inputs are string, array and object.`);
 }
 
+/**
+ * @param {InputOptions} rollupInputOptions
+ * @param {PluginOptions} pluginOptions
+ */
+function shouldReadInputFromRollup(rollupInputOptions, pluginOptions) {
+  return (
+    typeof rollupInputOptions.input === 'string' &&
+    rollupInputOptions.input.endsWith('.html') &&
+    !pluginOptions.inputHtml &&
+    !pluginOptions.inputPath
+  );
+}
+
 module.exports = {
   createError,
   getMainOutputDir,
   fromEntries,
   addRollupInput,
+  shouldReadInputFromRollup,
 };

--- a/packages/rollup-plugin-html/src/utils.js
+++ b/packages/rollup-plugin-html/src/utils.js
@@ -26,26 +26,6 @@ function fromEntries(entries) {
 }
 
 /**
- * @param {PluginOptions} pluginOptions
- * @param {GeneratedBundle[]} generatedBundles
- * @returns {string}
- */
-function getMainOutputDir(pluginOptions, generatedBundles) {
-  const mainOutputDir =
-    // user defined output dir
-    pluginOptions.dir ||
-    // if no used defined output dir, we find the "lowest" output dir, ex. if there are
-    // "dist/legacy" and "dist", we take "dist"
-    generatedBundles.map(b => b.options.dir).sort((a, b) => (a && b ? a.length - b.length : 0))[0];
-
-  if (typeof mainOutputDir !== 'string')
-    throw createError(
-      "Rollup must be configured to output in a directory: html({ outputDir: 'dist' })",
-    );
-  return mainOutputDir;
-}
-
-/**
  * @param {InputOptions} inputOptions
  * @param {string[]} inputModuleIds
  * @returns {InputOptions}
@@ -93,7 +73,6 @@ function shouldReadInputFromRollup(rollupInputOptions, pluginOptions) {
 
 module.exports = {
   createError,
-  getMainOutputDir,
   fromEntries,
   addRollupInput,
   shouldReadInputFromRollup,

--- a/packages/rollup-plugin-html/test/fixtures/getInputHtmlData/not-index.html
+++ b/packages/rollup-plugin-html/test/fixtures/getInputHtmlData/not-index.html
@@ -1,0 +1,3 @@
+<html>not-index.html
+
+</html>

--- a/packages/rollup-plugin-html/test/rollup-plugin-html.test.js
+++ b/packages/rollup-plugin-html/test/rollup-plugin-html.test.js
@@ -81,6 +81,31 @@ describe('rollup-plugin-html', () => {
     );
   });
 
+  it('can build with html file as rollup input', async () => {
+    const config = {
+      input: 'test/fixtures/rollup-plugin-html/index.html',
+      plugins: [
+        htmlPlugin({
+          minify: false,
+        }),
+      ],
+    };
+    const bundle = await rollup.rollup(config);
+    const { output } = await bundle.generate(outputConfig);
+
+    expect(output.length).to.equal(4);
+    const { code: entryA } = getChunk(output, 'entrypoint-a.js');
+    const { code: entryB } = getChunk(output, 'entrypoint-b.js');
+    expect(entryA).to.include("console.log('entrypoint-a.js');");
+    expect(entryB).to.include("console.log('entrypoint-b.js');");
+    expect(getAsset(output, 'index.html').source).to.equal(
+      '<html><head></head><body><h1>hello world</h1>\n\n' +
+        '<script type="module" src="./entrypoint-a.js"></script>' +
+        '<script type="module" src="./entrypoint-b.js"></script>' +
+        '</body></html>',
+    );
+  });
+
   it('can build with a html string as input', async () => {
     const config = {
       plugins: [

--- a/packages/rollup-plugin-html/test/src/getInputHtmlData.test.js
+++ b/packages/rollup-plugin-html/test/src/getInputHtmlData.test.js
@@ -5,11 +5,9 @@ const { getInputHtmlData } = require('../../src/getInputHtmlData');
 const rootDir = path.join(__dirname, '..', 'fixtures', 'getInputHtmlData');
 
 describe('getInputHtmlData()', () => {
-  it('supports setting path as input', () => {
-    const options = {
-      inputPath: 'index.html',
-    };
-    const result = getInputHtmlData(options, rootDir);
+  it('supports setting path as input in plugin options', () => {
+    const options = { inputPath: 'index.html' };
+    const result = getInputHtmlData(options, undefined, rootDir);
 
     expect(result).to.eql({
       rootDir,
@@ -18,12 +16,30 @@ describe('getInputHtmlData()', () => {
     });
   });
 
+  it('supports setting path as rollup input', () => {
+    const result = getInputHtmlData({}, 'index.html', rootDir);
+
+    expect(result).to.eql({
+      rootDir,
+      name: 'index.html',
+      inputHtml: '<html>index.html\n\n</html>',
+    });
+  });
+
+  it('path from plugin takes presedence over rollup input', () => {
+    const options = { inputPath: 'not-index.html' };
+    const result = getInputHtmlData(options, 'index.html', rootDir);
+
+    expect(result).to.eql({
+      rootDir,
+      name: 'not-index.html',
+      inputHtml: '<html>not-index.html\n\n</html>',
+    });
+  });
+
   it('supports setting html string as input', () => {
-    const options = {
-      name: 'foo.html',
-      inputHtml: '<html>My HTML</html>',
-    };
-    const result = getInputHtmlData(options, rootDir);
+    const options = { name: 'foo.html', inputHtml: '<html>My HTML</html>' };
+    const result = getInputHtmlData(options, undefined, rootDir);
 
     expect(result).to.eql({
       name: 'foo.html',
@@ -36,7 +52,7 @@ describe('getInputHtmlData()', () => {
     const options = {
       inputPath: 'pages/page-a.html',
     };
-    const result = getInputHtmlData(options, rootDir);
+    const result = getInputHtmlData(options, undefined, rootDir);
 
     expect(result).to.eql({
       rootDir: path.join(rootDir, 'pages'),
@@ -49,6 +65,6 @@ describe('getInputHtmlData()', () => {
     const options = {
       name: 'index.html',
     };
-    expect(() => getInputHtmlData(options, rootDir)).to.throw();
+    expect(() => getInputHtmlData(options, undefined, rootDir)).to.throw();
   });
 });

--- a/packages/rollup-plugin-polyfills-loader/README.md
+++ b/packages/rollup-plugin-polyfills-loader/README.md
@@ -42,7 +42,6 @@ export default {
       inject: false,
     }),
     polyfillsLoader({
-      htmlFileName: 'index.html',
       polyfills: {
         coreJs: true,
         fetch: true,
@@ -80,7 +79,6 @@ export default {
   plugins: [
     htmlPlugin,
     polyfillsLoader({
-      htmlFileName: 'index.html',
       modernOutput: 'modern',
       legacyOutput: { name: 'legacy', test: "!('noModule' in HTMLScriptElement.prototype)" },
       polyfills: {

--- a/packages/rollup-plugin-polyfills-loader/rollup-plugin-polyfills-loader.js
+++ b/packages/rollup-plugin-polyfills-loader/rollup-plugin-polyfills-loader.js
@@ -12,14 +12,10 @@ const { createError } = require('./src/utils');
 const { createPolyfillsLoaderConfig } = require('./src/createPolyfillsLoaderConfig');
 
 /**
- * @param {PluginOptions} pluginOptions
+ * @param {PluginOptions} [pluginOptions]
  * @returns {Plugin}
  */
-function rollupPluginPolyfillsLoader(pluginOptions) {
-  pluginOptions = {
-    htmlFileName: 'index.html',
-    ...(pluginOptions || {}),
-  };
+function rollupPluginPolyfillsLoader(pluginOptions = {}) {
   /** @type {GeneratedFile[] | undefined} */
   let generatedFiles;
 
@@ -40,9 +36,10 @@ function rollupPluginPolyfillsLoader(pluginOptions) {
         );
       }
 
-      const htmlPlugin = htmlPlugins.find(
-        pl => pl.getHtmlFileName() === pluginOptions.htmlFileName,
-      );
+      const htmlPlugin =
+        htmlPlugins.length === 1
+          ? htmlPlugins[0]
+          : htmlPlugins.find(pl => pl.getHtmlFileName() === pluginOptions.htmlFileName);
 
       if (!htmlPlugin) {
         throw createError(

--- a/packages/rollup-plugin-polyfills-loader/test/rollup-plugin-polyfills-loader.test.js
+++ b/packages/rollup-plugin-polyfills-loader/test/rollup-plugin-polyfills-loader.test.js
@@ -72,9 +72,7 @@ describe('rollup-plugin-polyfills-loader', () => {
           inputHtml: '<script type="module" src="test/fixtures/entrypoint-a.js"></script>',
           minify: false,
         }),
-        polyfillsLoader({
-          htmlFileName: 'index.html',
-        }),
+        polyfillsLoader(),
       ],
     };
 
@@ -89,6 +87,11 @@ describe('rollup-plugin-polyfills-loader', () => {
   it('can set the html file name', async () => {
     const inputOptions = {
       plugins: [
+        html({
+          name: 'bar.html',
+          inputHtml: '<script type="module" src="test/fixtures/entrypoint-a.js"></script>Bar',
+          minify: false,
+        }),
         html({
           name: 'foo.html',
           inputHtml: '<script type="module" src="test/fixtures/entrypoint-a.js"></script>',
@@ -117,7 +120,6 @@ describe('rollup-plugin-polyfills-loader', () => {
           minify: false,
         }),
         polyfillsLoader({
-          htmlFileName: 'index.html',
           polyfills: {
             webcomponents: true,
             fetch: true,
@@ -147,7 +149,6 @@ describe('rollup-plugin-polyfills-loader', () => {
       plugins: [
         htmlPlugin,
         polyfillsLoader({
-          htmlFileName: 'index.html',
           modernOutput: 'modern',
           legacyOutput: [{ name: 'legacy', test: "!('noModule' in HTMLScriptElement.prototype)" }],
           polyfills: {
@@ -162,7 +163,7 @@ describe('rollup-plugin-polyfills-loader', () => {
     const outputOptions = [
       {
         format: 'system',
-        dir: 'dist/legacy',
+        dir: 'dist',
         plugins: [htmlPlugin.addOutput('legacy')],
       },
       {
@@ -186,9 +187,7 @@ describe('rollup-plugin-polyfills-loader', () => {
         html({
           inputHtml: '<script type="module" src="test/fixtures/entrypoint-a.js"></script>',
         }),
-        polyfillsLoader({
-          htmlFileName: 'index.html',
-        }),
+        polyfillsLoader(),
       ],
     };
 

--- a/packages/rollup-plugin-polyfills-loader/test/snapshots/multiple-outputs.html
+++ b/packages/rollup-plugin-polyfills-loader/test/snapshots/multiple-outputs.html
@@ -1,4 +1,4 @@
-<html><head></head><body><script>System.import("./legacy/entrypoint-a.js");</script><script type="module" src="./entrypoint-a.js"></script><script>(function () {
+<html><head></head><body><script>System.import("./entrypoint-a.js");</script><script type="module" src="./entrypoint-a.js"></script><script>(function () {
   function loadScript(src, type) {
     return new Promise(function (resolve) {
       var script = document.createElement('script');
@@ -41,7 +41,7 @@
 
   function loadFiles() {
     if (!('noModule' in HTMLScriptElement.prototype)) {
-      System.import('./legacy/entrypoint-a.js');
+      System.import('./entrypoint-a.js');
     } else {
       loadScript('./entrypoint-a.js', 'module');
     }


### PR DESCRIPTION
- Allow setting index.html as regular input. This makes it easier to use our `@open-wc/building-rollup` config, as consumers can just set the rollup input and we don't need to make extra options.

- With rollup v2 the order in which build outputs are executed is random, while I was relying on them to be excuted in order. We need to know which build output to emit the generated HTML file from because they may have different output directories. I fixed this by checking if all outputs have the same directory, which is usually the case, and picking the last build to run in that case. Otherwise the user needs to specify a `buildOutputName` option to let us know which one to pick.

- In the polyfills loader when there is only one HTML plugin, we can just pick that one and not require the user to specify the HTML filename. This makes it easier to use the polyfills loader from the rollup config, since we don't know which name might be used.