### PR TITLE
chore: test packages with "next-major" release from lit-html/element

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "husky": "3.0.0",
     "lerna": "3.4.3",
     "lint-staged": "^10.0.0",
-    "lit-element": "^2.2.1",
+    "lit-element": "^3.0.0-pre.1",
     "mocha": "^6.2.2",
     "mock-require": "^3.0.3",
     "npm-run-all": "4.1.3",

--- a/packages/create/owc-app/package.json
+++ b/packages/create/owc-app/package.json
@@ -14,8 +14,8 @@
     "start": "es-dev-server --app-index index.html --node-resolve --open --watch"
   },
   "dependencies": {
-    "lit-element": "^2.0.1",
-    "lit-html": "^1.0.0"
+    "lit-element": "^3.0.0-pre.1",
+    "lit-html": "^2.0.0-pre.3"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^2.0.0",

--- a/packages/create/src/generators/app-lit-element-ts/templates/_package.json
+++ b/packages/create/src/generators/app-lit-element-ts/templates/_package.json
@@ -6,8 +6,8 @@
     "tsc:watch": "tsc --watch"
   },
   "dependencies": {
-    "lit-html": "^1.0.0",
-    "lit-element": "^2.0.1"
+    "lit-html": "^2.0.0-pre.3",
+    "lit-element": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "@types/node": "13.11.1",

--- a/packages/create/src/generators/app-lit-element/templates/_package.json
+++ b/packages/create/src/generators/app-lit-element/templates/_package.json
@@ -5,8 +5,8 @@
     "start": "es-dev-server --app-index index.html --node-resolve --open --watch"
   },
   "dependencies": {
-    "lit-html": "^1.0.0",
-    "lit-element": "^2.0.1"
+    "lit-html": "^2.0.0-pre.3",
+    "lit-element": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "es-dev-server": "^1.5.0"

--- a/packages/create/src/generators/wc-lit-element-ts/templates/_package.json
+++ b/packages/create/src/generators/wc-lit-element-ts/templates/_package.json
@@ -6,8 +6,8 @@
     "tsc:watch": "tsc --watch"
   },
   "dependencies": {
-    "lit-html": "^1.1.2",
-    "lit-element": "^2.2.1"
+    "lit-html": "^2.0.0-pre.3",
+    "lit-element": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "@types/node": "13.11.1",

--- a/packages/create/src/generators/wc-lit-element/templates/_package.json
+++ b/packages/create/src/generators/wc-lit-element/templates/_package.json
@@ -5,8 +5,8 @@
     "start": "es-dev-server --app-index demo/index.html --node-resolve --open --watch"
   },
   "dependencies": {
-    "lit-html": "^1.1.2",
-    "lit-element": "^2.2.1"
+    "lit-html": "^2.0.0-pre.3",
+    "lit-element": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "es-dev-server": "^1.23.0"

--- a/packages/create/test/snapshots/fully-loaded-app/package.json
+++ b/packages/create/test/snapshots/fully-loaded-app/package.json
@@ -58,7 +58,7 @@
   "author": "scaffold-app",
   "license": "MIT",
   "dependencies": {
-    "lit-html": "^1.0.0",
-    "lit-element": "^2.0.1"
+    "lit-html": "^2.0.0-pre.3",
+    "lit-element": "^3.0.0-pre.1"
   }
 }

--- a/packages/demoing-storybook/package.json
+++ b/packages/demoing-storybook/package.json
@@ -40,7 +40,7 @@
     "testing"
   ],
   "peerDependencies": {
-    "lit-html": "^1.0.0"
+    "lit-html": "^2.0.0-pre.3"
   },
   "dependencies": {
     "@babel/core": "^7.11.1",
@@ -64,7 +64,7 @@
     "fs-extra": "^8.1.0",
     "glob": "^7.1.3",
     "js-string-escape": "^1.0.1",
-    "lit-html": "^1.0.0",
+    "lit-html": "^2.0.0-pre.3",
     "lodash": "^4.17.15",
     "magic-string": "^0.25.7",
     "rollup": "^2.7.2",

--- a/packages/es-dev-server/package.json
+++ b/packages/es-dev-server/package.json
@@ -139,7 +139,7 @@
     "abort-controller": "^3.0.0",
     "buffer": "^5.4.3",
     "koa-proxies": "^0.8.1",
-    "lit-html": "^1.0.0",
+    "lit-html": "^2.0.0-pre.3",
     "lodash-es": "^4.17.15",
     "node-fetch": "^2.6.0",
     "request": "^2.88.0",

--- a/packages/import-maps-generate/test/assets/example/package.json
+++ b/packages/import-maps-generate/test/assets/example/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "lit-element": "^2.1.0"
+    "lit-element": "^3.0.0-pre.1"
   }
 }

--- a/packages/import-maps-generate/test/assets/exampleNested/package.json
+++ b/packages/import-maps-generate/test/assets/exampleNested/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "lit-element": "^2.1.0",
+    "lit-element": "^3.0.0-pre.1",
     "lit-html": "1.0.0"
   }
 }

--- a/packages/import-maps-generate/test/assets/exampleNestedResolution/package.json
+++ b/packages/import-maps-generate/test/assets/exampleNestedResolution/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "lit-element": "^2.1.0",
+    "lit-element": "^3.0.0-pre.1",
     "lit-html": "^0.14.0"
   },
   "importMap": {

--- a/packages/import-maps-generate/test/assets/exampleWorkspace/packages/a/package.json
+++ b/packages/import-maps-generate/test/assets/exampleWorkspace/packages/a/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "main": "./a.js",
   "dependencies": {
-    "lit-element": "^2.0.1"
+    "lit-element": "^3.0.0-pre.1"
   }
 }

--- a/packages/import-maps-generate/test/assets/exampleWorkspace/packages/b/package.json
+++ b/packages/import-maps-generate/test/assets/exampleWorkspace/packages/b/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "main": "./b.js",
   "dependencies": {
-    "lit-html": "^1.0.0"
+    "lit-html": "^2.0.0-pre.3"
   }
 }

--- a/packages/import-maps-generate/test/assets/exampleWorkspaceNested/packages/a/package.json
+++ b/packages/import-maps-generate/test/assets/exampleWorkspaceNested/packages/a/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "main": "./a.js",
   "dependencies": {
-    "lit-element": "^2.0.1"
+    "lit-element": "^3.0.0-pre.1"
   }
 }

--- a/packages/import-maps-generate/test/assets/exampleWorkspaceNestedResolution/packages/a/package.json
+++ b/packages/import-maps-generate/test/assets/exampleWorkspaceNestedResolution/packages/a/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "./a.js",
   "dependencies": {
-    "lit-element": "^2.0.1",
-    "lit-html": "^1.0.0"
+    "lit-element": "^3.0.0-pre.1",
+    "lit-html": "^2.0.0-pre.3"
   }
 }

--- a/packages/lit-helpers/package.json
+++ b/packages/lit-helpers/package.json
@@ -30,8 +30,8 @@
     "helpers"
   ],
   "peerDependencies": {
-    "lit-element": "^1.0.0",
-    "lit-html": "^1.0.0"
+    "lit-element": "^3.0.0-pre.1",
+    "lit-html": "^2.0.0-pre.3"
   },
   "sideEffects": false
 }

--- a/packages/rollup-plugin-index-html/package.json
+++ b/packages/rollup-plugin-index-html/package.json
@@ -30,7 +30,7 @@
     "@import-maps/resolve": "^1.0.0",
     "@open-wc/building-utils": "^2.18.1",
     "deepmerge": "^4.2.2",
-    "lit-html": "^1.0.0",
+    "lit-html": "^2.0.0-pre.3",
     "md5": "^2.2.1",
     "mkdirp": "^0.5.1",
     "parse5": "^5.1.1"

--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "lit-html": "^1.0.0"
+    "lit-html": "^2.0.0-pre.3"
   },
   "sideEffects": false
 }

--- a/packages/storybook-addon-web-components-knobs/package.json
+++ b/packages/storybook-addon-web-components-knobs/package.json
@@ -27,7 +27,7 @@
     "testing"
   ],
   "peerDependencies": {
-    "lit-html": "^1.0.0"
+    "lit-html": "^2.0.0-pre.3"
   },
   "dependencies": {
     "@open-wc/testing-helpers": "^1.8.9"
@@ -43,6 +43,6 @@
     "@storybook/addon-viewport": "^5.3.1",
     "@storybook/web-components": "^5.3.1",
     "babel-loader": "^8.0.0",
-    "lit-html": "^1.0.0"
+    "lit-html": "^2.0.0-pre.3"
   }
 }

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -30,8 +30,8 @@
   ],
   "dependencies": {
     "@open-wc/scoped-elements": "^1.2.2",
-    "lit-element": "^2.2.1",
-    "lit-html": "^1.0.0"
+    "lit-element": "^3.0.0-pre.1",
+    "lit-html": "^2.0.0-pre.3"
   },
   "devDependencies": {
     "webpack-merge": "^4.1.5"

--- a/packages/testing-helpers/src/fixture-no-side-effect.js
+++ b/packages/testing-helpers/src/fixture-no-side-effect.js
@@ -4,7 +4,7 @@ import { isValidRenderArg } from './lib.js';
 
 /**
  * @typedef {object} FixtureOptions
- * @property {Element} [parentNode] optional parent node to render the fixture's template to
+ * @property {HTMLElement} [parentNode] optional parent node to render the fixture's template to
  * @property {import('@open-wc/scoped-elements').ScopedElementsMap} [scopedElements] optional scoped-elements
  * definition map
  */

--- a/packages/testing-helpers/src/fixtureWrapper.js
+++ b/packages/testing-helpers/src/fixtureWrapper.js
@@ -5,8 +5,8 @@ export const cachedWrappers = [];
  * Creates a wrapper as a direct child of `<body>` to put the tested element into.
  * Need to be in the DOM to test for example `connectedCallback()` on elements.
  *
- * @param {Element} [parentNode]
- * @returns {Element} wrapping node
+ * @param {HTMLElement} [parentNode]
+ * @returns {HTMLElement} wrapping node
  */
 export function fixtureWrapper(parentNode = document.createElement('div')) {
   document.body.appendChild(parentNode);

--- a/packages/testing-helpers/src/lib.js
+++ b/packages/testing-helpers/src/lib.js
@@ -1,10 +1,8 @@
-import { TemplateResult } from 'lit-html';
-
 export const isIterable = object => object != null && typeof object[Symbol.iterator] === 'function';
 
 function isValidNonIterableRenderArg(x) {
   return (
-    x instanceof TemplateResult ||
+    typeof x._$litType$ !== 'undefined' ||
     x instanceof Node ||
     typeof x === 'number' ||
     typeof x === 'boolean' ||

--- a/packages/testing-helpers/src/litFixture.js
+++ b/packages/testing-helpers/src/litFixture.js
@@ -1,9 +1,8 @@
-import { TemplateResult } from 'lit-html';
 import { fixtureWrapper } from './fixtureWrapper.js';
 import { render } from './lit-html.js';
 import { elementUpdated } from './elementUpdated.js';
 import { NODE_TYPES } from './lib.js';
-import { getScopedElementsTemplate } from './scopedElementsWrapper.js';
+// import { getScopedElementsTemplate } from './scopedElementsWrapper.js';
 
 /**
  * @typedef {
@@ -38,12 +37,19 @@ const isUsefulNode = ({ nodeType, textContent }) => {
 export function litFixtureSync(template, options = {}) {
   const wrapper = fixtureWrapper(options.parentNode);
 
-  render(
-    options.scopedElements ? getScopedElementsTemplate(template, options.scopedElements) : template,
-    wrapper,
-  );
+  if (options.scopedElements) {
+    throw new Error('Scoped Elements are not currently supported at this time.');
+  }
 
-  if (template instanceof TemplateResult) {
+  render(template, wrapper);
+
+  if (
+    !(template instanceof String) &&
+    !(template instanceof Node) &&
+    !(template instanceof Number) &&
+    !(template instanceof Boolean) &&
+    !Array.isArray(template)
+  ) {
     return /** @type {T} */ (wrapper.firstElementChild);
   }
   const [node] = Array.from(wrapper.childNodes).filter(isUsefulNode);

--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -1,5 +1,5 @@
 import { ScopedElementsMixin } from '@open-wc/scoped-elements';
-import { html, LitElement, TemplateResult } from 'lit-element';
+import { html, LitElement } from 'lit-element';
 import { isIterable } from './lib.js';
 
 /** @typedef {import('@open-wc/scoped-elements').ScopedElementsMap} ScopedElementsMap */
@@ -9,7 +9,7 @@ const transform = template => {
     return [...template].map(v => transform(v));
   }
 
-  if (template instanceof TemplateResult) {
+  if (typeof template._$litType$ !== 'undefined') {
     return html(template.strings, ...template.values);
   }
 
@@ -86,7 +86,7 @@ customElements.define(wrapperTagName, ScopedElementsTestWrapper);
  *
  * @param {import('./litFixture').LitHTMLRenderable} template
  * @param {ScopedElementsMap} scopedElements
- * @returns {TemplateResult}
+ * @returns {import('lit-html').TemplateResult}
  */
 export function getScopedElementsTemplate(template, scopedElements) {
   const strings = [

--- a/tsconfig.build.types.json
+++ b/tsconfig.build.types.json
@@ -20,7 +20,9 @@
     "packages/semantic-dom-diff/get-diffable-html.js",
     "packages/semantic-dom-diff/src/utils.js",
     "packages/polyfills-loader/*.js",
-    "packages/import-maps-resolve/*.js",
-    "packages/scoped-elements/*.js"
+    "packages/import-maps-resolve/*.js"
+  ],
+  "exclude": [
+    "packages/testing-helpers/src/scopedElementsWrapper.js",
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11978,10 +11978,22 @@ lit-element@^2.0.1, lit-element@^2.2.1, lit-element@^2.3.1:
   dependencies:
     lit-html "^1.1.1"
 
+lit-element@^3.0.0-pre.1:
+  version "3.0.0-pre.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0-pre.1.tgz#91c318c1f85f184934a37d938f58648b201b079b"
+  integrity sha512-SQporGQ7vLcAupOf7chjkLGeanJNE8yxv3vYwfBRPgiQ+rdhrOmOmtUznDzY8GNvoi2AGus9mUZkMNMOHzr9xQ==
+  dependencies:
+    lit-html "^2.0.0-pre.2"
+
 lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.2.1.tgz#1fb933dc1e2ddc095f60b8086277d4fcd9d62cc8"
   integrity sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ==
+
+lit-html@^2.0.0-pre.2, lit-html@^2.0.0-pre.3:
+  version "2.0.0-pre.3"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-pre.3.tgz#d9714bd31fffe3262d162ef4ec4184b706288fe6"
+  integrity sha512-wnvsb7t3IuCAE2W+I/ZdIM9pjWUVhqmhlUYhZYTCcyGVRxwr0UqfZB+NektXmF16C5MZ838YUs97e+nCPV4NQg==
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This positions a branch for us to test the upcoming major releases of `lit-html` and `lit-element` in our tools and likely won't be merged until those dependencies get moved to their stable channel.

Notes:
- there were a number of versions of both packages and I'm not sure if there was a reason for it
  - I flattened ALL `lit-element` references (including one reference to a pre-2.0 release
  - I flattened `lit-element` references to the `1.*` release as it seemed that some of the `0.*` references were meant to be

In theory, if we run `yarn publish --canary --dist-tag next` we'll be able to make successive releases on the `next` channel for these packages and keep up with the ongoing development of `lit-html/element` as we go.

Thoughts?