### PR TITLE
fix(scoped-elements): make code ie11 compatible

### DIFF
--- a/packages/scoped-elements/src/transform.js
+++ b/packages/scoped-elements/src/transform.js
@@ -62,7 +62,7 @@ const transformTemplate = (strings, scopedElements, templateCache, tagsCache) =>
       const tag = registerElement(tagName, scopedElements[tagName], tagsCache);
       const start = item.index + block.length - tagName.length;
       const end = start + tagName.length;
-      const isClosingTag = block.startsWith('</');
+      const isClosingTag = block.indexOf('</') === 0;
 
       acc =
         acc.slice(0, start) +


### PR DESCRIPTION
This commit replaces `startsWith` by `indexOf` to make it work on ie11 without requiring a polyfill.

Fixes #1809 