### PR TITLE
feat(building-rollup): avoid helper chunk in modern build

### DIFF
--- a/packages/building-rollup/src/babel/babel-configs.js
+++ b/packages/building-rollup/src/babel/babel-configs.js
@@ -4,6 +4,25 @@ const { isFalsy } = require('../utils');
 const createBabelConfigRollupBuild = ({ developmentMode, rootDir }) => ({
   babelHelpers: 'bundled',
   compact: true,
+  presets: [
+    [
+      require.resolve('@babel/preset-env'),
+      {
+        targets: [
+          'last 3 Chrome major versions',
+          'last 3 ChromeAndroid major versions',
+          'last 3 Firefox major versions',
+          'last 3 Edge major versions',
+          'last 3 Safari major versions',
+          'last 3 iOS major versions',
+        ],
+        useBuiltIns: false,
+        shippedProposals: true,
+        modules: false,
+        bugfixes: true,
+      },
+    ],
+  ],
   plugins: [
     // rollup doesn't support optional chaining yet, so we compile it during input
     [require.resolve('@babel/plugin-proposal-optional-chaining'), { loose: true }],

--- a/packages/building-rollup/src/createBasicConfig.js
+++ b/packages/building-rollup/src/createBasicConfig.js
@@ -7,7 +7,6 @@ const { babel, getBabelOutputPlugin } = require('@rollup/plugin-babel');
 const merge = require('deepmerge');
 const {
   createBabelConfigRollupBuild,
-  babelConfigRollupGenerate,
   babelConfigLegacyRollupGenerate,
   babelConfigSystemJs,
 } = require('./babel/babel-configs');
@@ -42,12 +41,7 @@ function createBasicConfig(userOptions = {}) {
       assetFileNames: assetName,
       format: 'es',
       dir: opts.outputDir,
-      plugins: [
-        // build to js supported by modern browsers
-        getBabelOutputPlugin(babelConfigRollupGenerate),
-        // create babel-helpers chunk based on es5 build
-        bundledBabelHelpers({ minify: !developmentMode }),
-      ],
+      plugins: [],
     },
 
     plugins: [
@@ -58,8 +52,7 @@ function createBasicConfig(userOptions = {}) {
         },
       }),
 
-      // build non-standard syntax to standard syntax and other babel optimization plugins
-      // user plugins are deduped to allow overriding
+      // run babel, compiling down to latest of modern browsers
       dedupedBabelPlugin(
         babel,
         opts.babel,
@@ -82,6 +75,8 @@ function createBasicConfig(userOptions = {}) {
         entryFileNames: `nomodule-${fileName}`,
         chunkFileNames: `nomodule-${fileName}`,
         assetFileNames: `nomodule-${assetName}`,
+        // in the legacy build we want to build to es5, but the babel plugin in the input plugins runs for both
+        // we add output plugins here only for the legacy build to build to es5
         plugins: [
           // buid to es5
           getBabelOutputPlugin(babelConfigLegacyRollupGenerate),


### PR DESCRIPTION
Fixes https://github.com/open-wc/open-wc/issues/1625

This avoids creating an extra chunk with babel helpers for the modern build.

The reason the extra chunk is created is because when you run rollup with multiple outputs, you can only run different plugins per output in the "generate" phase of rollup. In this phase we can't efficiently add babel helpers in the regular bundle, and we need to create an extra chunk.

With the new approach, we use a regular babel plugin in the rollup "build" phase to build efficiently for modern browsers. And then only in the case of legacy browsers, we do an extra "generate" phase to build for legacy browsers. 

I want to run a few more tests with my own application which depends on this config before merging.