### PR TITLE
fix(semantic-dom-diff): fix unescaped attributes

### DIFF
--- a/packages/semantic-dom-diff/get-diffable-html.js
+++ b/packages/semantic-dom-diff/get-diffable-html.js
@@ -76,6 +76,9 @@ export function getDiffableHTML(html, options = {}) {
   const ignoreTags = [...(options.ignoreTags || []), ...DEFAULT_IGNORE_TAGS];
   const ignoreChildren = options.ignoreChildren || [];
   const stripEmptyAttributes = options.stripEmptyAttributes || DEFAULT_EMPTY_ATTRS;
+  const escapeAttributes = /(&|")/g;
+  /** @param {string} match */
+  const escapeAttributesFn = match => (match === '&' ? '&amp;' : '&quot;');
 
   let text = '';
   let depth = -1;
@@ -129,7 +132,7 @@ export function getDiffableHTML(html, options = {}) {
   function getAttributeString(el, { name, value }) {
     if (shouldStripAttribute({ name, value })) return '';
     if (name === 'class') return ` class="${getClassListValueString(el)}"`;
-    return ` ${name}="${value}"`;
+    return ` ${name}="${value.replace(escapeAttributes, escapeAttributesFn)}"`;
   }
 
   /**

--- a/packages/semantic-dom-diff/test/get-diffable-html.test.js
+++ b/packages/semantic-dom-diff/test/get-diffable-html.test.js
@@ -335,6 +335,22 @@ describe('getDiffableHTML()', () => {
         `);
       expect(html).to.equal('<div>\n</div>\n');
     });
+
+    it('escapes attributes that require it', () => {
+      const html = getDiffableHTML(`
+        <div a="i &quot;have&quot; quotes" b="attributes &amp; values" c="with &quot;quotes&quot; &amp; amps"></div>
+      `);
+
+      // prettier-ignore
+      expect(html).to.equal(
+        '<div\n' +
+        '  a="i &quot;have&quot; quotes"\n' +
+        '  b="attributes &amp; values"\n' +
+        '  c="with &quot;quotes&quot; &amp; amps"\n' +
+        '>\n' +
+        '</div>\n'
+      );
+    });
   });
 
   describe('special elements', () => {


### PR DESCRIPTION
The `semantic-dom-diff` package currently does not escape attributes that received previously escaped attribute values. As such, the resulting HTML from the `getDiffableHTML` function is not valid:

```
✖ 1 test failed

FAILED TESTS:
  getDiffableHTML()
    attributes
      ✖ escapes attributes that require it
        Chrome Headless 84.0.4147.105 (Linux x86_64)
      AssertionError: expected '<div\n  a="i "have" quotes"\n  b="attributes & values"\n>\n</div>\n' to equal '<div\n  a="i &quot;have&quot; quotes"\n  b="attributes &amp; values"\n>\n</div>\n'

      + expected - actual

       <div
      -  a="i "have" quotes"
      -  b="attributes & values"
      +  a="i &quot;have&quot; quotes"
      +  b="attributes &amp; values"
       >
       </div>
      
    at Context.<anonymous> (packages/semantic-dom-diff/test/get-diffable-html.test.js:345:23)
    at Test.Runnable.run (node_modules/karma-mocha-snapshot/lib/adapter.js:14:17)
```

This change incorporates the simplest solution to avoid any serialization issues, any feedback is welcome.

I also think this would've solved #1755