### PR TITLE
feat(chai-a11y-axe): lazy load axe when needed

### DIFF
--- a/packages/building-rollup/test/integration.test.js
+++ b/packages/building-rollup/test/integration.test.js
@@ -37,7 +37,7 @@ describe('integration tests', () => {
 
   ['js/rollup.spa.config.js', 'js/rollup.spa-nomodule.config.js'].forEach(testCase => {
     describe(`testcase ${testCase}`, function describe() {
-      this.timeout(10000);
+      this.timeout(40000);
       let page;
 
       before(async () => {

--- a/packages/chai-a11y-axe/package.json
+++ b/packages/chai-a11y-axe/package.json
@@ -28,6 +28,9 @@
     "A11Y",
     "testing"
   ],
+  "dependencies": {
+    "axe-core": "^3.5.3"
+  },
   "contributors": [
     "Pawel Psztyc"
   ]

--- a/packages/chai-a11y-axe/src/accessible.js
+++ b/packages/chai-a11y-axe/src/accessible.js
@@ -1,4 +1,5 @@
-/* global axe */
+import { axe, loadAxe } from './axe-import.js';
+
 /**
  * Creates a map of rules to disable during the test.
  * @param {Array<String>?} ignored List of rule names to ignore during the test.
@@ -22,7 +23,12 @@ function getRules(ignored) {
  * @param {Object} opts AXE configuration options.
  * @return {Promise} Promise resolved to the test results object
  */
-function runTestAsync(element, opts) {
+async function runTestAsync(element, opts) {
+  if (!axe) {
+    // ensure axe is loaded before running tests
+    await loadAxe();
+  }
+
   return new Promise((resolve, reject) => {
     // @ts-ignore
     axe.run(element, opts, (err, results) => {

--- a/packages/chai-a11y-axe/src/axe-import.js
+++ b/packages/chai-a11y-axe/src/axe-import.js
@@ -1,0 +1,33 @@
+// @ts-nocheck
+/**
+ * In the browser, importing axe-core/axe.min.js will register to the window. In webpack it will
+ * be parsed as a commonjs module, so it won't be on the window. In this file we conditionally
+ * export from the window, or a webpack specific module import.
+ */
+
+/* eslint-disable global-require, import/no-mutable-exports */
+export let axe;
+
+export async function loadAxe() {
+  if (window.axe) {
+    // axe was already imported before
+    axe = window.axe;
+    return;
+  }
+
+  if (typeof require === 'function') {
+    // we are in a webpack environment
+    axe = require('axe-core/axe.min.js');
+    return;
+  }
+
+  // regular behavior, load axe as an es module and let it
+  // register to the window
+  await import('axe-core/axe.min.js');
+  if (!window.axe) {
+    throw new Error(
+      'Error importing axe-core/axe.min.js, are you using a bundler or build tool that doesnt handle es modules?',
+    );
+  }
+  axe = window.axe;
+}

--- a/packages/testing-karma/package.json
+++ b/packages/testing-karma/package.json
@@ -33,7 +33,7 @@
     "@types/karma-coverage-istanbul-reporter": "^2.1.0",
     "@types/karma-mocha": "^1.3.0",
     "@types/karma-mocha-reporter": "^2.2.0",
-    "axe-core": "^3.3.1",
+    "axe-core": "^3.5.3",
     "karma": "^4.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^2.0.0",

--- a/packages/testing-karma/src/create-default-config.js
+++ b/packages/testing-karma/src/create-default-config.js
@@ -30,7 +30,6 @@ module.exports = config => ({
       // specify it, so force snapshot files to be js type to avoid karma complaints
       type: 'js',
     },
-    require.resolve('axe-core/axe.min.js'),
   ],
 
   customLaunchers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,21 +2384,21 @@
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.70"
+  version "1.3.75"
   dependencies:
-    "@open-wc/testing-karma" "^3.3.27"
+    "@open-wc/testing-karma" "^3.3.32"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "3.3.27"
+  version "3.3.32"
   dependencies:
-    "@open-wc/karma-esm" "^2.16.5"
+    "@open-wc/karma-esm" "^2.16.10"
     "@types/karma" "^5.0.0"
     "@types/karma-coverage-istanbul-reporter" "^2.1.0"
     "@types/karma-mocha" "^1.3.0"
     "@types/karma-mocha-reporter" "^2.2.0"
-    axe-core "^3.3.1"
+    axe-core "^3.5.3"
     karma "^4.1.0"
     karma-chrome-launcher "^3.1.0"
     karma-coverage-istanbul-reporter "^2.0.0"
@@ -4554,7 +4554,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
-axe-core@^3.3.1, axe-core@^3.3.2:
+axe-core@^3.3.2, axe-core@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.3.tgz#5b7c0ee7c5197d546bd3a07c3ef701896f5773e9"
   integrity sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==


### PR DESCRIPTION
This makes chai-a11y-axe import axe-core by itself, rather than relying on axe being provided globally as a library. This is possible because even though axe-core isn't an es module, it runs in strict mode so we can load it as a module just let it register on the window and use it from there.

This trick doesn't work with webpack, and for that we add some special logic. We do this for chai as well: https://github.com/open-wc/open-wc/blob/master/packages/testing/import-wrappers/chai.js

The benefit is that we can use @open-wc/testing with other test runners as well.

I made it so that axe is only loaded when you're actually doing an a11y test, this way people who use @open-wc/testing don't always need to load axe which is quite a big library.