### PR TITLE
feat(semantic-dom-diff): diff options now process scoped elements

### DIFF
--- a/packages/semantic-dom-diff/get-diffable-html.js
+++ b/packages/semantic-dom-diff/get-diffable-html.js
@@ -102,8 +102,18 @@ export function getDiffableHTML(html, options = {}) {
   }
 
   /** @param {Node} node */
+  function getTagName(node) {
+    // Use original tag if available via data-tag-name attribute (use-case for scoped elements)
+    // See packages/scoped-elements for more info
+    if (node instanceof Element) {
+      return node.getAttribute('data-tag-name') || node.localName;
+    }
+    return node.nodeName.toLowerCase();
+  }
+
+  /** @param {Node} node */
   function shouldProcessChildren(node) {
-    const name = node.nodeName.toLowerCase();
+    const name = getTagName(node);
     return (
       !ignoreTags.includes(name) &&
       !ignoreChildren.includes(name) &&
@@ -151,7 +161,7 @@ export function getDiffableHTML(html, options = {}) {
             `An object entry to ignoreAttributes should contain a 'tags' and an 'attributes' property.`,
           );
         }
-        return e.tags.includes(el.nodeName.toLowerCase()) && e.attributes.includes(attr.name);
+        return e.tags.includes(getTagName(el)) && e.attributes.includes(attr.name);
       });
     };
   }
@@ -178,21 +188,14 @@ export function getDiffableHTML(html, options = {}) {
   }
 
   /** @param {Element} el */
-  function getLocalName(el) {
-    // Use original tag if available via data-tag-name attribute (use-case for scoped elements)
-    // See packages/scoped-elements for more info
-    return el.getAttribute('data-tag-name') || el.localName;
-  }
-
-  /** @param {Element} el */
   function printOpenElement(el) {
-    text += `${getIndentation()}<${getLocalName(el)}${getAttributesString(el)}>\n`;
+    text += `${getIndentation()}<${getTagName(el)}${getAttributesString(el)}>\n`;
   }
 
   /** @param {Node} node */
   function onNodeStart(node) {
     // don't print this node if we should ignore it
-    if (node.nodeName === 'DIFF-CONTAINER' || ignoreTags.includes(node.nodeName.toLowerCase())) {
+    if (getTagName(node) === 'diff-container' || ignoreTags.includes(getTagName(node))) {
       return;
     }
 
@@ -214,17 +217,17 @@ export function getDiffableHTML(html, options = {}) {
 
   /** @param {Element} el */
   function printCloseElement(el) {
-    if (getLocalName(el) === 'diff-container' || VOID_ELEMENTS.includes(getLocalName(el))) {
+    if (getTagName(el) === 'diff-container' || VOID_ELEMENTS.includes(getTagName(el))) {
       return;
     }
 
-    text += `${getIndentation()}</${getLocalName(el)}>\n`;
+    text += `${getIndentation()}</${getTagName(el)}>\n`;
   }
 
   /** @param {Node} node */
   function onNodeEnd(node) {
     // don't print this node if we should ignore it
-    if (ignoreTags.includes(node.nodeName.toLowerCase())) {
+    if (ignoreTags.includes(getTagName(node))) {
       return;
     }
 

--- a/packages/semantic-dom-diff/test/get-diffable-html.test.js
+++ b/packages/semantic-dom-diff/test/get-diffable-html.test.js
@@ -815,6 +815,36 @@ describe('getDiffableHTML()', () => {
           '</my-element>\n',
       );
     });
+
+    it('ignored scoped tags', () => {
+      const html = getDiffableHTML(
+        `<div>
+          <div>A</div>
+          <span-123 data-tag-name="span">
+            <div>B</div>
+              <span>
+                <div>C</div>
+                <div>D</div>
+              </span>
+            <div>E</div>
+            <div>F</div>
+          </span-123>
+          <div>G</div>
+        </div>
+      `,
+        { ignoreTags: ['span'] },
+      );
+      expect(html).to.equal(
+        '<div>\n' +
+          '  <div>\n' +
+          '    A\n' +
+          '  </div>\n' +
+          '  <div>\n' +
+          '    G\n' +
+          '  </div>\n' +
+          '</div>\n',
+      );
+    });
   });
 
   it('dom node as input', () => {


### PR DESCRIPTION
Hey guys!

It's me again, trying to improve our `semantic-dom-diff` package to better process scoped elements.

I realised... why put the burden on devs to get the real names of scoped elements' tags when using diff options? It's important they know, but snapshots shouldn't care that much. I myself ended up with a test which looked like this:

```js
const getScopedTag = (el, tag) => el.constructor.getScopedTagName(tag, el.constructor.scopedElements)
const domDiffConfig = (el) => {
  return {
    ignoreChildren: [
      getScopedTag(el,'ing-input-amount'),
      getScopedTag(el,'ing-select'),
      getScopedTag(el,'ing-labs-spinner')
    ],
    ignoreAttributes: [
      getScopedTag(el,'ing-labs-spinner')
    ]
  }
}
```

I improved my previous contribution, from `getLocalName` to `getTagName` which will work both for  a `Node` or `Element` input type, and use it in every instance of the code needing a tag name.

Now you can ignore scoped elements' tags like a breeze! 💨 