### PR TITLE
feat(scoped-elements): self-registering components compatibility

### DIFF
--- a/packages/scoped-elements/README.md
+++ b/packages/scoped-elements/README.md
@@ -50,6 +50,8 @@ npm i --save @open-wc/scoped-elements
    >    };
    >  }
    > ```
+   >
+   > If you try to register the same element globally AND locally with the exact same name AND class instance it will reuse the global tag name and NOT scope it.
 
 4. Use your components in your html.
 

--- a/packages/scoped-elements/test/ScopedElementsMixin.test.js
+++ b/packages/scoped-elements/test/ScopedElementsMixin.test.js
@@ -304,6 +304,37 @@ describe('ScopedElementsMixin', () => {
     await waitUntil(() => el.shadowRoot.children[1] instanceof LazyElement);
   });
 
+  it('should reuse the global tag if defined with the same name and class reference', async () => {
+    class ItemA extends LitElement {
+      render() {
+        return html` <div>Item A</div> `;
+      }
+    }
+
+    customElements.define('item-a', ItemA);
+
+    const tag = defineCE(
+      class ContainerElement extends ScopedElementsMixin(LitElement) {
+        static get scopedElements() {
+          return {
+            ...super.scopedElements,
+            'item-a': customElements.get('item-a'),
+          };
+        }
+
+        render() {
+          return html` <item-a></item-a> `;
+        }
+      },
+    );
+
+    const el = await fixture(`<${tag}></${tag}>`);
+    const firstElement = el.shadowRoot.children[0];
+
+    expect(firstElement.tagName.toLowerCase()).to.be.equal('item-a');
+    expect(firstElement).to.be.instanceof(ItemA);
+  });
+
   describe('getScopedTagName', () => {
     it('should return the scoped tag name for a registered element', async () => {
       const chars = `-|\\.|[0-9]|[a-z]`;


### PR DESCRIPTION
Reusing the global tag name can be useful in some situations in which not all component libraries are exporting the component classes or when components are looking in dom for specific tag names. In those cases, although this change doesn't remove the limitation of having just one version of those elements in our app, it makes them work properly inside our scoped elements as we are going to use the tag name they use in their definition.

E.g. If we want to migrate our app to scoped-elements but we are using `vaadin-grid` we are going to have problems because of vaadin components. We already have two options:

1- Ask or make a PR against vaadin components to change the way they interact with other components and making them "scoped friendly" (in the future, with scoped custom element registries users could use any tag name inside their components, so custom elements shouldn't impose a specific one).
2- Wrap the vaadin components into another unscoped component. This workaround, although it is feasible, sometimes could make our apps hard to migrate to scoped elements.

With this change, we could continue using those unscoped friendly libraries eventually while we search a feasible scoped friendly substitution for them or they release a new scoped friendly version.

### How to use it

```js
// file item-a.js
// unscoped friendly component
class ItemA extends LitElement {
   render() {
     return html` <div>Item A</div> `;
  }
}

customElements.define('item-a', ItemA);


// file ContainerElement.js
import './item-a.js'; // imports the unscoped friendly component

const ItemA = customElements.get('item-a');  // we must obtain the component class reference

export class ContainerElement extends ScopedElementsMixin(LitElement) {
  static get scopedElements() {
    return {
      ...super.scopedElements,
      'item-a': ItemA,  // <-- If element is not declared here the tag would be scoped as usual
    };
  }

  render() {
    return html` <item-a></item-a> `; // <-- the tag in DOM would be 'item-a'
  }
}
```

There is a limitation to this solution. **Self-defined components can't be lazily defined.**