### PR TITLE
feat(create): copyTemplates resolves with the copied files

### DIFF
--- a/packages/create/src/core.js
+++ b/packages/create/src/core.js
@@ -1,13 +1,11 @@
 /* eslint-disable no-console, import/no-cycle */
 
-import fs from 'fs';
-import path from 'path';
 import { spawn } from 'child_process';
-
-import prompts from 'prompts';
-import glob from 'glob';
 import deepmerge from 'deepmerge';
-
+import fs from 'fs';
+import glob from 'glob';
+import path from 'path';
+import prompts from 'prompts';
 import Generator from './Generator.js';
 
 /**
@@ -320,6 +318,7 @@ export function copyTemplate(fromPath, toPath, data) {
 export function copyTemplates(fromGlob, toDir = process.cwd(), data = {}) {
   return new Promise(resolve => {
     glob(fromGlob, { dot: true }, (er, files) => {
+      const copiedFiles = [];
       files.forEach(filePath => {
         if (!fs.lstatSync(filePath).isDirectory()) {
           const fileContent = readFileFromPath(filePath);
@@ -330,11 +329,12 @@ export function copyTemplates(fromGlob, toDir = process.cwd(), data = {}) {
             const replace = path.join(fromGlob.replace(/\*/g, '')).replace(/\\(?! )/g, '/');
             const toPath = filePath.replace(replace, `${toDir}/`);
 
+            copiedFiles.push({ toPath, processed });
             writeFileToPath(toPath, processed);
           }
         }
       });
-      resolve();
+      resolve(copiedFiles);
     });
   });
 }

--- a/packages/create/test/core.test.js
+++ b/packages/create/test/core.test.js
@@ -3,18 +3,19 @@
 import chai from 'chai';
 import fs from 'fs';
 import {
-  processTemplate,
-  writeFileToPath,
-  virtualFiles,
-  resetVirtualFiles,
-  readFileFromPath,
   copyTemplateJsonInto,
+  copyTemplates,
   deleteVirtualFile,
   executeMixinGenerator,
   filesToTree,
   optionsToCommand,
-  writeFileToPathOnDisk,
+  processTemplate,
+  readFileFromPath,
+  resetVirtualFiles,
   setOverrideAllFiles,
+  virtualFiles,
+  writeFileToPath,
+  writeFileToPathOnDisk,
 } from '../src/core.js';
 
 const { expect } = chai;
@@ -128,6 +129,20 @@ describe('writeFileToPathOnDisk', () => {
     await writeFileToPathOnDisk(`./__tmpfoo.txt`, 'updatedfoofile', { ask: false });
     expect(fs.readFileSync(`./__tmpfoo.txt`, 'utf-8')).to.equal('updatedfoofile');
     setOverrideAllFiles(false);
+  });
+});
+
+describe('copyTemplates', () => {
+  it('returns a promise which resolves with the copied and processed files', async () => {
+    const copiedFiles = await copyTemplates(`./test/template/**/*`, `source`, {
+      name: 'hello-world',
+    });
+    expect(copiedFiles).to.deep.equal([
+      {
+        processed: "console.log('name: hello-world');\n",
+        toPath: './source/index.js',
+      },
+    ]);
   });
 });
 

--- a/packages/create/test/template/index.js
+++ b/packages/create/test/template/index.js
@@ -1,0 +1,1 @@
+console.log('name: <%= name %>');


### PR DESCRIPTION
This change allows me to do the following:

```js
participants.forEach(name => {
  copyTemplates(
    'templates/**/*',
    path.resolve(process.cwd(), `./participants/${name}`),
    { participantName: name },
  ).then(files => {
    files.forEach(file => {
      writeFileToPathOnDisk(file.toPath, file.processed, {
        override: opts.override, // option that gets passed from my middleware, sometimes I need to override, sometimes I don't :P
        ask: false,
      });
    });
  });
});
```

Which is super awesome for generic purposes where I don't need a cli or the other cool features that, I assume, made you guys opt for a `virtualFiles` array that keeps the state in between functions.

Let me know if the test makes sense.. I couldn't really figure out a way to test copyTemplates without creating an actual template for testing. But perhaps you guys have a helper for this kinda thing?

