### PR TITLE
fix(eslint-config): fixes open-wc/open-wc#1602

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -40,6 +40,7 @@ module.exports = {
         devDependencies: [
           '**/test/**/*.js',
           '**/stories/**/*.js',
+          '**/demo/**/*.js',
           '**/*.config.js',
           '**/*.conf.js',
         ],


### PR DESCRIPTION
Adds `**/demo/**/*.js` to `devDependencies` of the `import/no-extraneous-dependencies` linting rule.