### PR TITLE
feat(building-rollup): export appendScriptToBody function

### DIFF
--- a/packages/building-rollup/src/utils.js
+++ b/packages/building-rollup/src/utils.js
@@ -2,7 +2,6 @@ const merge = require('deepmerge');
 const { createScript } = require('@open-wc/building-utils');
 const { parse, serialize } = require('parse5');
 const { append, predicates, query } = require('@open-wc/building-utils/dom5-fork');
-const Terser = require('terser');
 
 const isFalsy = _ => !!_;
 
@@ -56,7 +55,7 @@ function appendScriptToBody(htmlString, code) {
  * @returns {string}
  */
 function applyServiceWorkerRegistration(htmlString) {
-  const { code } = Terser.minify(`
+  const code = `
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function() {
         navigator.serviceWorker
@@ -69,7 +68,7 @@ function applyServiceWorkerRegistration(htmlString) {
           });
       });
     }
-  `);
+  `;
 
   return appendScriptToBody(htmlString, code);
 }


### PR DESCRIPTION
I think this is useful when we want to use the `transform` option for the `html` feature.
For example to custom service worker inject:

```javascript
import { appendScriptToBody } from '@open-wc/building-rollup/src/utils';
// ...

const baseConfig = createSpaConfig({
  outputDir: DIST_PATH,
  legacyBuild: true,
  html: {
    transform: (html) => {
      const code = `
        if ('serviceWorker' in navigator) {
          window.addEventListener('load', function () {
            navigator.serviceWorker
              .register('./service-worker.js')
              .then(function () {
                console.log('Service Worker registered.');
              })
              .catch(function (err) {
                console.log('Service Worker registration failed: ', err);
              });
          });
        }
      `;
      return appendScriptToBody(html, code);
    }
  },
  workbox: workboxConfig
});
```

Also remove unneeded `Terser.minify`.