### PR TITLE
REMOVE_fix(storybook-addon-markdown-docs): remove dependency

### DIFF
--- a/packages/storybook-addon-markdown-docs/package.json
+++ b/packages/storybook-addon-markdown-docs/package.json
@@ -34,7 +34,6 @@
     "@babel/plugin-syntax-import-meta": "^7.8.3",
     "@mdjs/core": "^0.1.8",
     "@mdx-js/mdx": "^1.5.1",
-    "@open-wc/demoing-storybook": "^1.15.2",
     "@storybook/addon-docs": "5.3.1",
     "detab": "^2.0.3",
     "mdurl": "^1.0.1",


### PR DESCRIPTION
- wrong dependency @open-wc/demoing-storybook

should fix https://github.com/open-wc/open-wc/issues/1507