### PR TITLE
fix(demoing-storybook): ensure regenerator runtime is always loaded

### DIFF
--- a/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
+++ b/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
@@ -96,7 +96,7 @@ function createRollupConfig({ outputDir, indexFilename, indexHTMLString }) {
           coreJs: true,
           fetch: true,
           abortController: true,
-          regeneratorRuntime: true,
+          regeneratorRuntime: 'always',
           webcomponents: true,
           intersectionObserver: true,
           resizeObserver: true,


### PR DESCRIPTION
since we always compile to es5 now when building storybook, the regenerator runtime should always be loaded