### PR TITLE
Feat/update terser rollup

### DIFF
--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -75,7 +75,7 @@
     "magic-string": "^0.25.7",
     "parse5": "^5.1.1",
     "regenerator-runtime": "^0.13.3",
-    "rollup-plugin-terser": "^5.2.0",
+    "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-workbox": "^5.0.1",
     "terser": "^4.6.7"
   },

--- a/packages/building-rollup/src/createBasicConfig.js
+++ b/packages/building-rollup/src/createBasicConfig.js
@@ -60,7 +60,7 @@ function createBasicConfig(userOptions = {}) {
       ),
 
       // minify js code
-      !developmentMode && pluginWithOptions(terser, opts.terser, { output: { comments: false } }),
+      !developmentMode && pluginWithOptions(terser, opts.terser, { format: { comments: false } }),
     ].filter(isFalsy),
   };
 

--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -69,7 +69,7 @@
     "magic-string": "^0.25.7",
     "rollup": "^2.7.2",
     "rollup-plugin-babel": "^5.0.0-alpha.1",
-    "rollup-plugin-terser": "^5.2.0",
+    "rollup-plugin-terser": "^7.0.2",
     "storybook-addon-markdown-docs": "^0.4.2",
     "storybook-prebuilt": "^1.5.0"
   }

--- a/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
+++ b/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
@@ -105,7 +105,7 @@ function createRollupConfig({ outputDir, indexFilename, indexHTMLString }) {
           resizeObserver: true,
         },
       }),
-      terser({ output: { comments: false } }),
+      terser({ format: { comments: false } }),
     ],
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,16 +2752,16 @@
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
 "@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.88"
+  version "1.3.90"
   dependencies:
-    "@open-wc/testing-karma" "^4.0.3"
+    "@open-wc/testing-karma" "^4.0.5"
     "@types/node" "^11.13.0"
     karma-browserstack-launcher "^1.0.0"
 
 "@open-wc/testing-karma@file:./packages/testing-karma":
-  version "4.0.3"
+  version "4.0.5"
   dependencies:
-    "@open-wc/karma-esm" "^3.0.3"
+    "@open-wc/karma-esm" "^3.0.5"
     "@types/karma" "^5.0.0"
     "@types/karma-coverage-istanbul-reporter" "^2.1.0"
     "@types/karma-mocha" "^1.3.0"
@@ -11390,6 +11390,15 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jest-worker@^26.2.1:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.3.0.tgz#7c8a97e4f4364b4f05ed8bca8ca0c24de091871f"
+  integrity sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
 js-beautify@^1.6.12:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.10.3.tgz#c73fa10cf69d3dfa52d8ed624f23c64c0a6a94c1"
@@ -14796,7 +14805,7 @@ ramda@^0.21.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -15968,6 +15977,16 @@ rollup-plugin-terser@^5.2.0:
     serialize-javascript "^2.1.2"
     terser "^4.6.2"
 
+rollup-plugin-terser@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
+  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
+    serialize-javascript "^4.0.0"
+    terser "^5.0.0"
+
 rollup-plugin-workbox@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-workbox/-/rollup-plugin-workbox-5.0.1.tgz#7ab8338833e166f72514f58237685b3d1a53eaa5"
@@ -16226,6 +16245,13 @@ serialize-javascript@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.0.0.tgz#492e489a2d77b7b804ad391a5f5d97870952548e"
   integrity sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==
+
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-favicon@^2.5.0:
   version "2.5.0"
@@ -17393,6 +17419,15 @@ terser@^4.1.2, terser@^4.6.12, terser@^4.6.2, terser@^4.6.3, terser@^4.6.7:
   version "4.6.13"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.13.tgz#e879a7364a5e0db52ba4891ecde007422c56a916"
   integrity sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.0.tgz#c481f4afecdcc182d5e2bdd2ff2dc61555161e81"
+  integrity sha512-XTT3D3AwxC54KywJijmY2mxZ8nJiEjBHVYzq8l9OaYuRFWeQNBwvipuzzYEP4e+/AVcd1hqG/CqgsdIRyT45Fg==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
Updating `terser` will be quite a challenge in our codebase since the API is now async while a lot of the code that uses it is sync. This code is in less frequently updated packages which we plan to move or deprecate anyway, so we will tackle that in a later stage.

This PR only updates the rollup plugin, partially implementing the changes from https://github.com/open-wc/open-wc/pull/1805

Fixes https://github.com/open-wc/open-wc/issues/1830