### PR TITLE
fix(testing-helpers): publish typescript definition files again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,19 +36,17 @@ jobs:
           root: ~/
           paths:
             - repo/node_modules
-            - repo/packages/*/node_modules
-            - repo/packages/*/dist
-            - repo/packages/**/*.d.ts
+            - repo/packages/*
   test-local:
     <<: *defaults
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/
       # Download and cache dependencies
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
+      - attach_workspace:
+          at: ~/
       # run lint
       - run: npm run lint
 
@@ -62,12 +60,12 @@ jobs:
     steps:
       - checkout
       # Download and cache dependencies
-      - attach_workspace:
-          at: ~/
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
+      # Download and cache dependencies
+      - attach_workspace:
+          at: ~/
       - run: npm run test:bs
   deploy:
     <<: *defaults

--- a/packages/testing-helpers/index-no-side-effects.js
+++ b/packages/testing-helpers/index-no-side-effects.js
@@ -1,4 +1,6 @@
-export { html, unsafeStatic } from './src/lit-html.js';
+export { elementUpdated } from './src/elementUpdated.js';
+export { fixture, fixtureSync } from './src/fixture-no-side-effect.js';
+export { cachedWrappers, fixtureCleanup, fixtureWrapper } from './src/fixtureWrapper.js';
 export {
   aTimeout,
   defineCE,
@@ -9,8 +11,6 @@ export {
   triggerFocusFor,
   waitUntil,
 } from './src/helpers.js';
+export { html, unsafeStatic } from './src/lit-html.js';
 export { litFixture, litFixtureSync } from './src/litFixture.js';
 export { stringFixture, stringFixtureSync } from './src/stringFixture.js';
-export { fixture, fixtureSync } from './src/fixture-no-side-effect.js';
-export { cachedWrappers, fixtureCleanup, fixtureWrapper } from './src/fixtureWrapper.js';
-export { elementUpdated } from './src/elementUpdated.js';

--- a/packages/testing-helpers/index.js
+++ b/packages/testing-helpers/index.js
@@ -1,4 +1,6 @@
-export { html, unsafeStatic } from './src/lit-html.js';
+export { elementUpdated } from './src/elementUpdated.js';
+export { fixture, fixtureSync } from './src/fixture.js';
+export { cachedWrappers, fixtureCleanup, fixtureWrapper } from './src/fixtureWrapper.js';
 export {
   aTimeout,
   defineCE,
@@ -9,8 +11,6 @@ export {
   triggerFocusFor,
   waitUntil,
 } from './src/helpers.js';
+export { html, unsafeStatic } from './src/lit-html.js';
 export { litFixture, litFixtureSync } from './src/litFixture.js';
 export { stringFixture, stringFixtureSync } from './src/stringFixture.js';
-export { fixture, fixtureSync } from './src/fixture.js';
-export { cachedWrappers, fixtureCleanup, fixtureWrapper } from './src/fixtureWrapper.js';
-export { elementUpdated } from './src/elementUpdated.js';


### PR DESCRIPTION
This persists _ALL_ files in all packages, which _should_ also include the definitions in sub dirs... 🤞 

fixes #1445 
fixes #1438 