### PR TITLE
chore: fix link for deploying in README

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -19,7 +19,7 @@ npm init @open-wc
 - [Testing](/testing/)
 - [Building](/building/)
 - [Demoing](/demoing/)
-- [Publishing](/publishing/)
+- [Deploying](/deploying/)
 - [Automating](/automating/)
 
 ## Our Philosophy


### PR DESCRIPTION
Looks like this is a leftover from #1539 