### PR TITLE
chore: ignore build types files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,34 @@ local.log
 
 ## generated codelabs
 docs/.vuepress/public/codelabs
+
+## typings - add manually written *.d.ts files here
+*.d.ts
+!packages/es-dev-server/src/middleware/polyfills-loader-types.d.ts
+!packages/es-dev-server/src/middleware/compatibility-transform-types.d.ts
+!packages/es-dev-server/src/utils/inject-polyfills-loader-types.d.ts
+!packages/mdjs/types/global.d.ts
+!packages/mdjs/index.d.ts
+!packages/mdjs/src/types.d.ts
+!packages/polyfills-loader/src/types.d.ts
+!packages/rollup-plugin-html/src/types.d.ts
+!packages/lit-helpers/src/read-only-properties-mixin.d.ts
+!packages/building-rollup/src/types.d.ts
+!packages/testing-helpers/test/setup.d.ts
+!packages/dedupe-mixin/index.d.ts
+!packages/chai-a11y-axe/chai-a11y-axe-plugin.d.ts
+!packages/chai-a11y-axe/index.d.ts
+!packages/chai-a11y-axe/src/accessible.d.ts
+!packages/storybook-addon-markdown-docs/types/global.d.ts
+!packages/testing/index-no-side-effects.d.ts
+!packages/testing/index.d.ts
+!packages/testing/import-wrappers/chai.d.ts
+!packages/testing/register-chai-plugins.d.ts
+!packages/testing-karma/testing-karma.d.ts
+!packages/rollup-plugin-polyfills-loader/src/types.d.ts
+!packages/scoped-elements/src/types.d.ts
+!packages/semantic-dom-diff/chai-dom-diff.d.ts
+!packages/semantic-dom-diff/test/bdd-setup.d.ts
+!packages/semantic-dom-diff/index.d.ts
+!packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
+!packages/semantic-dom-diff/src/utils.d.ts

--- a/packages/lit-helpers/index.d.ts
+++ b/packages/lit-helpers/index.d.ts
@@ -1,4 +1,0 @@
-export { live } from './src/live';
-export { spread } from './src/spread';
-export { spreadProps } from './src/spreadProps';
-export { ReadOnlyPropertiesMixin } from './src/read-only-properties-mixin';

--- a/packages/lit-helpers/src/spread.d.ts
+++ b/packages/lit-helpers/src/spread.d.ts
@@ -1,3 +1,0 @@
-import { AttributePart } from 'lit-html';
-
-export declare const spread: (spreadData: { [key: string]: unknown }) => (part: AttributePart) => void;

--- a/packages/lit-helpers/src/spreadProps.d.ts
+++ b/packages/lit-helpers/src/spreadProps.d.ts
@@ -1,3 +1,0 @@
-import { PropertyPart } from 'lit-html';
-
-export declare const spreadProps: (props: { [key: string]: unknown }) => (part: PropertyPart) => void;

--- a/tsconfig.build.types.json
+++ b/tsconfig.build.types.json
@@ -17,6 +17,7 @@
   "files": ["browser.d.ts"],
   "include": [
     "packages/testing-helpers/*.js",
+    "packages/lit-helpers/*.js",
     "packages/semantic-dom-diff/get-diffable-html.js",
     "packages/semantic-dom-diff/src/utils.js",
     "packages/polyfills-loader/*.js",


### PR DESCRIPTION
What I did:

- generally, ignore `*.d.ts` files (as they get auto generated)
- keep handwritten `*.d.ts` files by adding them to the gitignore ignore 😅
- auto-generate types for lit-helpers