### PR TITLE
docs: apply specific type of URL by deploy type

### DIFF
--- a/docs/_data/site.js
+++ b/docs/_data/site.js
@@ -1,6 +1,22 @@
+let url = '/';
+
+switch (process.env.CONTEXT) {
+  case 'production':
+    url = process.env.URL;
+    break;
+  case 'deploy-preview':
+    url = process.env.DEPLOY_URL;
+    break;
+  case 'branch-deploy':
+    url = process.env.DEPLOY_PRIME_URL;
+    break;
+  default:
+    break;
+}
+
 module.exports = {
   name: 'Open Web Components',
   shortDesc:
     'Open Web Components provides a set of defaults, recommendations and tools to help facilitate your web component project. Our recommendations include: developing, linting, testing, building, tooling, demoing, publishing and automating.',
-  url: process.env.DEPLOY_URL ? process.env.DEPLOY_URL : '/',
+  url,
 };


### PR DESCRIPTION
Updates the URL of the build based on this documentation: https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata Please give another eye to it in case you think I've misread.