### PR TITLE
fix: arrow function to function for legacy browser

### DIFF
--- a/packages/building-utils/index-html/create-index-html.js
+++ b/packages/building-utils/index-html/create-index-html.js
@@ -115,7 +115,7 @@ function createScripts(polyfillsConfig, polyfills, entries, needsLoader) {
     scripts.push(
       createScript(
         null,
-        "window.importShim = src => import(src.startsWith('.') ? new URL(src, document.baseURI) : src)",
+        "window.importShim = function(src) { return import(src.startsWith('.') ? new URL(src, document.baseURI) : src); }",
       ),
     );
   }


### PR DESCRIPTION
- avoid don't support arrow function syntax in legacy browser
