### PR TITLE
feat(building-rollup): use new preserveEntrySignatures option

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prettier-plugin-package": "^1.0.0",
     "puppeteer": "^2.1.1",
     "rimraf": "^3.0.2",
-    "rollup": "^2.0.0",
+    "rollup": "^2.7.2",
     "sinon": "^7.4.1",
     "typescript": "^3.7.3",
     "vuepress": "^1.3.0",

--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -45,6 +45,9 @@
     "modules",
     "rollup"
   ],
+  "peerDependencies": {
+    "rollup": "^2.7.2"
+  },
   "dependencies": {
     "@babel/core": "^7.9.0",
     "@babel/helpers": "^7.9.2",

--- a/packages/building-rollup/src/createBasicConfig.js
+++ b/packages/building-rollup/src/createBasicConfig.js
@@ -33,6 +33,7 @@ function createBasicConfig(userOptions = {}) {
   const assetName = `[${developmentMode ? 'name' : 'hash'}][extname]`;
 
   const config = {
+    preserveEntrySignatures: false,
     treeshake: !developmentMode,
 
     output: {

--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -64,7 +64,7 @@
     "glob": "^7.1.3",
     "lit-html": "^1.0.0",
     "magic-string": "^0.25.7",
-    "rollup": "^2.0.0",
+    "rollup": "^2.7.2",
     "rollup-plugin-babel": "^5.0.0-alpha.1",
     "rollup-plugin-terser": "^5.2.0",
     "storybook-addon-markdown-docs": "^0.2.7",

--- a/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
+++ b/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
@@ -24,6 +24,7 @@ function onwarn(warning, warn) {
  */
 function createRollupConfig({ outputDir, indexFilename, indexHTMLString }) {
   const config = {
+    preserveEntrySignatures: false,
     output: {
       entryFileNames: '[hash].js',
       chunkFileNames: '[hash].js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -15965,13 +15965,6 @@ rollup@^1.31.1:
     "@types/node" "*"
     acorn "^7.1.0"
 
-rollup@^2.0.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.3.3.tgz#5982df700d7aae8907075ba68122bb57d98e9cd0"
-  integrity sha512-uJ9VNWk80mb4wDCSfd1AyHoSc9TrWbkZtnO6wbsMTp9muSWkT26Dvc99MX1yGCOTvUN1Skw/KpFzKdUDuZKTXA==
-  optionalDependencies:
-    fsevents "~2.1.2"
-
 rollup@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.7.2.tgz#0f8ee6216d33e83c0750116312c2c92b94cc7f72"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,16 +2304,16 @@
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.56"
+  version "1.3.58"
   dependencies:
-    "@open-wc/testing-karma" "^3.3.12"
+    "@open-wc/testing-karma" "^3.3.15"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.3.12"
+  version "3.3.15"
   dependencies:
-    "@open-wc/karma-esm" "^2.13.23"
+    "@open-wc/karma-esm" "^2.13.26"
     axe-core "^3.3.1"
     karma "^4.1.0"
     karma-chrome-launcher "^3.1.0"
@@ -15969,6 +15969,13 @@ rollup@^2.0.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.3.3.tgz#5982df700d7aae8907075ba68122bb57d98e9cd0"
   integrity sha512-uJ9VNWk80mb4wDCSfd1AyHoSc9TrWbkZtnO6wbsMTp9muSWkT26Dvc99MX1yGCOTvUN1Skw/KpFzKdUDuZKTXA==
+  optionalDependencies:
+    fsevents "~2.1.2"
+
+rollup@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.7.2.tgz#0f8ee6216d33e83c0750116312c2c92b94cc7f72"
+  integrity sha512-SdtTZVMMVSPe7SNv4exUyPXARe5v/p3TeeG3LRA5WabLPJt4Usi3wVrvVlyAUTG40JJmqS6zbIHt2vWTss2prw==
   optionalDependencies:
     fsevents "~2.1.2"
 


### PR DESCRIPTION
For entrypoint modules rollup's default behavior is to preserve the original export signature.

One downside of this is that the exports add a (tiny) amount of unused code for web apps, since the entrypoint is never imported anywhere else. 

Another downside is that if the entrypoint bundle contains code used by other bundles, rollup needs to create an extra separate module which contains these exports. This is to not pollute the main entrypoint with exports it never included.

This behavior makes sense for libraries, but not for webapps. Rollup recently added a new option to configure this behavior. This PR adds this option by default to our configs.

This also adds a peerDependency to specify the version.