### PR TITLE
chore: run tests on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           at: ~/
       # reinstall dependencies, cannot use cached dependencies from a linux VM
       - run: yarn install --frozen-lockfile
-      - run: npm run test:node
+      - run: npm run test:node-windows
   deploy:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,10 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  windows: circleci/windows@2.4.0
 
 defaults: &defaults
   working_directory: ~/repo
@@ -14,24 +17,16 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
-      # seems we always need to run yarn for mono repos to get nested dependencies and bin links
       - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - node_modules
           key: v4-dependencies-{{ checksum "yarn.lock" }}
-
-      # build what needs to be build so we can use it in the next steps
       - run: npm run build
-
-      # auto build typescript definition files (not part of build as locally JsDoc alone is all we need)
       - run: npm run build:types
-
-      # persist built files and duplicate dependencies to workspace
       - persist_to_workspace:
           root: ~/
           paths:
@@ -41,32 +36,33 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: ~/
-      # run lint
       - run: npm run lint
-
-      # run tests
       - run: npm run test:node
-
-      # run browser tests
       - run: npm run test:browser
   test-bs:
     <<: *defaults
     steps:
       - checkout
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v4-dependencies-{{ checksum "yarn.lock" }}
-      # Download and cache dependencies
       - attach_workspace:
           at: ~/
       - run: npm run test:bs
+  test-windows:
+    executor: windows/default
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+      # reinstall dependencies, cannot use cached dependencies from a linux VM
+      - run: yarn install --frozen-lockfile
+      - run: npm run test:node
   deploy:
     <<: *defaults
     steps:
@@ -91,6 +87,7 @@ workflows:
   test-deploy:
     jobs:
       - build
+      - test-windows
       - test-local:
           requires:
             - build
@@ -99,6 +96,7 @@ workflows:
             - build
       - deploy:
           requires:
+            - test-windows
             - test-local
             - test-bs
           filters:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:browser:watch": "karma start --auto-watch=true --single-run=false",
     "test:bs": "karma start karma.bs.conf.js --coverage",
     "test:node": "lerna run test:node",
+    "test:node-windows": "lerna run --scope \"@open-wc/rollup-plugin-html\" --scope \"@open-wc/rollup-plugin-polyfills-loader\" --scope \"polyfills-loader\" test:node",
     "test:update-snapshots": "lerna run test:update-snapshots",
     "update-dependency": "node scripts/update-dependency.js",
     "vuepress:build": "vuepress build docs",

--- a/packages/building-utils/index.js
+++ b/packages/building-utils/index.js
@@ -1,11 +1,13 @@
 const findSupportedBrowsers = require('./find-supported-browsers');
 const defaultFileExtensions = require('./default-file-extensions');
 const { toBrowserPath } = require('./to-browser-path');
+const { toFilePath } = require('./to-file-path');
 const dom5Utils = require('./dom5-utils');
 
 module.exports = {
   findSupportedBrowsers,
   defaultFileExtensions,
   toBrowserPath,
+  toFilePath,
   ...dom5Utils,
 };

--- a/packages/building-utils/to-file-path.js
+++ b/packages/building-utils/to-file-path.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+/**
+ * Transforms a file system path to a browser URL. For example windows uses `\` on the file system,
+ * but it should use `/` in the browser.
+ */
+function toFilePath(browserPath) {
+  return browserPath.replace(new RegExp('/', 'g'), path.sep);
+}
+
+module.exports = { toFilePath };

--- a/packages/polyfills-loader/test/create-polyfills-loader.test.js
+++ b/packages/polyfills-loader/test/create-polyfills-loader.test.js
@@ -28,7 +28,10 @@ function testSnapshot({ name, config, expectedFiles = /** @type {string[]} */ ([
   }
 }
 
-describe('create-polyfills-loader', () => {
+describe('create-polyfills-loader', function describe() {
+  // bootup of the first test can take a long time in CI to load all the polyfills
+  this.timeout(5000);
+
   it('generates a loader script with one module resource', () => {
     testSnapshot({
       name: 'module-resource',

--- a/packages/rollup-plugin-html/src/extractModules.js
+++ b/packages/rollup-plugin-html/src/extractModules.js
@@ -1,6 +1,6 @@
 /** @typedef {import('./types').InputHtmlData} InputHtmlData */
 
-const { findJsScripts } = require('@open-wc/building-utils');
+const { findJsScripts, toFilePath } = require('@open-wc/building-utils');
 const path = require('path');
 const { parse, serialize } = require('parse5');
 const {
@@ -29,12 +29,15 @@ function extractModules(inputHtmlData, inputHtmlName, projectRootDir = process.c
 
     if (!src) {
       // turn inline module (<script type="module"> ...code ... </script>)
-      const suffix = path.basename(inputHtmlName).split('.')[0];
-      const importPath = path.join(htmlRootDir, `inline-module-${suffix}-${i}.js`);
+      const suffix = path.posix.basename(inputHtmlName).split('.')[0];
+      const importPath = path.posix.join(htmlRootDir, `inline-module-${suffix}-${i}.js`);
       inlineModules.set(importPath, getTextContent(scriptNode));
     } else {
       // external script <script type="module" src="./foo.js"></script>
-      const importPath = path.join(src.startsWith('/') ? projectRootDir : htmlRootDir, src);
+      const importPath = path.join(
+        src.startsWith('/') ? projectRootDir : htmlRootDir,
+        toFilePath(src),
+      );
       moduleImports.push(importPath);
     }
 

--- a/packages/rollup-plugin-html/src/getEntrypointBundles.js
+++ b/packages/rollup-plugin-html/src/getEntrypointBundles.js
@@ -4,6 +4,7 @@
 /** @typedef {import('./types').GeneratedBundle} GeneratedBundle */
 
 const path = require('path');
+const { toBrowserPath } = require('@open-wc/building-utils');
 const { createError } = require('./utils');
 
 /**
@@ -18,13 +19,13 @@ function createImportPath({ publicPath, mainOutputDir, fileOutputDir, htmlFileNa
   const pathFromMainToFileDir = path.relative(mainOutputDir, fileOutputDir);
   let importPath;
   if (publicPath) {
-    importPath = path.join(publicPath, pathFromMainToFileDir, fileName);
+    importPath = toBrowserPath(path.join(publicPath, pathFromMainToFileDir, fileName));
   } else {
     const pathFromHtmlToOutputDir = path.relative(
       path.dirname(htmlFileName),
       pathFromMainToFileDir,
     );
-    importPath = path.join(pathFromHtmlToOutputDir, fileName);
+    importPath = toBrowserPath(path.join(pathFromHtmlToOutputDir, fileName));
   }
 
   if (importPath.startsWith('http') || importPath.startsWith('/') || importPath.startsWith('.')) {

--- a/packages/rollup-plugin-html/test/fixtures/getInputHtmlData/index.html
+++ b/packages/rollup-plugin-html/test/fixtures/getInputHtmlData/index.html
@@ -1,3 +1,3 @@
-<html>index.html
-
+<html>
+  index.html
 </html>

--- a/packages/rollup-plugin-html/test/rollup-plugin-html.test.js
+++ b/packages/rollup-plugin-html/test/rollup-plugin-html.test.js
@@ -34,10 +34,14 @@ const outputConfig = {
   dir: 'dist',
 };
 
+function stripNewlines(str) {
+  return str.replace(/(\r\n|\n|\r)/gm, '');
+}
+
 describe('rollup-plugin-html', () => {
   it('can build an app with rollup bundle injected into a default HTML page and filename', async () => {
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [
         htmlPlugin({
           minify: false,
@@ -49,7 +53,7 @@ describe('rollup-plugin-html', () => {
 
     expect(output.length).to.equal(2);
     expect(getChunk(output, 'entrypoint-a.js').code).to.include("console.log('entrypoint-a.js');");
-    expect(getAsset(output, 'index.html').source).to.equal(
+    expect(stripNewlines(getAsset(output, 'index.html').source)).to.equal(
       '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>' +
         '<script type="module" src="./entrypoint-a.js"></script>' +
         '</body></html>',
@@ -60,7 +64,7 @@ describe('rollup-plugin-html', () => {
     const config = {
       plugins: [
         htmlPlugin({
-          inputPath: 'test/fixtures/rollup-plugin-html/index.html',
+          inputPath: require.resolve('./fixtures/rollup-plugin-html/index.html'),
           minify: false,
         }),
       ],
@@ -73,8 +77,8 @@ describe('rollup-plugin-html', () => {
     const { code: entryB } = getChunk(output, 'entrypoint-b.js');
     expect(entryA).to.include("console.log('entrypoint-a.js');");
     expect(entryB).to.include("console.log('entrypoint-b.js');");
-    expect(getAsset(output, 'index.html').source).to.equal(
-      '<html><head></head><body><h1>hello world</h1>\n\n' +
+    expect(stripNewlines(getAsset(output, 'index.html').source)).to.equal(
+      '<html><head></head><body><h1>hello world</h1>' +
         '<script type="module" src="./entrypoint-a.js"></script>' +
         '<script type="module" src="./entrypoint-b.js"></script>' +
         '</body></html>',
@@ -83,7 +87,7 @@ describe('rollup-plugin-html', () => {
 
   it('can build with html file as rollup input', async () => {
     const config = {
-      input: 'test/fixtures/rollup-plugin-html/index.html',
+      input: require.resolve('./fixtures/rollup-plugin-html/index.html'),
       plugins: [
         htmlPlugin({
           minify: false,
@@ -98,8 +102,8 @@ describe('rollup-plugin-html', () => {
     const { code: entryB } = getChunk(output, 'entrypoint-b.js');
     expect(entryA).to.include("console.log('entrypoint-a.js');");
     expect(entryB).to.include("console.log('entrypoint-b.js');");
-    expect(getAsset(output, 'index.html').source).to.equal(
-      '<html><head></head><body><h1>hello world</h1>\n\n' +
+    expect(stripNewlines(getAsset(output, 'index.html').source)).to.equal(
+      '<html><head></head><body><h1>hello world</h1>' +
         '<script type="module" src="./entrypoint-a.js"></script>' +
         '<script type="module" src="./entrypoint-b.js"></script>' +
         '</body></html>',
@@ -122,7 +126,7 @@ describe('rollup-plugin-html', () => {
     const { output } = await bundle.generate(outputConfig);
 
     expect(output.length).to.equal(2);
-    expect(getAsset(output, 'index.html').source).to.equal(
+    expect(stripNewlines(getAsset(output, 'index.html').source)).to.equal(
       '<html><head></head><body><h1>Hello world</h1>' +
         '<script type="module" src="./entrypoint-a.js"></script></body></html>',
     );
@@ -146,7 +150,7 @@ describe('rollup-plugin-html', () => {
     expect(output.length).to.equal(2);
     const { code: appCode } = getChunk(output, 'inline-module-index-0.js');
     expect(appCode).to.include("console.log('entrypoint-a.js');");
-    expect(getAsset(output, 'index.html').source).to.equal(
+    expect(stripNewlines(getAsset(output, 'index.html').source)).to.equal(
       '<html><head></head><body><h1>Hello world</h1>' +
         '<script type="module" src="./inline-module-index-0.js"></script>' +
         '</body></html>',
@@ -170,7 +174,7 @@ describe('rollup-plugin-html', () => {
 
   it('can build with js input and generated html output', async () => {
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [
         htmlPlugin({
           name: 'index.html',
@@ -195,7 +199,7 @@ describe('rollup-plugin-html', () => {
 
   it('can build transforming final output', async () => {
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [
         htmlPlugin({
           name: 'index.html',
@@ -221,7 +225,7 @@ describe('rollup-plugin-html', () => {
 
   it('can build with a public path', async () => {
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [
         htmlPlugin({
           name: 'index.html',
@@ -245,7 +249,7 @@ describe('rollup-plugin-html', () => {
 
   it('can build with a public path with a file in a directory', async () => {
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [
         htmlPlugin({
           name: 'pages/index.html',
@@ -278,7 +282,7 @@ describe('rollup-plugin-html', () => {
     });
 
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [plugin],
     };
 
@@ -325,7 +329,7 @@ describe('rollup-plugin-html', () => {
     });
 
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [plugin],
     };
 
@@ -420,7 +424,7 @@ describe('rollup-plugin-html', () => {
 
   it('can build with js input, injecting the same bundle into multiple html files', async () => {
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [
         htmlPlugin({
           name: 'page-a.html',
@@ -568,7 +572,7 @@ describe('rollup-plugin-html', () => {
     });
 
     await rollup.rollup({
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [pluginA],
     });
     await rollup.rollup({ plugins: [pluginB] });
@@ -581,7 +585,7 @@ describe('rollup-plugin-html', () => {
 
   it('supports other plugins injecting a transform function', async () => {
     const config = {
-      input: './test/fixtures/rollup-plugin-html/entrypoint-a.js',
+      input: require.resolve('./fixtures/rollup-plugin-html/entrypoint-a.js'),
       plugins: [
         htmlPlugin({
           name: 'my-page.html',

--- a/packages/rollup-plugin-html/test/rollup-plugin-html.test.js
+++ b/packages/rollup-plugin-html/test/rollup-plugin-html.test.js
@@ -34,6 +34,7 @@ const outputConfig = {
   dir: 'dist',
 };
 
+/** @param {string} str */
 function stripNewlines(str) {
   return str.replace(/(\r\n|\n|\r)/gm, '');
 }

--- a/packages/rollup-plugin-html/test/src/extractModules.test.js
+++ b/packages/rollup-plugin-html/test/src/extractModules.test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const path = require('path');
 const { extractModules } = require('../../src/extractModules');
 
 describe('extractModules()', () => {
@@ -17,7 +18,7 @@ describe('extractModules()', () => {
     );
 
     expect(inlineModules.size).to.equal(0);
-    expect(moduleImports).to.eql(['/foo.js', '/bar.js']);
+    expect(moduleImports).to.eql([`${path.sep}foo.js`, `${path.sep}bar.js`]);
     expect(htmlWithoutModules).to.eql(
       '<html><head></head><body><div>before</div><div>after</div></body></html>',
     );
@@ -38,7 +39,10 @@ describe('extractModules()', () => {
     );
 
     expect(inlineModules.size).to.equal(0);
-    expect(moduleImports).to.eql(['/base/foo.js', '/base/bar.js']);
+    expect(moduleImports).to.eql([
+      `${path.sep}base${path.sep}foo.js`,
+      `${path.sep}base${path.sep}bar.js`,
+    ]);
     expect(htmlWithoutModules).to.eql(
       '<html><head></head><body><div>before</div><div>after</div></body></html>',
     );
@@ -59,7 +63,10 @@ describe('extractModules()', () => {
     );
 
     expect(inlineModules.size).to.equal(0);
-    expect(moduleImports).to.eql(['/base-1/base-2/foo.js', '/base-1/bar.js']);
+    expect(moduleImports).to.eql([
+      `${path.sep}base-1${path.sep}base-2${path.sep}foo.js`,
+      `${path.sep}base-1${path.sep}bar.js`,
+    ]);
     expect(htmlWithoutModules).to.eql(
       '<html><head></head><body><div>before</div><div>after</div></body></html>',
     );

--- a/packages/rollup-plugin-html/test/src/getInputHtmlData.test.js
+++ b/packages/rollup-plugin-html/test/src/getInputHtmlData.test.js
@@ -4,25 +4,36 @@ const { getInputHtmlData } = require('../../src/getInputHtmlData');
 
 const rootDir = path.join(__dirname, '..', 'fixtures', 'getInputHtmlData');
 
+/** @param {string} str */
+function cleanupHtml(str) {
+  return str.replace(/(\r\n|\n|\r| )/gm, '');
+}
+
 describe('getInputHtmlData()', () => {
   it('supports setting path as input in plugin options', () => {
     const options = { inputPath: 'index.html' };
     const result = getInputHtmlData(options, undefined, rootDir);
 
-    expect(result).to.eql({
+    expect({
+      ...result,
+      inputHtml: cleanupHtml(result.inputHtml),
+    }).to.eql({
       rootDir,
       name: 'index.html',
-      inputHtml: '<html>index.html\n\n</html>',
+      inputHtml: '<html>index.html</html>',
     });
   });
 
   it('supports setting path as rollup input', () => {
     const result = getInputHtmlData({}, 'index.html', rootDir);
 
-    expect(result).to.eql({
+    expect({
+      ...result,
+      inputHtml: cleanupHtml(result.inputHtml),
+    }).to.eql({
       rootDir,
       name: 'index.html',
-      inputHtml: '<html>index.html\n\n</html>',
+      inputHtml: '<html>index.html</html>',
     });
   });
 
@@ -30,18 +41,24 @@ describe('getInputHtmlData()', () => {
     const options = { inputPath: 'not-index.html' };
     const result = getInputHtmlData(options, 'index.html', rootDir);
 
-    expect(result).to.eql({
+    expect({
+      ...result,
+      inputHtml: cleanupHtml(result.inputHtml),
+    }).to.eql({
       rootDir,
       name: 'not-index.html',
-      inputHtml: '<html>not-index.html\n\n</html>',
+      inputHtml: '<html>not-index.html</html>',
     });
   });
 
   it('supports setting html string as input', () => {
-    const options = { name: 'foo.html', inputHtml: '<html>My HTML</html>' };
+    const options = { name: 'foo.html', inputHtml: '<html>foo</html>' };
     const result = getInputHtmlData(options, undefined, rootDir);
 
-    expect(result).to.eql({
+    expect({
+      ...result,
+      inputHtml: cleanupHtml(result.inputHtml),
+    }).to.eql({
       name: 'foo.html',
       rootDir,
       inputHtml: options.inputHtml,
@@ -54,10 +71,13 @@ describe('getInputHtmlData()', () => {
     };
     const result = getInputHtmlData(options, undefined, rootDir);
 
-    expect(result).to.eql({
+    expect({
+      ...result,
+      inputHtml: cleanupHtml(result.inputHtml),
+    }).to.eql({
       rootDir: path.join(rootDir, 'pages'),
       name: 'page-a.html',
-      inputHtml: '<html>page-a.html\n\n</html>',
+      inputHtml: '<html>page-a.html</html>',
     });
   });
 

--- a/packages/rollup-plugin-polyfills-loader/test/rollup-plugin-polyfills-loader.test.js
+++ b/packages/rollup-plugin-polyfills-loader/test/rollup-plugin-polyfills-loader.test.js
@@ -64,7 +64,10 @@ const defaultOutputOptions = [
   },
 ];
 
-describe('rollup-plugin-polyfills-loader', () => {
+describe('rollup-plugin-polyfills-loader', function describe() {
+  // bootup of the first test can take a long time in CI to load all the polyfills
+  this.timeout(5000);
+
   it('can inject a polyfills loader with a single output', async () => {
     const inputOptions = {
       plugins: [


### PR DESCRIPTION
I'm currently working on the new rollup config, and the plugins that go along with it. I want to make sure that they work on windows, so I added a windows step in the CI.

A lot of tests fail on windows, not necessarily because of bad code but often because of path and newline differences. For now I scoped it to the packages I'm working on, over time we can add more packages.