### PR TITLE
fix(polyfills-loader): remove source map URL

### DIFF
--- a/packages/es-dev-server/test/snapshots/polyfills-loader/inline-scripts-exclude.html
+++ b/packages/es-dev-server/test/snapshots/polyfills-loader/inline-scripts-exclude.html
@@ -81,7 +81,7 @@ async function* asyncGenerator() {
     }
 
     if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype) || window.ShadyDOM && window.ShadyDOM.force) {
-      polyfills.push(loadScript('./polyfills/webcomponents.6954abecfe8b165751e6bc9b0af6c639.js'));
+      polyfills.push(loadScript('./polyfills/webcomponents.06b4c3b88cf074d8d957bbee7eaf7012.js'));
     }
 
     if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) {
@@ -107,7 +107,7 @@ async function* asyncGenerator() {
       polyfillsLoader();
     }
 
-    s.src = "polyfills/core-js.da8d8819d4fcddc05b82706be190ca82.js";
+    s.src = "polyfills/core-js.a8ea21cd3f54f879f981d1dccc3c2a0c.js";
     s.onload = onLoaded;
 
     s.onerror = function () {

--- a/packages/es-dev-server/test/snapshots/polyfills-loader/inline-scripts-resolve-imports.html
+++ b/packages/es-dev-server/test/snapshots/polyfills-loader/inline-scripts-resolve-imports.html
@@ -50,7 +50,7 @@
     }
 
     if (!('attachShadow' in Element.prototype) || !('getRootNode' in Element.prototype) || window.ShadyDOM && window.ShadyDOM.force) {
-      polyfills.push(loadScript('./polyfills/webcomponents.6954abecfe8b165751e6bc9b0af6c639.js'));
+      polyfills.push(loadScript('./polyfills/webcomponents.06b4c3b88cf074d8d957bbee7eaf7012.js'));
     }
 
     if (!('noModule' in HTMLScriptElement.prototype) && 'getRootNode' in Element.prototype) {
@@ -84,7 +84,7 @@
       polyfillsLoader();
     }
 
-    s.src = "polyfills/core-js.da8d8819d4fcddc05b82706be190ca82.js";
+    s.src = "polyfills/core-js.a8ea21cd3f54f879f981d1dccc3c2a0c.js";
     s.onload = onLoaded;
 
     s.onerror = function () {

--- a/packages/polyfills-loader/src/create-polyfills-data.js
+++ b/packages/polyfills-loader/src/create-polyfills-data.js
@@ -194,7 +194,16 @@ function createPolyfillsData(cfg) {
     if (!codePath || !fs.existsSync(codePath) || !fs.statSync(codePath).isFile()) {
       throw new Error(`Could not find a file at ${filePath}`);
     }
-    return fs.readFileSync(filePath, 'utf-8');
+
+    const contentLines = fs.readFileSync(filePath, 'utf-8').split('\n');
+
+    // remove source map url
+    for (let i = contentLines.length - 1; i >= 0; i -= 1) {
+      if (contentLines[i].startsWith('//# sourceMappingURL')) {
+        contentLines[i] = '';
+      }
+    }
+    return contentLines.join('\n');
   }
 
   /** @type {PolyfillFile[]} */


### PR DESCRIPTION
This removes the source map URL from polyfills because they're causing 404s. We could look into including source maps later if needed.