### PR TITLE
feat(eslint-config): Improve ESLint v7 support by adding plugins to peerDeps

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,6 +22,14 @@
     "eslint",
     "config"
   ],
+  "peerDependencies": {
+    "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-html": "^6.0.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-lit": "^1.2.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-wc": "^1.2.0"
+  },
   "dependencies": {
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",


### PR DESCRIPTION
To better support ESLint v7 peerDep resolution.
See: https://github.com/open-wc/open-wc/issues/1739
==
When we extend `open-wc/eslint-config` and install it on a project, the various plugins found in `dependencies` are not resolved by ESLint v7:
```json
"dependencies": {
    "eslint-plugin-babel": "^5.3.0",
    "eslint-plugin-html": "^6.0.0",
    "eslint-plugin-import": "^2.18.2",
    "eslint-plugin-lit": "^1.2.0",
    "eslint-plugin-no-only-tests": "^2.4.0",
    "eslint-plugin-wc": "^1.2.0"
  }
```
Therefore, we have to manually install each plugin individually as a `devDependencies` for each project that extends `open-wc/eslint-config`.

You'll notice that the `airbnb-base` config includes `plugin-import` in `peerDependencies` and they refer to installing peerDeps in their [README](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base#eslint-config-airbnb-base-1) and recommending `install-peerdeps` as a shortcut.

Like `airbnb-base`, it would excellent to get to use such a shortcut, but we need those plugins added as `peerDependencies`:

```json
"peerDependencies": {
    "eslint-plugin-babel": "^5.3.0",
    "eslint-plugin-html": "^6.0.0",
    "eslint-plugin-import": "^2.18.2",
    "eslint-plugin-lit": "^1.2.0",
    "eslint-plugin-no-only-tests": "^2.4.0",
    "eslint-plugin-wc": "^1.2.0"
  }
```