### PR TITLE
fix(create): support number for optionsToCommand

### DIFF
--- a/packages/create/src/core.js
+++ b/packages/create/src/core.js
@@ -284,7 +284,7 @@ export function optionsToCommand(options, generatorName = '@open-wc') {
   let command = `npm init ${generatorName} `;
   Object.keys(options).forEach(key => {
     const value = options[key];
-    if (typeof value === 'string') {
+    if (typeof value === 'string' || typeof value === 'number') {
       command += `--${key} ${value} `;
     } else if (typeof value === 'boolean' && value === true) {
       command += `--${key} `;

--- a/packages/create/test/core.test.js
+++ b/packages/create/test/core.test.js
@@ -255,6 +255,13 @@ describe('optionsToCommand', () => {
     expect(optionsToCommand(options)).to.equal('npm init @open-wc --type scaffold ');
   });
 
+  it('supports numbers', async () => {
+    const options = {
+      version: 2,
+    };
+    expect(optionsToCommand(options)).to.equal('npm init @open-wc --version 2 ');
+  });
+
   it('supports boolean', async () => {
     const options = {
       writeToDisk: true,


### PR DESCRIPTION
In our extension of the open-wc scaffolder we allow an option which has type = number, because we allow our users to pick which version of our design system they want to scaffold files for.

With this change, the scaffolder will tell the user they can mimic their interaction in the scaffold menu by running it imperatively with the flag `--designSystemVersion 2`, but because currently type 'number' is not supported here, it will skip it. 