### PR TITLE
feat(es-dev-server): allow middlewares to respond before `koa-static`

### DIFF
--- a/packages/es-dev-server/src/create-middlewares.ts
+++ b/packages/es-dev-server/src/create-middlewares.ts
@@ -201,6 +201,7 @@ export function createMiddlewares(config: ParsedConfig, fileWatcher = chokidar.w
   middlewares.push(
     koaStatic(rootDir, {
       hidden: true,
+      defer: true,
       setHeaders(res) {
         res.setHeader('cache-control', 'no-cache');
       },


### PR DESCRIPTION
fixes #1730 