### PR TITLE
fix(lit-helpers): spreadProps typings

### DIFF
--- a/packages/lit-helpers/src/spreadProps.d.ts
+++ b/packages/lit-helpers/src/spreadProps.d.ts
@@ -1,3 +1,3 @@
 import { PropertyPart } from 'lit-html';
 
-export declare const spreadProps: (props: { [key: string]: unknown }) => (part: PropertyPart) => void;
+export declare const spreadProps: <T extends object>(props: T) => (part: PropertyPart) => void;


### PR DESCRIPTION
previous type was needlessly narrow, it would error on:

```ts
const tpl = (opts?: TemplateOpts) => html`<x-l ...="${spreadProps(opts ?? {})}"></x-l>`;
```