### PR TITLE
chore(testing-helpers): alphabetize exports

### DIFF
--- a/packages/testing-helpers/index-no-side-effects.js
+++ b/packages/testing-helpers/index-no-side-effects.js
@@ -1,15 +1,16 @@
 export { html, unsafeStatic } from './src/lit-html.js';
 export {
+  aTimeout,
+  defineCE,
+  isIE,
+  nextFrame,
+  oneEvent,
   triggerBlurFor,
   triggerFocusFor,
-  oneEvent,
-  isIE,
-  defineCE,
-  aTimeout,
-  nextFrame,
+  waitUntil,
 } from './src/helpers.js';
 export { litFixture, litFixtureSync } from './src/litFixture.js';
 export { stringFixture, stringFixtureSync } from './src/stringFixture.js';
 export { fixture, fixtureSync } from './src/fixture-no-side-effect.js';
-export { cachedWrappers, fixtureWrapper, fixtureCleanup } from './src/fixtureWrapper.js';
+export { cachedWrappers, fixtureCleanup, fixtureWrapper } from './src/fixtureWrapper.js';
 export { elementUpdated } from './src/elementUpdated.js';

--- a/packages/testing-helpers/index.js
+++ b/packages/testing-helpers/index.js
@@ -1,16 +1,16 @@
 export { html, unsafeStatic } from './src/lit-html.js';
 export {
+  aTimeout,
+  defineCE,
+  isIE,
+  nextFrame,
+  oneEvent,
   triggerBlurFor,
   triggerFocusFor,
-  oneEvent,
-  isIE,
-  defineCE,
-  aTimeout,
-  nextFrame,
   waitUntil,
 } from './src/helpers.js';
 export { litFixture, litFixtureSync } from './src/litFixture.js';
 export { stringFixture, stringFixtureSync } from './src/stringFixture.js';
 export { fixture, fixtureSync } from './src/fixture.js';
-export { cachedWrappers, fixtureWrapper, fixtureCleanup } from './src/fixtureWrapper.js';
+export { cachedWrappers, fixtureCleanup, fixtureWrapper } from './src/fixtureWrapper.js';
 export { elementUpdated } from './src/elementUpdated.js';


### PR DESCRIPTION
Force a release of the `testing-helpers` package so that it picks up the types in CI now...

fixes #1438 