### PR TITLE
fix(es-dev-server): add directly depended package to package.json

### DIFF
--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -97,6 +97,7 @@
     "polyfills-loader": "^1.5.1",
     "portfinder": "^1.0.21",
     "strip-ansi": "^5.2.0",
+    "systemjs": "^4.0.0",
     "useragent": "^2.3.0",
     "whatwg-url": "^7.0.0"
   },


### PR DESCRIPTION
Adds dependency to package as listed in #1439. If this isn't the right path, let's discuss next steps in the issue.

fixes #1439 