### PR TITLE
fix(create): set default value for variable

### DIFF
--- a/packages/create/src/generators/wc-lit-element/templates/_MyEl.js
+++ b/packages/create/src/generators/wc-lit-element/templates/_MyEl.js
@@ -4,11 +4,9 @@ export class <%= className %> extends LitElement {
   static get styles() {
     return css`
       :host {
-        --<%= tagName %>-text-color: #000;
-
         display: block;
         padding: 25px;
-        color: var(--<%= tagName %>-text-color);
+        color: var(--<%= tagName %>-text-color, #000);
       }
     `;
   }


### PR DESCRIPTION
Previous code set a specific variable value on `:host`, which does not make sense for variables since we probably want to allow overrides from ancestors.