### PR TITLE
fix(testing-helpers): dependencies & await to the wrong element update

### DIFF
--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -28,15 +28,12 @@
     "browser-testing",
     "fixtures"
   ],
-  "peerDependencies": {
+  "dependencies": {
+    "@open-wc/scoped-elements": "^1.1.1",
     "lit-element": "^2.2.1",
     "lit-html": "^1.0.0"
   },
-  "dependencies": {
-    "@open-wc/scoped-elements": "^1.1.1"
-  },
   "devDependencies": {
-    "lit-html": "^1.0.0",
     "webpack-merge": "^4.1.5"
   }
 }

--- a/packages/testing-helpers/src/litFixture.js
+++ b/packages/testing-helpers/src/litFixture.js
@@ -70,7 +70,7 @@ export async function litFixture(template, options = {}) {
     const [node] =
       /** @type {T[]} */
       (Array.from(el.shadowRoot.childNodes).filter(isUsefulNode));
-    await elementUpdated(node.firstElementChild);
+    await elementUpdated(node);
 
     return node;
   }


### PR DESCRIPTION
In case scopedElements litFixture was awaiting element update of `node.firstElementChild`, which was `null`, instead of `node`.