### PR TITLE
docs: update events.md

### DIFF
--- a/docs/faq/events.md
+++ b/docs/faq/events.md
@@ -67,7 +67,7 @@ If you are adding a listener to your element, from inside your element, you shou
 ```js
 constructor() {
     super();
-    this.addEventListener('done', this.handleDone.bind(this));
+    this.addEventListener('done', this.handleDone);
 }
 handleDone(event) {
     this.done = true;
@@ -75,7 +75,7 @@ handleDone(event) {
 }
 ```
 
-Side note: as you will be adding this listener manually, you _will_ need to ensure that `this` is bound to your liking. See the `.bind()` syntax above.
+Side note: as long as your event handler is a method of your custom element, there is no need to manually `bind` it. When calling `addEventListener`, the value of `this` inside the event handler [is a reference to the element](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#The_value_of_this_within_the_handler).
 
 ### On elements outside of your element
 


### PR DESCRIPTION
Clarify that `.bind` is not necessary to call when attaching an event via `addEventListener` to the element