### PR TITLE
fix(scoped-elements): html in attributes

### DIFF
--- a/packages/scoped-elements/test/transform.test.js
+++ b/packages/scoped-elements/test/transform.test.js
@@ -27,6 +27,18 @@ describe('html', () => {
       input: ['<mandalore-planet class="sample"></mandalore-planet>'],
       output: ['<mandalore-planet-\\d{1,5} class="sample"></mandalore-planet-\\d{1,5}>'],
     },
+    {
+      input: ['<mandalore-planet class="sample" data-test="<my-component>"></mandalore-planet>'],
+      output: [
+        '<mandalore-planet-\\d{1,5} class="sample" data-test="<my-component>"></mandalore-planet-\\d{1,5}>',
+      ],
+    },
+    {
+      input: ['<mandalore-planet class="sample" data-test=\'<my-component>\'></mandalore-planet>'],
+      output: [
+        '<mandalore-planet-\\d{1,5} class="sample" data-test=\'<my-component>\'></mandalore-planet-\\d{1,5}>',
+      ],
+    },
   ].forEach(({ input, output }, index) => {
     it(`should transform strings tags into the actual registered tags - ${index}`, () => {
       // @ts-ignore


### PR DESCRIPTION
Changed the regexp to a custom algorithm to stop scoping HTML inside attributes.

fixes: https://github.com/open-wc/open-wc/issues/1351