### PR TITLE
fix(create): TypeScript support

### DIFF
--- a/packages/create/src/generators/app-lit-element-ts/templates/_MyApp.ts
+++ b/packages/create/src/generators/app-lit-element-ts/templates/_MyApp.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, property } from 'lit-element';
+import { css, html, LitElement, property, TemplateResult } from 'lit-element';
 import { openWcLogo } from './open-wc-logo.js';
 
 export class <%= className %> extends LitElement {
@@ -49,7 +49,7 @@ export class <%= className %> extends LitElement {
     }
   `;
 
-  render() {
+  render(): TemplateResult {
     return html`
       <main>
         <div class="logo">${openWcLogo}</div>

--- a/packages/create/src/generators/linting-eslint-ts/templates/_.eslintrc.js
+++ b/packages/create/src/generators/linting-eslint-ts/templates/_.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:import/errors',
     'plugin:import/warnings',
+    'plugin:import/typescript',
   ],
   rules: {
     // disable the rule for all files


### PR DESCRIPTION
- Add default returned type to `render()` to avoid `Missing return type on function.eslint@typescript-eslint/explicit-module-boundary-types)` errors.
- Apply recommendations from https://github.com/benmosher/eslint-plugin-import for TypeScript support.