### PR TITLE
docs: retain opened menu items when new sw has taken over and refreshed

### DIFF
--- a/docs/_includes/partials/service-worker.njk
+++ b/docs/_includes/partials/service-worker.njk
@@ -12,11 +12,30 @@
     });
   }
 
+  if (sessionStorage.getItem('openItems')) {
+    const openItems = JSON.parse(sessionStorage.getItem('openItems'));
+    const menuItems = [...document.querySelectorAll('section > p.sidebar-heading')];
+
+    if (openItems.length === menuItems.length) {
+      menuItems.forEach((item, i) => {
+        if (openItems[i]) {
+          item.click();
+        }
+      });
+
+      sessionStorage.removeItem('openItems');
+    }
+  }
+
   let refreshing;
   navigator.serviceWorker.addEventListener('controllerchange',
     function() {
       if (refreshing) return;
       refreshing = true;
+      const openItems = [...document.querySelectorAll('section > p.sidebar-heading')]
+        .map(item => item.classList.contains('open'));
+
+      sessionStorage.setItem('openItems', JSON.stringify(openItems));
       window.location.reload();
     }
   );


### PR DESCRIPTION
This solves @daKmoR frustration
![image](https://user-images.githubusercontent.com/17054057/89775135-799fef00-db07-11ea-8d50-9fab10a1e8b7.png)

How to try it locally:
- `npm run docs:build`
- `cd _site && http-server -o`
- open docs in browser
- make a change to `docs/about/README.md` (add some dummy text, so long as its byte different)
- `cd .. && npm run docs:build`
- `cd _site && http-server -o`
- go to browser, refresh, **quickly** open a menu item
- once the new service worker has taken over, you should still see the menuitem being open

Example:
![gif](https://media.giphy.com/media/fsEQmNLN4Uqjg0oigK/giphy.gif)

