### PR TITLE
docs: testing karma coverage check

### DIFF
--- a/packages/testing-karma/README.md
+++ b/packages/testing-karma/README.md
@@ -159,7 +159,7 @@ module.exports = config => {
       ],
 
       coverageReporter: {
-        thresholds: {
+        check: {
           global: {
             statements: 50,
             lines: 50,


### PR DESCRIPTION
After #1556, as stated by @Westbrook on #1164, the `coverageReporter` `global` setting is now defined inside the `check` attribute instead of the `thresholds`  :)