### PR TITLE
docs(rollup-plugin-html): fix syntax error in example

### DIFF
--- a/packages/rollup-plugin-html/README.md
+++ b/packages/rollup-plugin-html/README.md
@@ -102,7 +102,7 @@ export default {
   output: { dir: 'dist' },
   plugins: [
     html({
-      inputHtml: '<html><script type="module" src="./app.js></script></html>',
+      inputHtml: '<html><script type="module" src="./app.js"></script></html>',
     }),
   ],
 };


### PR DESCRIPTION
Adds missing quotes