### PR TITLE
chore: update axe-core to 4.x

### DIFF
--- a/packages/chai-a11y-axe/package.json
+++ b/packages/chai-a11y-axe/package.json
@@ -29,7 +29,7 @@
     "testing"
   ],
   "dependencies": {
-    "axe-core": "^3.5.3"
+    "axe-core": "^4.0.2"
   },
   "contributors": [
     "Pawel Psztyc"

--- a/packages/testing-karma/package.json
+++ b/packages/testing-karma/package.json
@@ -33,7 +33,7 @@
     "@types/karma-coverage-istanbul-reporter": "^2.1.0",
     "@types/karma-mocha": "^1.3.0",
     "@types/karma-mocha-reporter": "^2.2.0",
-    "axe-core": "^3.5.3",
+    "axe-core": "^4.0.2",
     "karma": "^5.1.1",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,7 +2766,7 @@
     "@types/karma-coverage-istanbul-reporter" "^2.1.0"
     "@types/karma-mocha" "^1.3.0"
     "@types/karma-mocha-reporter" "^2.2.0"
-    axe-core "^3.5.3"
+    axe-core "^4.0.2"
     karma "^5.1.1"
     karma-chrome-launcher "^3.1.0"
     karma-coverage "^2.0.2"
@@ -4933,10 +4933,15 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
-axe-core@^3.3.2, axe-core@^3.5.3:
+axe-core@^3.3.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.3.tgz#5b7c0ee7c5197d546bd3a07c3ef701896f5773e9"
   integrity sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==
+
+axe-core@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
+  integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
 
 axios@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
Update `axe-core` to latest [major release](https://github.com/dequelabs/axe-core/releases/tag/v4.0.0) to pull in latest accessibility rules.