### PR TITLE
Run worbox only on the last output build

### DIFF
--- a/packages/building-rollup/src/createSpaConfig.js
+++ b/packages/building-rollup/src/createSpaConfig.js
@@ -38,6 +38,30 @@ function createSpaConfig(options) {
     minify: !userOptions.developmentMode,
   };
 
+  const workboxPlugin = pluginWithOptions(
+    generateSW,
+    userOptions.workbox,
+    {
+      globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
+      navigateFallback: '/index.html',
+      // where to output the generated sw
+      swDest: path.join(process.cwd(), outputDir, 'sw.js'),
+      // directory to match patterns against to be precached
+      globDirectory: path.join(process.cwd(), outputDir),
+      // cache any html js and css by default
+      globPatterns: ['**/*.{html,js,css,webmanifest}'],
+      skipWaiting: true,
+      clientsClaim: true,
+      runtimeCaching: [
+        {
+          urlPattern: 'polyfills/*.js',
+          handler: 'CacheFirst',
+        },
+      ],
+    },
+    () => {},
+  );
+
   if (userOptions.legacyBuild) {
     if (!htmlPlugin) {
       throw new Error('Cannot generate multi build outputs when html plugin is disabled');
@@ -72,30 +96,7 @@ function createSpaConfig(options) {
       pluginWithOptions(polyfillsLoader, userOptions.polyfillsLoader, polyfillsLoaderConfig),
 
       // generate service worker
-      userOptions.workbox &&
-        pluginWithOptions(
-          generateSW,
-          userOptions.workbox,
-          {
-            globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
-            navigateFallback: '/index.html',
-            // where to output the generated sw
-            swDest: path.join(process.cwd(), outputDir, 'sw.js'),
-            // directory to match patterns against to be precached
-            globDirectory: path.join(process.cwd(), outputDir),
-            // cache any html js and css by default
-            globPatterns: ['**/*.{html,js,css,webmanifest}'],
-            skipWaiting: true,
-            clientsClaim: true,
-            runtimeCaching: [
-              {
-                urlPattern: 'polyfills/*.js',
-                handler: 'CacheFirst',
-              },
-            ],
-          },
-          () => {},
-        ),
+      userOptions.workbox && workboxPlugin,
     ],
   });
 }

--- a/packages/building-rollup/src/createSpaConfig.js
+++ b/packages/building-rollup/src/createSpaConfig.js
@@ -42,6 +42,7 @@ function createSpaConfig(options) {
     generateSW,
     userOptions.workbox,
     {
+      // Keep 'legacy-*.js' and 'nomodule-*.js' just for retro compatibility
       globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
       navigateFallback: '/index.html',
       // where to output the generated sw
@@ -85,6 +86,14 @@ function createSpaConfig(options) {
       minify: !userOptions.developmentMode,
       polyfills: defaultPolyfills,
     };
+  }
+
+  if (userOptions.workbox) {
+    if (userOptions.legacyBuild) {
+      basicConfig.output[0].plugins.push(workboxPlugin);
+    } else {
+      basicConfig.output.plugins.push(workboxPlugin);
+    }
   }
 
   return merge(basicConfig, {

--- a/packages/building-rollup/src/createSpaConfig.js
+++ b/packages/building-rollup/src/createSpaConfig.js
@@ -103,9 +103,6 @@ function createSpaConfig(options) {
 
       // inject polyfills loader into HTML
       pluginWithOptions(polyfillsLoader, userOptions.polyfillsLoader, polyfillsLoaderConfig),
-
-      // generate service worker
-      userOptions.workbox && workboxPlugin,
     ],
   });
 }

--- a/packages/building-rollup/src/createSpaConfig.js
+++ b/packages/building-rollup/src/createSpaConfig.js
@@ -67,7 +67,7 @@ function createSpaConfig(options) {
     generateSW,
     userOptions.workbox,
     {
-      // Keep 'legacy-*.js' and 'nomodule-*.js' just for retro compatibility
+      // Keep 'legacy-*.js' just for retro compatibility
       globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
       navigateFallback: '/index.html',
       // where to output the generated sw
@@ -89,8 +89,9 @@ function createSpaConfig(options) {
   );
 
   if (userOptions.workbox) {
-    if (userOptions.legacyBuild) {
-      basicConfig.output[0].plugins.push(workboxPlugin);
+    if (basicConfig.output.length > 1) {
+      const lastOutput = basicConfig.output.length - 1;
+      basicConfig.output[lastOutput].plugins.push(workboxPlugin);
     } else {
       basicConfig.output.plugins.push(workboxPlugin);
     }

--- a/packages/building-rollup/src/createSpaConfig.js
+++ b/packages/building-rollup/src/createSpaConfig.js
@@ -38,31 +38,6 @@ function createSpaConfig(options) {
     minify: !userOptions.developmentMode,
   };
 
-  const workboxPlugin = pluginWithOptions(
-    generateSW,
-    userOptions.workbox,
-    {
-      // Keep 'legacy-*.js' and 'nomodule-*.js' just for retro compatibility
-      globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
-      navigateFallback: '/index.html',
-      // where to output the generated sw
-      swDest: path.join(process.cwd(), outputDir, 'sw.js'),
-      // directory to match patterns against to be precached
-      globDirectory: path.join(process.cwd(), outputDir),
-      // cache any html js and css by default
-      globPatterns: ['**/*.{html,js,css,webmanifest}'],
-      skipWaiting: true,
-      clientsClaim: true,
-      runtimeCaching: [
-        {
-          urlPattern: 'polyfills/*.js',
-          handler: 'CacheFirst',
-        },
-      ],
-    },
-    () => {},
-  );
-
   if (userOptions.legacyBuild) {
     if (!htmlPlugin) {
       throw new Error('Cannot generate multi build outputs when html plugin is disabled');
@@ -87,6 +62,31 @@ function createSpaConfig(options) {
       polyfills: defaultPolyfills,
     };
   }
+
+  const workboxPlugin = pluginWithOptions(
+    generateSW,
+    userOptions.workbox,
+    {
+      // Keep 'legacy-*.js' and 'nomodule-*.js' just for retro compatibility
+      globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
+      navigateFallback: '/index.html',
+      // where to output the generated sw
+      swDest: path.join(process.cwd(), outputDir, 'sw.js'),
+      // directory to match patterns against to be precached
+      globDirectory: path.join(process.cwd(), outputDir),
+      // cache any html js and css by default
+      globPatterns: ['**/*.{html,js,css,webmanifest}'],
+      skipWaiting: true,
+      clientsClaim: true,
+      runtimeCaching: [
+        {
+          urlPattern: 'polyfills/*.js',
+          handler: 'CacheFirst',
+        },
+      ],
+    },
+    () => {},
+  );
 
   if (userOptions.workbox) {
     if (userOptions.legacyBuild) {


### PR DESCRIPTION
After all, the legacy build browsers doesn’t support SWs.