### PR TITLE
docs(es-dev-server): clarify async nature of startServer

### DIFF
--- a/packages/es-dev-server/README.md
+++ b/packages/es-dev-server/README.md
@@ -694,7 +694,7 @@ fileWatcher.close();
 
 ### startServer
 
-`startServer` creates and starts the server, listening on the configured port. It opens the browser if configured and logs a startup message.
+`startServer` asynchronously creates and starts the server, listening on the configured port. It opens the browser if configured and logs a startup message.
 
 Returns the koa app and a node http or http2 server.
 
@@ -702,8 +702,12 @@ Returns the koa app and a node http or http2 server.
 import Koa from 'koa';
 import { createConfig, startServer } from 'es-dev-server';
 
-const config = createConfig({ ... });
-const { app, server } = startServer(config, fileWatcher);
+async function main() {
+  const config = createConfig({ ... });
+  const { app, server } = await startServer(config, fileWatcher);
+}
+
+main();
 ```
 
 </details>


### PR DESCRIPTION
fixes #1519

This adds the `await startServer()` for clarity. To not further confuse (with the lack of top-level await) I wrapped the call in an async method. Let me know if you think of something that is more true to the functionality we're shipping here.