### PR TITLE
chore(packages/webpack-index-html-plugin): corrected wrong keyname in…

### DIFF
--- a/packages/webpack-index-html-plugin/README.md
+++ b/packages/webpack-index-html-plugin/README.md
@@ -86,7 +86,7 @@ To enable polyfills:
 ```js
 new WebpackIndexHTMLPlugin({
   polyfills: {
-    polyfillsHash: true,
+    hashPolyfills: true,
     coreJs: true,
     regeneratorRuntime: true,
     webcomponents: true,


### PR DESCRIPTION
The keyname to toggle filename-hashing for polyfills has changed. The keyname in the docs has no effect - so users will not be able to turn off the hashes in filenames for the polyfills in /dist when they follow the docs.

the README.md has been changed to save some precious time for other developers, please merge this PR ;-)

the correct options are mentioned here: packages/building-utils/index-html/create-index-html.js (line 78)

polyfills: {
    hashPolyfills: true,
    coreJs: true,
    regeneratorRuntime: true,
    webcomponents: true,
    fetch: true,
    intersectionObserver: true,
  },