### PR TITLE
fix(testing-helpers): replace ts-expect-error with ignore

### DIFF
--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -29,7 +29,7 @@ const transform = template => {
  * However, a new type error is created --> Base constructors must all have the same return type.ts(2510)
  * But this can be ignored, and then at least you do get the super static props typed properly.
  */
-// @ts-expect-error
+// @ts-ignore https://github.com/microsoft/TypeScript/issues/40110 , not using expect-error, because in some TS versions it does not throw
 class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
   static get properties() {
     return {


### PR DESCRIPTION
This is needed because different typescript versions seem to either throw or not throw, inconsistently. This makes expect-error problematic for users with typescript versions that don't throw on this. Review when the TS issue is closed by typescript.

fixes https://github.com/open-wc/open-wc/issues/1826