### PR TITLE
fix(testing-helpers): auto-generate scoped elements test wrapper name

### DIFF
--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -48,7 +48,24 @@ class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
   }
 }
 
-customElements.define('scoped-elements-test-wrapper', ScopedElementsTestWrapper);
+/**
+ * Obtains a unique tag name for the test wrapper
+ * @param {number} [counter=0]
+ * @returns {string}
+ */
+const getWrapperUniqueName = (counter = 0) => {
+  const tag = `scoped-elements-test-wrapper-${counter}`;
+
+  if (customElements.get(tag) !== undefined) {
+    return getWrapperUniqueName(counter + 1);
+  }
+
+  return tag;
+};
+
+const wrapperTagName = getWrapperUniqueName();
+
+customElements.define(wrapperTagName, ScopedElementsTestWrapper);
 
 /**
  * Wraps the template inside a scopedElements component
@@ -58,10 +75,12 @@ customElements.define('scoped-elements-test-wrapper', ScopedElementsTestWrapper)
  * @returns {TemplateResult}
  */
 export function getScopedElementsTemplate(template, scopedElements) {
-  return html`
-    <scoped-elements-test-wrapper
-      .scopedElements="${scopedElements}"
-      .template="${template}"
-    ></scoped-elements-test-wrapper>
-  `;
+  const strings = [
+    `<${wrapperTagName} .scopedElements="`,
+    '" .template="',
+    `"></${wrapperTagName}>`,
+  ];
+
+  // @ts-ignore
+  return html(strings, scopedElements, template);
 }


### PR DESCRIPTION
Loading multiple instances of the testing package could cause a naming collision in the ScopedElementsTestWrapper definition. Auto-generating the tag name and checking that it is not used in the global registry before definition solves the problem.

Fix: #1637