### PR TITLE
chore: require node v10 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@open-wc/root",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "lerna run build",
     "build:types": "tsc -p tsconfig.build.types.json",

--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/building-rollup",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build:babelrc": "rimraf dist && rollup -c demo/babelrc/rollup.config.js",
     "build:basic": "rimraf dist && rollup -c demo/js/rollup.basic.config.js",

--- a/packages/building-utils/package.json
+++ b/packages/building-utils/package.json
@@ -13,6 +13,9 @@
   },
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/building-utils",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "test": "npm run test:node",
     "test:node": "mocha test/**/*.test.js test/*.test.js",

--- a/packages/building-webpack/package.json
+++ b/packages/building-webpack/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/building-webpack",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "demo:build": "webpack --mode production --config demo/js/webpack.config.js",
     "demo:build:dev": "webpack --mode development --config demo/js/webpack.config.js",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -16,6 +16,9 @@
   "bin": {
     "create-open-wc": "./dist/create.js"
   },
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "rm -rf dist && babel src --out-dir dist --copy-files --include-dotfiles",
     "prepublishOnly": "npm run build && ../../scripts/insert-header.js",

--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -18,6 +18,9 @@
     "start-storybook": "src/start/cli.js",
     "build-storybook": "src/build/cli.js"
   },
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build:start": "es-dev-server --root-dir storybook-static --app-index index.html --open",
     "prepublishOnly": "../../scripts/insert-header.js",

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -18,7 +18,7 @@
     "es-dev-server": "./dist/cli.js"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=10.13.0"
   },
   "scripts": {
     "build": "babel src --out-dir dist --copy-files --include-dotfiles",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/eslint-config",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/import-maps-generate/package.json
+++ b/packages/import-maps-generate/package.json
@@ -18,6 +18,9 @@
     "generate": "./dist/generate.js",
     "generate-import-map": "./dist/generate.js"
   },
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "babel src --out-dir dist --copy-files --include-dotfiles",
     "prepublishOnly": "npm run build && ../../scripts/insert-header.js",

--- a/packages/import-maps-resolve/package.json
+++ b/packages/import-maps-resolve/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/import-maps-resolve",
   "main": "./index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "npm run build && ../../scripts/insert-header.js",
     "test": "npm run test:node",

--- a/packages/karma-esm/package.json
+++ b/packages/karma-esm/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/karma-esm",
   "main": "./karma-esm.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",
     "test": "karma start demo/basic/karma.config.js --coverage",

--- a/packages/mdjs/package.json
+++ b/packages/mdjs/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/mdjs",
   "main": "./index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",
     "start": "npm run start:stories",

--- a/packages/polyfills-loader/package.json
+++ b/packages/polyfills-loader/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/polyfills-loader",
   "main": "index.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=10.13.0"
   },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/prettier-config",
   "main": "prettier.config.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/rollup-plugin-html/package.json
+++ b/packages/rollup-plugin-html/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/packages/rollup-plugin-html",
   "main": "rollup-plugin-html.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "demo:mpa": "rm -rf demo/dist && rollup -c demo/mpa/rollup.config.js --watch & yarn serve-demo",
     "demo:spa": "yarn demo:spa:defaults",

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/rollup-plugin-index-html",
   "main": "rollup-plugin-index-html.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/rollup-plugin-polyfills-loader/package.json
+++ b/packages/rollup-plugin-polyfills-loader/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/packages/rollup-plugin-polyfills-loader",
   "main": "rollup-plugin-polyfills-loader.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "demo:multi-build": "rm -rf demo/dist && rollup -c demo/multi-build/rollup.config.js --watch & yarn serve-demo",
     "demo:multi-page": "rm -rf demo/dist && rollup -c demo/multi-page/rollup.config.js --watch & yarn serve-demo",

--- a/packages/storybook-addon-markdown-docs/package.json
+++ b/packages/storybook-addon-markdown-docs/package.json
@@ -11,6 +11,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/storybook-addon-markdown-docs",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build:styles": "node styles/create-global-styles.js",
     "start": "npm run storybook",

--- a/packages/storybook-addon-web-components-knobs/package.json
+++ b/packages/storybook-addon-web-components-knobs/package.json
@@ -11,6 +11,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/storybook-addon-web-components-knobs",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",
     "storybook": "start-storybook -p 9001 -c demo/.storybook",

--- a/packages/testing-karma-bs/package.json
+++ b/packages/testing-karma-bs/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing-karma-bs",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",
     "test": "karma start demo/karma.conf.js --coverage",

--- a/packages/testing-karma/package.json
+++ b/packages/testing-karma/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing-karma",
   "main": "testing-karma.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/testing-wallaby/package.json
+++ b/packages/testing-wallaby/package.json
@@ -13,6 +13,9 @@
   },
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing-wallaby",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js"
   },

--- a/packages/webpack-import-meta-loader/package.json
+++ b/packages/webpack-import-meta-loader/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/webpack-import-meta-loader",
   "main": "webpack-import-meta-loader.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "prepublishOnly": "../../scripts/insert-header.js",
     "test": "npm run test:node",

--- a/packages/webpack-index-html-plugin/package.json
+++ b/packages/webpack-index-html-plugin/package.json
@@ -14,6 +14,9 @@
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/webpack-index-html-plugin",
   "main": "webpack-index-html-plugin.js",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {},
   "files": [
     "*.js",


### PR DESCRIPTION
We implicitly already require node v10 for a lot of packages, this makes that dependency explicit.

Node v8 is no longer supported by node itself, so I think this should not be a breaking change.

What do you guys think?

Fixes https://github.com/open-wc/open-wc/issues/1213