### PR TITLE
fix(building-rollup): ensuring input is a string before checking exte…

### DIFF
--- a/packages/building-rollup/modern-and-legacy-config.js
+++ b/packages/building-rollup/modern-and-legacy-config.js
@@ -27,7 +27,7 @@ function createConfig(_options, legacy) {
     indexHTMLPlugin: {},
     ..._options,
     plugins: {
-      indexHTML: _options.input.endsWith('.html'),
+      indexHTML: _options.input.endsWith && _options.input.endsWith('.html'),
       workbox: true,
       babel: true,
       ...(_options.plugins || {}),

--- a/packages/building-rollup/modern-config.js
+++ b/packages/building-rollup/modern-config.js
@@ -25,7 +25,7 @@ module.exports = function createBasicConfig(_options) {
     indexHTMLPlugin: {},
     ..._options,
     plugins: {
-      indexHTML: _options.input.endsWith('.html'),
+      indexHTML: _options.input.endsWith && _options.input.endsWith('.html'),
       workbox: true,
       babel: true,
       ...(_options.plugins || {}),


### PR DESCRIPTION
I also ran into #1282 when using a configuration that has an array input. Something like this trips it up:

```
createDefaultConfig({
	input: ['file1.js', 'file2.js']
});
```

You get a `TypeError: _options.input.endsWith is not a function` error, since `input` in this case isn't a string, it's an array -- which is a valid Rollup thing to want to do.