### PR TITLE
feat(building-rollup): runtime cache polyfills

### DIFF
--- a/packages/building-rollup/src/createSpaConfig.js
+++ b/packages/building-rollup/src/createSpaConfig.js
@@ -87,6 +87,12 @@ function createSpaConfig(options) {
             globPatterns: ['**/*.{html,js,css}'],
             skipWaiting: true,
             clientsClaim: true,
+            runtimeCaching: [
+              {
+                urlPattern: 'polyfills/*.js',
+                handler: 'CacheFirst',
+              },
+            ],
           },
           () => {},
         ),


### PR DESCRIPTION
closes https://github.com/open-wc/open-wc/issues/1371