### PR TITLE
fix(testing-helpers): constrain the type of defineCE

### DIFF
--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -11,12 +11,12 @@ let defineCECounter = 0;
  * const el = fixture(`<${tag}></${tag}>`);
  * // test el
  *
- * @param {typeof HTMLElement | function} klass Class which extends HTMLElement
+ * @template {HTMLElement} T
+ * @param {import("@open-wc/dedupe-mixin").Constructor<T>} klass Class which extends HTMLElement
  * @returns {string} Tag name of the registered element
  */
 export function defineCE(klass) {
   const tag = `test-${defineCECounter}`;
-  // @ts-ignore
   customElements.define(tag, klass);
   defineCECounter += 1;
   return tag;


### PR DESCRIPTION
it should take a subclass of HTMLElement