### PR TITLE
feat(scoped-elements): add data-tag-name with the original tagName

### DIFF
--- a/packages/scoped-elements/README.md
+++ b/packages/scoped-elements/README.md
@@ -243,7 +243,7 @@ To demonstrate, we made three demos:
 ## How it works
 
 `ScopedElementsMixin` is mixed into your LitElement and via `static get scopedElements()` you define the tags and classes you wanna use in your elements template.
-Under the hood it changes your template so `<my-button>${this.text}</my-button>` becomes `<my-button-2748>${this.text}</my-button-2748>`.
+Under the hood it changes your template so `<my-button>${this.text}</my-button>` becomes `<my-button-2748 data-tag-name="my-button">${this.text}</my-button-2748>`.
 
 Every auto-defined scoped elements gets a random\* 4 digits number suffix. This suffix changes every time to make sure developers are not inclined to use it the generated tag name as a styling hook. Additionally the suffix allows scoped-elements and traditional self-defined elements to coexist, avoiding name collision.
 

--- a/packages/scoped-elements/src/transform.js
+++ b/packages/scoped-elements/src/transform.js
@@ -58,12 +58,16 @@ const transformTemplate = (strings, scopedElements, templateCache, tagsCache) =>
 
     for (let i = matches.length - 1; i >= 0; i -= 1) {
       const item = matches[i];
-      const klass = scopedElements[item[1]];
-      const tag = registerElement(item[1], klass, tagsCache);
-      const start = item.index + item[0].length - item[1].length;
-      const end = start + item[1].length;
+      const [block, tagName] = item;
+      const tag = registerElement(tagName, scopedElements[tagName], tagsCache);
+      const start = item.index + block.length - tagName.length;
+      const end = start + tagName.length;
+      const isClosingTag = block.startsWith('</');
 
-      acc = acc.slice(0, start) + tag + acc.slice(end);
+      acc =
+        acc.slice(0, start) +
+        (isClosingTag ? tag : `${tag} data-tag-name="${tagName}"`) +
+        acc.slice(end);
     }
 
     return acc;

--- a/packages/scoped-elements/test/transform.test.js
+++ b/packages/scoped-elements/test/transform.test.js
@@ -9,23 +9,38 @@ describe('html', () => {
   [
     {
       input: ['<mandalore-planet>', '</mandalore-planet>'],
-      output: ['<mandalore-planet-\\d{1,5}>', '</mandalore-planet-\\d{1,5}>'],
+      output: [
+        '<mandalore-planet-\\d{1,5} data-tag-name="mandalore-planet">',
+        '</mandalore-planet-\\d{1,5}>',
+      ],
     },
     {
       input: ['<mandalore-planet class="sample">', '</mandalore-planet>'],
-      output: ['<mandalore-planet-\\d{1,5} class="sample">', '</mandalore-planet-\\d{1,5}>'],
+      output: [
+        '<mandalore-planet-\\d{1,5} data-tag-name="mandalore-planet" class="sample">',
+        '</mandalore-planet-\\d{1,5}>',
+      ],
     },
     {
       input: ['<mandalore-planet\tclass="sample">', '</mandalore-planet>'],
-      output: ['<mandalore-planet-\\d{1,5}\tclass="sample">', '</mandalore-planet-\\d{1,5}>'],
+      output: [
+        '<mandalore-planet-\\d{1,5} data-tag-name="mandalore-planet"\tclass="sample">',
+        '</mandalore-planet-\\d{1,5}>',
+      ],
     },
     {
       input: ['<mandalore-planet\rclass="sample">', '</mandalore-planet>'],
-      output: ['<mandalore-planet-\\d{1,5}\rclass="sample">', '</mandalore-planet-\\d{1,5}>'],
+      output: [
+        '<mandalore-planet-\\d{1,5} data-tag-name="mandalore-planet"\rclass="sample">',
+        '</mandalore-planet-\\d{1,5}>',
+      ],
     },
     {
       input: ['<mandalore-planet class="sample"></mandalore-planet>'],
-      output: ['<mandalore-planet-\\d{1,5} class="sample"></mandalore-planet-\\d{1,5}>'],
+      output: [
+        '<mandalore-planet-\\d{1,5} data-tag-name="mandalore-planet"' +
+          ' class="sample"></mandalore-planet-\\d{1,5}>',
+      ],
     },
   ].forEach(({ input, output }, index) => {
     it(`should transform strings tags into the actual registered tags - ${index}`, () => {


### PR DESCRIPTION
This change adds the attribute `data-tag-name` to each scoped element with the unscoped tagName.

In relation with #1751, this data attribute could be used to select scoped elements in e2e tests predictively.