### PR TITLE
Allow more files to use devDependencies

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -37,7 +37,7 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: ['**/test/**/*.js', '**/stories/**/*.js', '**/*.config.js'],
+        devDependencies: ['**/test/**/*.js', '**/stories/**/*.js', '**/*.config.js', '**/*.conf.js'],
       },
     ],
     'class-methods-use-this': [

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -37,7 +37,12 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: ['**/test/**/*.js', '**/stories/**/*.js', '**/*.config.js', '**/*.conf.js'],
+        devDependencies: [
+          '**/test/**/*.js',
+          '**/stories/**/*.js',
+          '**/*.config.js',
+          '**/*.conf.js',
+        ],
       },
     ],
     'class-methods-use-this': [


### PR DESCRIPTION
Karma uses `karma.conf.js` as the default configuration file name: http://karma-runner.github.io/4.0/config/configuration-file.html

This commit adds `'**/*.conf.js'` to the list of files that should accept dependencies as devDependencies, to support Karma config files.