### PR TITLE
fix(@open-wc/webpack-import-meta-loader): fix a bug in the publicPath…

### DIFF
--- a/packages/webpack-import-meta-loader/webpack-import-meta-loader.js
+++ b/packages/webpack-import-meta-loader/webpack-import-meta-loader.js
@@ -45,7 +45,7 @@ module.exports = function (source) {
         if (publicPath) {
           url += publicPath;
         } else {
-          url += '//';
+          url += '/';
         }
 
         return url + relativeUrl;


### PR DESCRIPTION
```js
// Currently
console.log(import.meta.url); // -> http://localhost:8080//_dist_/index.js

// Expected
console.log(import.meta.url); // -> http://localhost:8080/_dist_/index.js
```

I had thought that this might be a bug in my usage but based on the logic I'm not sure this ever worked without __webpack_public_path__ being set.

I'd love to use this as a part of Snowpack's Webpack bundler plugin if we can fix.