### PR TITLE
docs: add sidebar back to the deploying page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -139,7 +139,7 @@ module.exports = {
       '/testing/': sidebar,
       '/building/': sidebar,
       '/demoing/': sidebar,
-      '/publishing/': sidebar,
+      '/deploying/': sidebar,
       '/automating/': sidebar,
       '/scoped-elements/': sidebar,
       '/mdjs/': sidebar,


### PR DESCRIPTION
Missed some of the config settings in Vuepress for the updated "Deploying" page...  😥 

Adding back the sidebar.