### PR TITLE
fix(storybook-addon-markdown-docs): remove dep

### DIFF
--- a/packages/storybook-addon-markdown-docs/package.json
+++ b/packages/storybook-addon-markdown-docs/package.json
@@ -34,7 +34,6 @@
     "@babel/plugin-syntax-import-meta": "^7.8.3",
     "@mdjs/core": "^0.1.9",
     "@mdx-js/mdx": "^1.5.1",
-    "@open-wc/demoing-storybook": "^2.0.0",
     "@storybook/addon-docs": "5.3.1",
     "detab": "^2.0.3",
     "mdurl": "^1.0.1",


### PR DESCRIPTION
- wrong dependency @open-wc/demoing-storybook

should fix #1507