### PR TITLE
fix(testing-karma): disable restartOnFileChange option

### DIFF
--- a/packages/testing-karma/src/create-default-config.js
+++ b/packages/testing-karma/src/create-default-config.js
@@ -86,7 +86,7 @@ module.exports = config => ({
     showDiff: true,
   },
 
-  restartOnFileChange: true,
+  restartOnFileChange: false,
 
   client: {
     mocha: {


### PR DESCRIPTION
After a lot of debugging, I found out that there is a race condition inside the karma browser client where sometimes it cancels a test run right after a reload when the `restartOnFileChange` option is set. 

Disabling this makes it more stable, but you have to wait for a test run to finish before rerunning tests again.