### PR TITLE
fix(create): generate sourcemap for ts files

### DIFF
--- a/packages/create/src/generators/app-lit-element-ts/templates/_tsconfig.json
+++ b/packages/create/src/generators/app-lit-element-ts/templates/_tsconfig.json
@@ -10,7 +10,9 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "outDir": "out-tsc"
+    "outDir": "out-tsc",
+    "sourceMap": true,
+    "inlineSources": true
   },
   "include": ["**/*.ts"]
 }

--- a/packages/create/src/generators/wc-lit-element-ts/templates/_tsconfig.json
+++ b/packages/create/src/generators/wc-lit-element-ts/templates/_tsconfig.json
@@ -10,7 +10,9 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "sourceMap": true,
+    "inlineSources": true
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
Generates a separate .js.map file in out-tsc/ that has the original TS source inlined in it.

This should let us see the original TS source while debugging.

Browser is able to load the sourcemap when used in development mode with es-dev-server.
Currently not being processed by rollup in production mode and the behavior is same as earlier.