### PR TITLE
fix(rollup-plugin-html): set a valid entrypoint name

### DIFF
--- a/packages/rollup-plugin-html/src/utils.js
+++ b/packages/rollup-plugin-html/src/utils.js
@@ -50,7 +50,7 @@ function addRollupInput(inputOptions, inputModuleIds) {
       ...inputOptions,
       input: {
         ...inputOptions.input,
-        ...fromEntries(inputModuleIds.map(i => [i, i])),
+        ...fromEntries(inputModuleIds.map(i => [i.split('/').slice(-1)[0].split('.')[0], i])),
       },
     };
   }


### PR DESCRIPTION
When the rollup entrypoint is an object, we should set a valid entrypoint instead of the full file path.