### PR TITLE
fix(es-dev-server): fix messagechannel to be ES5 compatible

### DIFF
--- a/packages/es-dev-server/src/browser-scripts/message-channel.ts
+++ b/packages/es-dev-server/src/browser-scripts/message-channel.ts
@@ -31,7 +31,7 @@ export default `
         }
 
         eventSource.close();
-        setTimeout(() => {
+        setTimeout(function () {
           console.log('Disconnected from es-dev-server, no longer reloading on file changes.');
         }, 300);
       });


### PR DESCRIPTION
The inlined script on message-channel.ts is not transpiled. This code was using
the arrow function which was failing in ES5 only browsers like IE11.

The fix is to use non-arrow anonymous function similar to rest of the script.

Tested manually with IE11.