### PR TITLE
docs: updates rollup plugin url and usage in rollup package documentation

### DIFF
--- a/packages/building-rollup/README.md
+++ b/packages/building-rollup/README.md
@@ -268,11 +268,12 @@ export default deepmerge(basicConfig, {
 
 #### Resolve commonjs modules
 
-CommonJS is the module format for NodeJS, and not suitable for the browser. Rollup only handles es modules by default, but sometimes it's necessary to be able to import a dependency. To do this, you can add [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs):
+CommonJS is the module format for NodeJS, and not suitable for the browser. Rollup only handles es modules by default, but sometimes it's necessary to be able to import a dependency if you want to use third party libraries in your web component. To do this, you can add [@rollup/plugin-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs):
 
 ```javascript
 import { createCompatibilityConfig } from '@open-wc/building-rollup';
-import commonjs from 'rollup-plugin-commonjs';
+import commonjs from '@rollup/plugin-commonjs';
+
 
 const configs = createCompatibilityConfig({ input: './index.html' });
 


### PR DESCRIPTION
* Updates URL for commonjs plugin. Link for the rollup plugin commonjs is outdated as recently it has been moved into scoped packages.
* Updates code example.
* Also adds additional information on why do we want to use commonjs module.