### PR TITLE
feat(testing-helpers): add scoped-elements support

### DIFF
--- a/packages/scoped-elements/index.js
+++ b/packages/scoped-elements/index.js
@@ -1,1 +1,3 @@
+/** @typedef {import('./src/types').ScopedElementsMap} ScopedElementsMap */
+
 export { ScopedElementsMixin } from './src/ScopedElementsMixin.js';

--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -6,6 +6,7 @@ import { defineScopedElement, registerElement } from './registerElement.js';
 import { shadyTemplateFactory } from './shadyTemplateFactory.js';
 
 /**
+ * @typedef {import('./types').ScopedElementsMap} ScopedElementsMap
  * @typedef {import('lit-html/lib/shady-render').ShadyRenderOptions} ShadyRenderOptions
  * @typedef {function(TemplateResult, Element|DocumentFragment|ShadowRoot, ShadyRenderOptions): void} RenderFunction
  */
@@ -19,6 +20,7 @@ const templateCaches = new WeakMap();
 
 /**
  * Retrieves or creates a templateCache for a specific key
+ *
  * @param {Function} key
  * @returns {Map<TemplateStringsArray, TemplateStringsArray>}
  */
@@ -54,7 +56,7 @@ const getTagsCache = key => {
  * Transforms an array of TemplateResults or arrays into another one with resolved scoped elements
  *
  * @param {ReadonlyArray} items
- * @param {Object.<string, typeof HTMLElement>} scopedElements
+ * @param {ScopedElementsMap} scopedElements
  * @param {Map<TemplateStringsArray, TemplateStringsArray>} templateCache
  * @param {Map<string, string>} tagsCache
  * @returns {ReadonlyArray}
@@ -76,7 +78,7 @@ const transformArray = (items, scopedElements, templateCache, tagsCache) =>
  * Transforms a TemplateResult into another one with resolved scoped elements
  *
  * @param {TemplateResult} template
- * @param {Object.<string, typeof HTMLElement>} scopedElements
+ * @param {ScopedElementsMap} scopedElements
  * @param {Map<TemplateStringsArray, TemplateStringsArray>} templateCache
  * @param {Map<string, string>} tagsCache
  * @returns {TemplateResult}
@@ -89,6 +91,15 @@ const transformTemplate = (template, scopedElements, templateCache, tagsCache) =
     template.processor,
   );
 
+/**
+ * Gets an instance of the ScopedElementsTemplateFactory
+ *
+ * @param {string} scopeName
+ * @param {ScopedElementsMap} scopedElements
+ * @param {Map<TemplateStringsArray, TemplateStringsArray>} templateCache
+ * @param {Map<string, string>} tagsCache
+ * @returns {function(any): any}
+ */
 const scopedElementsTemplateFactory = (
   scopeName,
   scopedElements,
@@ -104,13 +115,16 @@ export const ScopedElementsMixin = dedupeMixin(
   superclass =>
     // eslint-disable-next-line no-shadow
     class ScopedElementsMixin extends superclass {
+      /**
+       * Obtains the scoped elements definitions map
+       *
+       * @returns {ScopedElementsMap}
+       */
       static get scopedElements() {
         return {};
       }
 
-      /**
-       * @override
-       */
+      /** @override */
       static render(template, container, options) {
         if (!options || typeof options !== 'object' || !options.scopeName) {
           throw new Error('The `scopeName` option is required.');

--- a/packages/scoped-elements/src/registerElement.js
+++ b/packages/scoped-elements/src/registerElement.js
@@ -17,8 +17,8 @@ const extendsHTMLElement = klass => Object.prototype.isPrototypeOf.call(HTMLElem
  * @param {CustomElementRegistry} registry
  */
 const defineElement = (tagName, klass, registry = customElements) => {
-  registry.define(tagName, class extends klass {});
   addToGlobalTagsCache(tagName, klass);
+  registry.define(tagName, class extends klass {});
 };
 
 /**
@@ -99,7 +99,9 @@ export function defineScopedElement(tagName, klass, tagsCache) {
   const tag = tagsCache.get(tagName);
 
   if (tag) {
-    defineElement(tag, klass, customElements);
+    if (customElements.get(tag) === undefined) {
+      defineElement(tag, klass, customElements);
+    }
   } else {
     tagsCache.set(tagName, registerElement(tagName, klass, tagsCache));
   }

--- a/packages/scoped-elements/src/transform.js
+++ b/packages/scoped-elements/src/transform.js
@@ -1,7 +1,11 @@
 import { registerElement } from './registerElement.js';
 
 /**
- * allowed tag name chars
+ * @typedef {import('./types').ScopedElementsMap} ScopedElementsMap
+ */
+
+/**
+ * Allowed tag name chars
  *
  * @type {string}
  */
@@ -42,19 +46,19 @@ const matchAll = str => {
  * Transforms a string array into another one with resolved scoped elements and caches it for future references
  *
  * @param {TemplateStringsArray} strings
- * @param {Object.<string, typeof HTMLElement>} tags
+ * @param {ScopedElementsMap} scopedElements
  * @param {Map<TemplateStringsArray, TemplateStringsArray>} templateCache
  * @param {Map<string, string>} tagsCache
  * @returns {TemplateStringsArray}
  */
-const transformTemplate = (strings, tags, templateCache, tagsCache) => {
+const transformTemplate = (strings, scopedElements, templateCache, tagsCache) => {
   const transformedStrings = strings.map(str => {
     let acc = str;
     const matches = matchAll(str);
 
     for (let i = matches.length - 1; i >= 0; i -= 1) {
       const item = matches[i];
-      const klass = tags[item[1]];
+      const klass = scopedElements[item[1]];
       const tag = registerElement(item[1], klass, tagsCache);
       const start = item.index + item[0].length - item[1].length;
       const end = start + item[1].length;
@@ -79,11 +83,14 @@ const transformTemplate = (strings, tags, templateCache, tagsCache) => {
  *
  * @exports
  * @param {TemplateStringsArray} strings
- * @param {Object.<string, typeof HTMLElement>} tags
+ * @param {ScopedElementsMap} scopedElements
  * @param {Map<TemplateStringsArray, TemplateStringsArray>} templateCache
  * @param {Map<string, string>} tagsCache
  * @returns {TemplateStringsArray}
  */
-export function transform(strings, tags, templateCache = globalCache, tagsCache) {
-  return templateCache.get(strings) || transformTemplate(strings, tags, templateCache, tagsCache);
+export function transform(strings, scopedElements, templateCache = globalCache, tagsCache) {
+  return (
+    templateCache.get(strings) ||
+    transformTemplate(strings, scopedElements, templateCache, tagsCache)
+  );
 }

--- a/packages/scoped-elements/src/types.d.ts
+++ b/packages/scoped-elements/src/types.d.ts
@@ -1,0 +1,3 @@
+export type ScopedElementsMap = {
+    [key: string]: typeof HTMLElement;
+}

--- a/packages/scoped-elements/src/types.d.ts
+++ b/packages/scoped-elements/src/types.d.ts
@@ -1,3 +1,27 @@
+import { Constructor } from "@open-wc/dedupe-mixin";
+import { LitElement } from "lit-element";
+
 export type ScopedElementsMap = {
     [key: string]: typeof HTMLElement;
 }
+
+export declare class ScopedElementsHost {
+  /**
+   * Obtains the scoped elements definitions map
+   */
+  static scopedElements: ScopedElementsMap;
+
+  /**
+   * Returns a scoped tag name
+   */
+  static getScopedTagName(tagName: string): string;
+
+  /**
+   * Defines a scoped element
+   */
+  defineScopedElement<T extends HTMLElement>(tagName: string, klass: Constructor<T>): void
+}
+
+declare function ScopedElementsMixinImplementation<T extends Constructor<LitElement>>(superclass: T): T & Constructor<ScopedElementsHost>
+
+export type ScopedElementsMixin = typeof ScopedElementsMixinImplementation;

--- a/packages/scoped-elements/test/ScopedElementsMixin.test.js
+++ b/packages/scoped-elements/test/ScopedElementsMixin.test.js
@@ -22,7 +22,6 @@ describe('ScopedElementsMixin', () => {
   it('has a default value for "static get scopedElements()" of {}', async () => {
     const tag = defineCE(class extends ScopedElementsMixin(LitElement) {});
     const el = await fixture(`<${tag}></${tag}>`);
-    // @ts-ignore
     expect(el.constructor.scopedElements).to.deep.equal({});
   });
 
@@ -257,7 +256,6 @@ describe('ScopedElementsMixin', () => {
     expect(el.shadowRoot.children[1]).to.not.be.an.instanceOf(FeatureB);
     expect(el.shadowRoot.children[2]).to.not.undefined;
 
-    // @ts-ignore
     el.defineScopedElement('feature-b', FeatureB);
 
     expect(el.shadowRoot.children[1]).to.be.an.instanceOf(FeatureB);
@@ -359,9 +357,7 @@ describe('ScopedElementsMixin', () => {
 
       const el = await fixture(`<${tag}></${tag}>`);
 
-      // @ts-ignore
       expect(el.constructor.getScopedTagName('feature-a')).to.match(tagRegExp);
-      // @ts-ignore
       expect(el.constructor.getScopedTagName('feature-b')).to.match(tagRegExp);
     });
 
@@ -387,7 +383,6 @@ describe('ScopedElementsMixin', () => {
 
       const el = await fixture(`<${tag}></${tag}>`);
 
-      // @ts-ignore
       expect(el.constructor.getScopedTagName('unregistered-feature')).to.match(tagRegExp);
     });
   });

--- a/packages/scoped-elements/test/ScopedElementsMixin.test.js
+++ b/packages/scoped-elements/test/ScopedElementsMixin.test.js
@@ -261,6 +261,26 @@ describe('ScopedElementsMixin', () => {
     expect(el.shadowRoot.children[1]).to.be.an.instanceOf(FeatureB);
   });
 
+  it('should avoid definition if lazy is already defined', async () => {
+    const tag = defineCE(
+      class extends ScopedElementsMixin(LitElement) {
+        render() {
+          return html` <feature-a></feature-a> `;
+        }
+      },
+    );
+
+    const el = await fixture(`<${tag}></${tag}>`);
+
+    expect(el.shadowRoot.children[0]).to.not.be.an.instanceOf(FeatureA);
+
+    el.defineScopedElement('feature-a', FeatureA);
+
+    expect(el.shadowRoot.children[0]).to.be.an.instanceOf(FeatureA);
+
+    el.defineScopedElement('feature-a', FeatureA);
+  });
+
   it("support define a lazy element even if it's not used in previous templates", async () => {
     class LazyElement extends LitElement {
       render() {

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -29,7 +29,11 @@
     "fixtures"
   ],
   "peerDependencies": {
+    "lit-element": "^2.2.1",
     "lit-html": "^1.0.0"
+  },
+  "dependencies": {
+    "@open-wc/scoped-elements": "^1.1.0"
   },
   "devDependencies": {
     "lit-html": "^1.0.0",

--- a/packages/testing-helpers/src/fixture-no-side-effect.js
+++ b/packages/testing-helpers/src/fixture-no-side-effect.js
@@ -5,6 +5,8 @@ import { isValidRenderArg } from './lib.js';
 /**
  * @typedef {object} FixtureOptions
  * @property {Element} [parentNode] optional parent node to render the fixture's template to
+ * @property {import('@open-wc/scoped-elements').ScopedElementsMap} [scopedElements] optional scoped-elements
+ * definition map
  */
 
 /**

--- a/packages/testing-helpers/src/litFixture.js
+++ b/packages/testing-helpers/src/litFixture.js
@@ -7,7 +7,8 @@ import { getScopedElementsTemplate } from './scopedElementsWrapper.js';
 
 /**
  * @typedef {
-     import('lit-html').TemplateResult | import('lit-html').TemplateResult[]
+     import('lit-html').TemplateResult
+   | import('lit-html').TemplateResult[]
    | Node | Node[]
    | string | string[]
    | number | number[]
@@ -59,16 +60,20 @@ export function litFixtureSync(template, options = {}) {
  * @returns {Promise<T>}
  */
 export async function litFixture(template, options = {}) {
+  /** @type {T} */
+  // NB: in the case of scopedElements, this is ScopedElementsTestWrapper, not T,
+  // but that's only a small lie
   const el = litFixtureSync(template, options);
   await elementUpdated(el);
 
   if (options.scopedElements) {
-    const [node] = Array.from(el.shadowRoot.childNodes).filter(isUsefulNode);
-    await elementUpdated(/** @type {T} */ (node));
+    const [node] =
+      /** @type {T[]} */
+      (Array.from(el.shadowRoot.childNodes).filter(isUsefulNode));
+    await elementUpdated(node.firstElementChild);
 
-    return /** @type {T} */ (node);
+    return node;
   }
 
-  // @ts-ignore
   return el;
 }

--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -1,6 +1,5 @@
 import { ScopedElementsMixin } from '@open-wc/scoped-elements';
 import { html, LitElement, TemplateResult } from 'lit-element';
-import { nothing } from 'lit-html';
 import { isIterable } from './lib.js';
 
 /** @typedef {import('@open-wc/scoped-elements').ScopedElementsMap} ScopedElementsMap */
@@ -31,13 +30,13 @@ class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
     /** @type {ScopedElementsMap} */
     this.scopedElements = {};
 
-    /** @type {TemplateResult|{}} */
-    this.template = nothing;
+    /** @type {import('./litFixture').LitHTMLRenderable} */
+    // eslint-disable-next-line babel/no-unused-expressions
+    this.template;
   }
 
-  async firstUpdated() {
-    // @ts-ignore
-    await super.firstUpdated();
+  firstUpdated(_changed) {
+    super.firstUpdated(_changed);
 
     Object.keys(this.scopedElements).forEach(key =>
       this.defineScopedElement(key, this.scopedElements[key]),
@@ -49,7 +48,6 @@ class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
   }
 }
 
-// @ts-ignore
 customElements.define('scoped-elements-test-wrapper', ScopedElementsTestWrapper);
 
 /**

--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -1,0 +1,69 @@
+import { ScopedElementsMixin } from '@open-wc/scoped-elements';
+import { html, LitElement, TemplateResult } from 'lit-element';
+import { nothing } from 'lit-html';
+import { isIterable } from './lib.js';
+
+/** @typedef {import('@open-wc/scoped-elements').ScopedElementsMap} ScopedElementsMap */
+
+const transform = template => {
+  if (isIterable(template)) {
+    return [...template].map(v => transform(v));
+  }
+
+  if (template instanceof TemplateResult) {
+    return html(template.strings, ...template.values);
+  }
+
+  return template;
+};
+
+class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
+  static get properties() {
+    return {
+      scopedElements: { type: Object },
+      template: { type: Object },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {ScopedElementsMap} */
+    this.scopedElements = {};
+
+    /** @type {TemplateResult|{}} */
+    this.template = nothing;
+  }
+
+  async firstUpdated() {
+    // @ts-ignore
+    await super.firstUpdated();
+
+    Object.keys(this.scopedElements).forEach(key =>
+      this.defineScopedElement(key, this.scopedElements[key]),
+    );
+  }
+
+  render() {
+    return transform(this.template);
+  }
+}
+
+// @ts-ignore
+customElements.define('scoped-elements-test-wrapper', ScopedElementsTestWrapper);
+
+/**
+ * Wraps the template inside a scopedElements component
+ *
+ * @param {import('./litFixture').LitHTMLRenderable} template
+ * @param {ScopedElementsMap} scopedElements
+ * @returns {TemplateResult}
+ */
+export function getScopedElementsTemplate(template, scopedElements) {
+  return html`
+    <scoped-elements-test-wrapper
+      .scopedElements="${scopedElements}"
+      .template="${template}"
+    ></scoped-elements-test-wrapper>
+  `;
+}

--- a/packages/testing-helpers/src/stringFixture.js
+++ b/packages/testing-helpers/src/stringFixture.js
@@ -1,5 +1,7 @@
+import { html } from 'lit-html';
 import { fixtureWrapper } from './fixtureWrapper.js';
 import { elementUpdated } from './elementUpdated.js';
+import { litFixture } from './litFixture.js';
 
 /**
  * Setups an element synchronously from the provided string template and puts it in the DOM.
@@ -25,7 +27,12 @@ export function stringFixtureSync(template, options = {}) {
  * @param {import('./fixture-no-side-effect.js').FixtureOptions} [options]
  * @returns {Promise<T>}
  */
-export async function stringFixture(template, options) {
+export async function stringFixture(template, options = {}) {
+  if (options.scopedElements) {
+    // @ts-ignore
+    return litFixture(html([template]), options);
+  }
+
   const el = stringFixtureSync(template, options);
   await elementUpdated(el);
   // @ts-ignore

--- a/packages/testing-helpers/test/fixture.test.js
+++ b/packages/testing-helpers/test/fixture.test.js
@@ -1,6 +1,7 @@
 // @ts-ignore
 import sinon from 'sinon';
 // @ts-ignore
+import { html as litHtml, LitElement } from 'lit-element';
 import { expect } from './setup.js';
 import { cachedWrappers } from '../src/fixtureWrapper.js';
 import { defineCE } from '../src/helpers.js';
@@ -360,5 +361,43 @@ describe('fixtureSync & fixture', () => {
     const litTag = unsafeStatic(tag);
     await fixture(html`<${litTag}></${litTag}>`);
     expect(counter).to.equal(2);
+  });
+
+  it('supports scoped-elements', async () => {
+    class TestClass extends LitElement {
+      static get properties() {
+        return {
+          foo: { type: String },
+        };
+      }
+
+      constructor() {
+        super();
+
+        this.foo = '';
+      }
+
+      render() {
+        return litHtml`
+          <div>${this.foo}</div>
+        `;
+      }
+    }
+
+    const elString = await fixture('<test-class foo="bar"></test-class>', {
+      scopedElements: {
+        'test-class': TestClass,
+      },
+    });
+
+    expect(elString).shadowDom.to.equal('<div>bar</div>');
+
+    const elLit = await fixture(html` <test-class foo="bar"></test-class> `, {
+      scopedElements: {
+        'test-class': TestClass,
+      },
+    });
+
+    expect(elLit).shadowDom.to.equal('<div>bar</div>');
   });
 });


### PR DESCRIPTION
This PR allows to use scopedElements in fixtures with the following syntax:

```js
await fixture('<test-class foo="bar"></test-class>', {
  scopedElements: {
    'test-class': TestClass,
  },
});
```

or

```js
await fixture(html`<test-class foo="bar"></test-class>`, {
  scopedElements: {
    'test-class': TestClass,
  },
});
```