### PR TITLE
WIP: docs: pwa-ify and update on reload

### DIFF
--- a/docs/_includes/home.njk
+++ b/docs/_includes/home.njk
@@ -81,6 +81,7 @@
         </div>
         <div class="global-ui"></div>
       </div>
+      {% include 'partials/service-worker.njk' %}
     </body>
 
   </html>

--- a/docs/_includes/layout.njk
+++ b/docs/_includes/layout.njk
@@ -44,6 +44,7 @@
         {{ content.jsCode | safe }}
       </script>
     {% endif %}
+    {% include 'partials/service-worker.njk' %}
   </body>
 
 </html>

--- a/docs/_includes/partials/service-worker.njk
+++ b/docs/_includes/partials/service-worker.njk
@@ -1,0 +1,23 @@
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function() {
+      navigator.serviceWorker
+        .register(`${window.location.pathname.split('/').length - 1 > 1 ? '../service-worker.js' : './service-worker.js' }`)
+        .then(function() {
+          console.log('ServiceWorker registered.');
+        })
+        .catch(function(err) {
+          console.log('ServiceWorker registration failed: ', err);
+        });
+    });
+  }
+
+  let refreshing;
+  navigator.serviceWorker.addEventListener('controllerchange',
+    function() {
+      if (refreshing) return;
+      refreshing = true;
+      window.location.reload();
+    }
+  );
+</script>

--- a/docs/rollup.config.js
+++ b/docs/rollup.config.js
@@ -12,9 +12,21 @@ module.exports = async () => {
     // development mode creates a non-minified build for debugging or development
     developmentMode: false, // process.env.ROLLUP_WATCH === 'true',
 
-    // set to true to inject the service worker registration into your index.html
     injectServiceWorker: false,
-    workbox: false,
+    workbox: {
+      globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
+      swDest: path.join(process.cwd(), '_site', 'service-worker.js'),
+      globDirectory: path.join(process.cwd(), '_site'),
+      globPatterns: ['**/*.{html,js,json,css,webmanifest,png,gif}'],
+      skipWaiting: true,
+      clientsClaim: true,
+      runtimeCaching: [
+        {
+          urlPattern: 'polyfills/*.js',
+          handler: 'CacheFirst',
+        },
+      ],
+    },
   });
 
   const dest = '_site/';

--- a/docs/rollup.config.js
+++ b/docs/rollup.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const copy = require('rollup-plugin-copy');
+const { generateSW } = require('rollup-plugin-workbox');
 const { createMpaConfig } = require('./_building-rollup/createMpaConfig.js');
 
 module.exports = async () => {
@@ -13,7 +14,12 @@ module.exports = async () => {
     developmentMode: false, // process.env.ROLLUP_WATCH === 'true',
 
     injectServiceWorker: false,
-    workbox: {
+    workbox: false,
+  });
+
+  const dest = '_site/';
+  mpaConfig.plugins.push(
+    generateSW({
       globIgnores: ['polyfills/*.js', 'legacy-*.js', 'nomodule-*.js'],
       swDest: path.join(process.cwd(), '_site', 'service-worker.js'),
       globDirectory: path.join(process.cwd(), '_site'),
@@ -26,10 +32,9 @@ module.exports = async () => {
           handler: 'CacheFirst',
         },
       ],
-    },
-  });
+    }),
+  );
 
-  const dest = '_site/';
   mpaConfig.plugins.push(
     copy({
       targets: [


### PR DESCRIPTION
We need to have a new service worker in the same location and with the same name as our previous service worker for this to take effect, which is why I overrided the default workbox config.

What happens now is that every page will try to register a service worker. If there is a new service worker available, it'll skip waiting, and on controllerchange reload the page.

Would like someone else to confirm to make sure:

Steps:
- Run a build: `yarn docs:build`
- `cd _site && http-server -o` (dont use the Eds configuration for this, because it configures a base path)
- Go the page, confirm service worker is installed (devtools -> application -> Service Workers “#0 activated and is running”)
- Close the tab.
- Make some changes in a readme or anything in the docs
- Run another build: `cd .. && yarn docs:build`
- `cd _site && http-server -o`
- Go to the page, confirm the change is there
- Confirm there is a new service worker is installed (devtools -> application -> Service Workers “#1 activated and is running”)
