### PR TITLE
fix(scoped-elements): getScopedTagName returns undefined

### DIFF
--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -2,8 +2,7 @@
 import { TemplateResult } from 'lit-element';
 import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { transform } from './transform.js';
-import { defineScopedElement } from './registerElement.js';
-import { getFromGlobalTagsCache } from './globalTagsCache.js';
+import { defineScopedElement, registerElement } from './registerElement.js';
 
 /**
  * @typedef {import('lit-html/lib/shady-render').ShadyRenderOptions} ShadyRenderOptions
@@ -115,7 +114,9 @@ export const ScopedElementsMixin = dedupeMixin(
       static getScopedTagName(tagName) {
         const klass = this.scopedElements[tagName];
 
-        return klass ? getFromGlobalTagsCache(klass) : tagsCaches.get(this).get(tagName);
+        return klass
+          ? registerElement(tagName, klass, tagsCaches.get(this))
+          : tagsCaches.get(this).get(tagName);
       }
     },
 );

--- a/packages/scoped-elements/test/ScopedElementsMixin.test.js
+++ b/packages/scoped-elements/test/ScopedElementsMixin.test.js
@@ -293,7 +293,7 @@ describe('ScopedElementsMixin', () => {
   });
 
   describe('getScopedTagName', () => {
-    it('should return the scoped tag name', async () => {
+    it('should return the scoped tag name for a registered element', async () => {
       const chars = `-|\\.|[0-9]|[a-z]`;
       const tagRegExp = new RegExp(`[a-z](${chars})*-(${chars})*-[0-9]{1,5}`);
 
@@ -320,6 +320,34 @@ describe('ScopedElementsMixin', () => {
       expect(el.constructor.getScopedTagName('feature-a')).to.match(tagRegExp);
       // @ts-ignore
       expect(el.constructor.getScopedTagName('feature-b')).to.match(tagRegExp);
+    });
+
+    it('should return the scoped tag name for a non already registered element', async () => {
+      const chars = `-|\\.|[0-9]|[a-z]`;
+      const tagRegExp = new RegExp(`[a-z](${chars})*-(${chars})*-[0-9]{1,5}`);
+
+      class UnregisteredFeature extends LitElement {
+        render() {
+          return html`
+            <div>Unregistered feature</div>
+          `;
+        }
+      }
+
+      const tag = defineCE(
+        class extends ScopedElementsMixin(LitElement) {
+          static get scopedElements() {
+            return {
+              'unregistered-feature': UnregisteredFeature,
+            };
+          }
+        },
+      );
+
+      const el = await fixture(`<${tag}></${tag}>`);
+
+      // @ts-ignore
+      expect(el.constructor.getScopedTagName('unregistered-feature')).to.match(tagRegExp);
     });
   });
 });


### PR DESCRIPTION
getScopedTagName should define the scoped element if it's not already defined.

fixes: https://github.com/open-wc/open-wc/issues/1455