### PR TITLE
fix(testing-helpers): change default timeout to 1000ms for waitUntil

### DIFF
--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -151,14 +151,14 @@ export function oneEvent(eventTarget, eventName) {
  * @param {{ interval?: number, timeout?: number }} [options] timeout and polling interval
  */
 export function waitUntil(predicate, message, options = {}) {
-  const { interval = 50, timeout = 2000 } = options;
+  const { interval = 50, timeout = 1000 } = options;
 
   return new Promise((resolve, reject) => {
     let timeoutId;
 
     setTimeout(() => {
       clearTimeout(timeoutId);
-      reject(new Error(message ? `Timeout: ${message}` : 'waitUntil timed out'));
+      reject(new Error(message ? `Timeout: ${message}` : `waitUntil timed out after ${timeout}ms`));
     }, timeout);
 
     async function nextInterval() {


### PR DESCRIPTION
Fixes #1460 

* Changed default timeout for `waitUntil` to `1000`ms
* Added given `timeout` to error