### PR TITLE
fix(rollup-plugin-html): ensure inline module ids are unique

### DIFF
--- a/packages/rollup-plugin-html/rollup-plugin-html.js
+++ b/packages/rollup-plugin-html/rollup-plugin-html.js
@@ -58,6 +58,7 @@ function rollupPluginHtml(pluginOptions) {
   let htmlFiles = [];
   /** @type {string} */
   let fakeModuleForPureHtmlInput = '';
+  let inlineModuleIndex = 0;
 
   // variables for multi build
   /** @type {string[]} */
@@ -108,7 +109,9 @@ function rollupPluginHtml(pluginOptions) {
       const htmlDataArray = getInputHtmlData(pluginOptions, rollupInput);
       for (const htmlData of htmlDataArray) {
         const htmlFileName = pluginOptions.name || htmlData.name || defaultFileName;
-        const inputHtmlResources = extractModules(htmlData, htmlFileName);
+        const inputHtmlResources = extractModules(inlineModuleIndex, htmlData, htmlFileName);
+        inlineModuleIndex += inputHtmlResources.inlineModules.size;
+
         const html = inputHtmlResources.htmlWithoutModules;
         const { inlineModules } = inputHtmlResources;
 

--- a/packages/rollup-plugin-html/src/extractModules.js
+++ b/packages/rollup-plugin-html/src/extractModules.js
@@ -10,11 +10,17 @@ const {
 } = require('@open-wc/building-utils/dom5-fork/index.js');
 
 /**
+ * @param {number} inlineModuleIndex
  * @param {HtmlFile} inputHtmlData
  * @param {string} inputHtmlName
  * @param {string} [projectRootDir]
  */
-function extractModules(inputHtmlData, inputHtmlName, projectRootDir = process.cwd()) {
+function extractModules(
+  inlineModuleIndex,
+  inputHtmlData,
+  inputHtmlName,
+  projectRootDir = process.cwd(),
+) {
   const { html, rootDir: htmlRootDir } = inputHtmlData;
   const documentAst = parse(html);
   const scriptNodes = findJsScripts(documentAst, { jsScripts: true, inlineJsScripts: true });
@@ -30,7 +36,10 @@ function extractModules(inputHtmlData, inputHtmlName, projectRootDir = process.c
     if (!src) {
       // turn inline module (<script type="module"> ...code ... </script>)
       const suffix = path.posix.basename(inputHtmlName).split('.')[0];
-      const importPath = path.posix.join(htmlRootDir, `inline-module-${suffix}-${i}.js`);
+      const importPath = path.posix.join(
+        htmlRootDir,
+        `inline-module-${suffix}-${inlineModuleIndex + i}.js`,
+      );
       inlineModules.set(importPath, getTextContent(scriptNode));
     } else {
       // external script <script type="module" src="./foo.js"></script>

--- a/packages/rollup-plugin-html/test/src/extractModules.test.js
+++ b/packages/rollup-plugin-html/test/src/extractModules.test.js
@@ -5,6 +5,7 @@ const { extractModules } = require('../../src/extractModules');
 describe('extractModules()', () => {
   it('extracts all modules from a html document', () => {
     const { moduleImports, inlineModules, htmlWithoutModules } = extractModules(
+      0,
       {
         html:
           '<div>before</div>' +
@@ -26,6 +27,7 @@ describe('extractModules()', () => {
 
   it('resolves imports relative to the root dir', () => {
     const { moduleImports, inlineModules, htmlWithoutModules } = extractModules(
+      0,
       {
         html:
           '<div>before</div>' +
@@ -50,6 +52,7 @@ describe('extractModules()', () => {
 
   it('resolves relative imports relative to the relative import base', () => {
     const { moduleImports, inlineModules, htmlWithoutModules } = extractModules(
+      0,
       {
         html:
           '<div>before</div>' +
@@ -74,6 +77,7 @@ describe('extractModules()', () => {
 
   it('extracts all inline modules from a html document', () => {
     const { moduleImports, inlineModules, htmlWithoutModules } = extractModules(
+      0,
       {
         html:
           '<div>before</div>' +
@@ -98,6 +102,7 @@ describe('extractModules()', () => {
 
   it('prefixes inline module with index.html directory', () => {
     const { moduleImports, inlineModules, htmlWithoutModules } = extractModules(
+      0,
       {
         html:
           '<div>before</div>' +


### PR DESCRIPTION
The HTML plugin has a bug where inline modules from different HTML files could end up with the same id if two HTML files have the same name.

I considered using UUIDs, but that would make testing harder. Keeping a counter is sufficient here.