### PR TITLE
feat(demoing-storybook): Avoiding absolute imports behind a CLI flag

### DIFF
--- a/packages/demoing-storybook/src/start/cli.js
+++ b/packages/demoing-storybook/src/start/cli.js
@@ -16,21 +16,29 @@ const toBrowserPath = require('../shared/toBrowserPath');
 const getAssets = require('../shared/getAssets');
 
 async function run() {
-  const config = /** @type {ServerConfig & { stories: string[], addons: string[], configDir: string, setupMdjsPlugins: MdjsProcessPlugin[] }} */ (readCommandLineArgs());
+  const config = /** @type {ServerConfig & { stories: string[], addons: string[], configDir: string, setupMdjsPlugins: MdjsProcessPlugin[], relativeImports: boolean }} */ (readCommandLineArgs());
   const rootDir = config.rootDir ? path.resolve(process.cwd(), config.rootDir) : process.cwd();
+  const pathPrefix = config.relativeImports ? './' : '/';
 
   const storybookConfigDir = config.configDir;
   const previewPath = require.resolve('storybook-prebuilt/web-components.js');
   const managerPath = require.resolve('storybook-prebuilt/manager.js');
-  const previewPathRelative = rootDir ? `/${path.relative(rootDir, previewPath)}` : previewPath;
-  const managerPathRelative = rootDir ? `/${path.relative(rootDir, managerPath)}` : managerPath;
+  const previewPathRelative = rootDir
+    ? `${pathPrefix}${path.relative(rootDir, previewPath)}`
+    : previewPath;
+  const managerPathRelative = rootDir
+    ? `${pathPrefix}${path.relative(rootDir, managerPath)}`
+    : managerPath;
   const previewImport = toBrowserPath(previewPathRelative);
   const managerImport = toBrowserPath(managerPathRelative);
 
   const previewConfigPath = path.join(process.cwd(), storybookConfigDir, 'preview.js');
   let previewConfigImport;
   if (fs.existsSync(previewConfigPath)) {
-    previewConfigImport = `/${toBrowserPath(path.relative(rootDir, previewConfigPath))}`;
+    const previewConfigRelative = rootDir
+      ? `${pathPrefix}${path.relative(rootDir, previewConfigPath)}`
+      : previewConfigPath;
+    previewConfigImport = `${toBrowserPath(previewConfigRelative)}`;
   }
 
   const assets = getAssets({
@@ -38,7 +46,7 @@ async function run() {
     rootDir,
     managerImport,
     addons: config.addons,
-    absoluteImports: true,
+    absoluteImports: !config.relativeImports,
   });
 
   config.babelModernExclude = [...(config.babelModernExclude || []), '**/storybook-prebuilt/**'];
@@ -56,6 +64,7 @@ async function run() {
       previewConfigImport,
       storiesPatterns: config.stories,
       rootDir,
+      absolutePath: !config.relativeImports,
     }),
   ].filter(_ => _);
 

--- a/packages/demoing-storybook/src/start/readCommandLineArgs.js
+++ b/packages/demoing-storybook/src/start/readCommandLineArgs.js
@@ -46,6 +46,13 @@ module.exports = function readCommandLineArgs() {
       defaultValue: mainJs.stories || './stories/*.stories.{js,mdx}',
       description: 'List of story files e.g. --stories stories/*.stories.\\{js,mdx\\}',
     },
+    {
+      name: 'relative-imports',
+      type: Boolean,
+      defaultValue: false,
+      description:
+        'Generates relative imports in URL (required if storybook is served on a sub path)',
+    },
     { name: 'help', type: Boolean, description: 'See all options' },
   ];
 
@@ -86,6 +93,7 @@ module.exports = function readCommandLineArgs() {
   return {
     configDir: storybookArgs['config-dir'],
     stories: storybookArgs.stories,
+    relativeImports: storybookArgs['relative-imports'] || false,
     addons: mainJs.addons || [],
     setupMdjsPlugins: mainJs.setupMdjsPlugins,
 

--- a/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
+++ b/packages/demoing-storybook/src/start/transformers/createServeStorybookTransformer.js
@@ -10,6 +10,7 @@ const { createOrderedExports } = require('../../shared/createOrderedExports');
  * @param {string} args.previewConfigImport
  * @param {string[]} args.storiesPatterns glob patterns of story files
  * @param {string} args.rootDir
+ * @param {boolean} args.absolutePath
  */
 function createServeStorybookTransformer({
   assets,
@@ -17,6 +18,7 @@ function createServeStorybookTransformer({
   previewConfigImport,
   storiesPatterns,
   rootDir,
+  absolutePath,
 }) {
   const servedStoryUrls = new Set();
   const { indexHTML, iframeHTML } = assets;
@@ -30,7 +32,7 @@ function createServeStorybookTransformer({
         previewImport,
         previewConfigImport,
         storiesPatterns,
-        absolutePath: true,
+        absolutePath,
         rootDir,
       });
 


### PR DESCRIPTION
In my setup, I needed to rely on `storybook-prebuilt` being served under a sub directory (http://localhost:8080/storybook/).

I tried with `demoing-storybook` but it didn't worked because some absolute paths were generated in storybook-ui.

This PR aims at providing a `--relative-imports` CLI flag allowing to generate relative imports instead of absolute imports, when generating storyook-ui imports.