### PR TITLE
feat(es-dev-server): allow configuring custom babel include/exclude

### DIFF
--- a/packages/es-dev-server/src/config.ts
+++ b/packages/es-dev-server/src/config.ts
@@ -108,8 +108,12 @@ export interface Config {
   babelExclude?: string[];
   /** files excluded from babel on modern browser */
   babelModernExclude?: string[];
-  /** files excluded from module transfomration */
+  /** files excluded from module transformration */
   babelModuleExclude?: string[];
+  /** files to include from user defined babel config */
+  customBabelInclude?: string[];
+  /** files to exclude from user defined babel config */
+  customBabelExclude?: string[];
   /**
    * babel config to use, this is useful when you want to provide a
    * babel config from a tool, and don't want to require all users to use the same babel config
@@ -159,6 +163,8 @@ export interface ParsedConfig {
   babelExclude: string[];
   babelModernExclude: string[];
   babelModuleExclude: string[];
+  customBabelInclude: string[];
+  customBabelExclude: string[];
 }
 
 /**
@@ -171,6 +177,8 @@ export function createConfig(config: Partial<Config>): ParsedConfig {
     babelExclude = [],
     babelModernExclude = [],
     babelModuleExclude = [],
+    customBabelInclude = [],
+    customBabelExclude = [],
     basePath,
     compress = true,
     fileExtensions: fileExtensionsArg,
@@ -289,6 +297,8 @@ export function createConfig(config: Partial<Config>): ParsedConfig {
     babelExclude,
     babelModernExclude,
     babelModuleExclude,
+    customBabelInclude,
+    customBabelExclude,
     basePath,
     compatibilityMode: compatibility,
     polyfillsLoader: polyfillsLoader !== false,

--- a/packages/es-dev-server/src/create-middlewares.ts
+++ b/packages/es-dev-server/src/create-middlewares.ts
@@ -64,6 +64,8 @@ export function createMiddlewares(config: ParsedConfig, fileWatcher = chokidar.w
     babelExclude,
     babelModernExclude,
     babelModuleExclude,
+    customBabelInclude,
+    customBabelExclude,
   } = config;
 
   const middlewares: Middleware[] = [];
@@ -115,6 +117,8 @@ export function createMiddlewares(config: ParsedConfig, fileWatcher = chokidar.w
         babelExclude,
         babelModernExclude,
         babelModuleExclude,
+        customBabelInclude,
+        customBabelExclude,
       }),
     );
   }

--- a/packages/es-dev-server/src/plugins/babelTransformPlugin.ts
+++ b/packages/es-dev-server/src/plugins/babelTransformPlugin.ts
@@ -27,6 +27,8 @@ interface BabelTransformConfig {
   babelExclude: string[];
   babelModernExclude: string[];
   babelModuleExclude: string[];
+  customBabelInclude: string[];
+  customBabelExclude: string[];
 }
 
 export function babelTransformPlugin(config: BabelTransformConfig): Plugin {


### PR DESCRIPTION
This allows configuring custom babel include/exclude. We need this when using a babel plugin for test coverage, so that we can restrict the amount of files babel runs on. Improving speed.