### PR TITLE
fix: support md images and line breaks in storybook

### DIFF
--- a/packages/demoing-storybook/demo/stories/docs-only.stories.md
+++ b/packages/demoing-storybook/demo/stories/docs-only.stories.md
@@ -5,3 +5,13 @@ export default { title: 'Docs only' };
 # Docs only
 
 This is a MD file with only docs
+
+## Using 2 spaces to create a line break
+
+x point 1  
+x point 2  
+x point 3
+
+## Including an image
+
+![mdjs logo](https://raw.githubusercontent.com/open-wc/open-wc/master/assets/images/logo.png)

--- a/packages/storybook-addon-markdown-docs/demo/stories/docs-only.stories.md
+++ b/packages/storybook-addon-markdown-docs/demo/stories/docs-only.stories.md
@@ -5,3 +5,13 @@ export default { title: 'Docs only' };
 # Docs only
 
 This is a MD file with only docs
+
+## Using 2 spaces to create a line break
+
+x point 1  
+x point 2  
+x point 3
+
+## Including an image
+
+![mdjs logo](https://raw.githubusercontent.com/open-wc/open-wc/master/assets/images/logo.png)

--- a/packages/storybook-addon-markdown-docs/package.json
+++ b/packages/storybook-addon-markdown-docs/package.json
@@ -37,6 +37,7 @@
     "@open-wc/demoing-storybook": "^1.15.0",
     "@storybook/addon-docs": "5.3.1",
     "detab": "^2.0.3",
+    "mdurl": "^1.0.1",
     "remark-html": "^10.0.0",
     "remark-parse": "^7.0.2",
     "remark-slug": "^5.1.2",
@@ -51,7 +52,6 @@
     "@types/mocha": "^5.0.0",
     "babel-loader": "^8.0.0",
     "chai": "^4.2.0",
-    "es-dev-server": "^1.46.0",
     "mocha": "^6.2.2",
     "mocha-chai-snapshot": "^1.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,7 +1151,7 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.8.3"
 
-"@babel/register@^7.0.0", "@babel/register@^7.8.3":
+"@babel/register@^7.0.0":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.8.6.tgz#a1066aa6168a73a70c35ef28cc5865ccc087ea69"
   integrity sha512-7IDO93fuRsbyml7bAafBQb3RcBGlCpU4hh5wADA2LJEEcYk92WkwFZ0pHyIi2fb5Auoz1714abETdZKCOxN0CQ==
@@ -2569,16 +2569,16 @@
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.52"
+  version "1.3.54"
   dependencies:
-    "@open-wc/testing-karma" "^3.3.8"
+    "@open-wc/testing-karma" "^3.3.10"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.3.8"
+  version "3.3.10"
   dependencies:
-    "@open-wc/karma-esm" "^2.13.19"
+    "@open-wc/karma-esm" "^2.13.21"
     axe-core "^3.3.1"
     karma "^4.1.0"
     karma-chrome-launcher "^3.1.0"


### PR DESCRIPTION
this now allows images and line breaks in storybook... as if they don't have a closing tag the jsx parser throws 😭