### PR TITLE
feat(eslint-plugin-lit-a11y): interactive-supports-focus

### DIFF
--- a/packages/eslint-plugin-lit-a11y/docs/rules/interactive-supports-focus.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/interactive-supports-focus.md
@@ -1,0 +1,57 @@
+# Elements with an interactive role and interaction handlers (mouse or key press) must be focusable. (interactive-supports-focus)
+
+Please describe the origin of the rule here.
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+// Bad: span with @click attribute has no tabindex
+html`
+  <span @click="${submitForm()}" role="button">Submit</span>
+`;
+// Bad: anchor element without href is not focusable
+html`
+  <a @click="${showNextPage()}" role="button">Next page</a>
+`;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// Good: div with @click attribute is hidden from screen reader
+html`
+  <div aria-hidden @click=${() => void 0} />
+`;
+// Good: span with @click attribute is in the tab order
+html`
+  <span @click="${doSomething()}" tabIndex="0" role="button">Click me!</span>
+`;
+// Good: span with @click attribute may be focused programmatically
+html`
+  <span @click="${doSomething()}" tabIndex="-1" role="menuitem">Click me too!</span>
+`;
+// Good: anchor element with href is inherently focusable
+html`
+  <a href="javascript:void(0);" @click="${doSomething()}">Click ALL the things!</a>
+`;
+// Good: buttons are inherently focusable
+html`
+  <button @click="${doSomething()}">Click the button :)</button>
+`;
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/packages/eslint-plugin-lit-a11y/lib/rules/interactive-supports-focus.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/interactive-supports-focus.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview
+ * @author open-wc
+ */
+
+const includes = require('array-includes');
+const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
+const { eventHandlersByType } = require('../utils/eventsHandlers.js');
+const { getAttrVal } = require('../utils/getAttrVal.js');
+const { getTabIndex } = require('../utils/getTabIndex.js');
+const { isDisabledElement } = require('../utils/isDisabledElement.js');
+const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
+const { isInteractiveElement } = require('../utils/isInteractiveElement.js');
+const { isPresentationRole } = require('../utils/isPresentationRole.js');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Elements with an interactive role and interaction handlers (mouse or key press) must be focusable.',
+      category: 'Fill me in',
+      recommended: false,
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [
+      // fill in your schema
+    ],
+  },
+
+  create(context) {
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    const tabbable = (context.options && context.options[0] && context.options[0].tabbable) || [];
+
+    const interactiveProps = [...eventHandlersByType.mouse, ...eventHandlersByType.keyboard];
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      TaggedTemplateExpression: node => {
+        if (
+          node.type === 'TaggedTemplateExpression' &&
+          node.tag.type === 'Identifier' &&
+          node.tag.name === 'html'
+        ) {
+          // const type = elementType(node);
+
+          const analyzer = TemplateAnalyzer.create(node);
+
+          analyzer.traverse({
+            enterElement: element => {
+              const hasInteractiveProps = Object.keys(element.attribs).some(attr =>
+                interactiveProps.includes(attr),
+              );
+              const hasTabindex = getTabIndex(getAttrVal(element.attribs.tabindex)) !== undefined;
+
+              if (
+                !hasInteractiveProps &&
+                isDisabledElement(element.attribs) &&
+                isHiddenFromScreenReader(element.name, element.attribs) &&
+                isPresentationRole(element.attribs)
+              ) {
+                // Presentation is an intentional signal from the author that this
+                // element is not meant to be perceivable. For example, a click screen
+                // to close a dialog.
+                return;
+              }
+
+              if (
+                hasInteractiveProps &&
+                // && isInteractiveRole(element.name, attributes)
+                !isInteractiveElement(element.name, element.attribs) &&
+                // && !isNonInteractiveElement(element.name, attributes)
+                // && !isNonInteractiveRole(element.name, attributes)
+                !hasTabindex
+              ) {
+                const role = getAttrVal(element.attribs.role);
+                if (includes(tabbable, role)) {
+                  // Always tabbable, tabIndex = 0
+                  context.report({
+                    node,
+                    message: `Elements with the '${role}' interactive role must be tabbable.`,
+                  });
+                } else {
+                  // Focusable, tabIndex = -1 or 0
+                  context.report({
+                    node,
+                    message: `Elements with the '${role}' interactive role must be focusable.`,
+                  });
+                }
+              }
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getTabIndex.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getTabIndex.js
@@ -1,0 +1,26 @@
+const getTabIndex = tabIndexAttrValue => {
+  // String and number values.
+  if (['string', 'number'].indexOf(typeof tabIndexAttrValue) > -1) {
+    // Empty string will convert to zero, so check for it explicity.
+    if (typeof tabIndexAttrValue === 'string' && tabIndexAttrValue.length === 0) {
+      return undefined;
+    }
+    const value = Number(tabIndexAttrValue);
+    if (Number.isNaN(value)) {
+      return undefined;
+    }
+
+    return Number.isInteger(value) ? value : undefined;
+  }
+
+  // Booleans are not valid values, return undefined.
+  if (tabIndexAttrValue === true || tabIndexAttrValue === false) {
+    return undefined;
+  }
+
+  return tabIndexAttrValue;
+};
+
+module.exports = {
+  getTabIndex,
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isDisabledElement.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isDisabledElement.js
@@ -1,0 +1,28 @@
+const { getAttrVal } = require('./getAttrVal');
+
+const isDisabledElement = attributes => {
+  if (Object.keys(attributes).includes('disabled')) {
+    const disabledAttr = attributes.disabled;
+    const disabledAttrValue = getAttrVal(disabledAttr);
+    const isHTML5Disabled = disabledAttr && disabledAttrValue !== undefined;
+    if (isHTML5Disabled) {
+      return true;
+    }
+  }
+
+  if (Object.keys(attributes).includes('aria-disabled')) {
+    const ariaDisabledAttr = attributes['aria-disabled'];
+    const ariaDisabledAttrValue = getAttrVal(ariaDisabledAttr);
+
+    if (ariaDisabledAttr && ariaDisabledAttrValue !== undefined && ariaDisabledAttrValue === true) {
+      return true;
+    }
+    return false;
+  }
+
+  return false;
+};
+
+module.exports = {
+  isDisabledElement,
+};

--- a/packages/eslint-plugin-lit-a11y/package.json
+++ b/packages/eslint-plugin-lit-a11y/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "aria-query": "^4.2.2",
+    "array-includes": "^3.1.1",
     "axe-core": "^3.5.3",
     "axobject-query": "^2.2.0",
     "dom5": "^3.0.1",

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/interactive-supports-focus.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/interactive-supports-focus.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Elements with an interactive role and interaction handlers (mouse or key press) must be focusable.
+ * @author open-wc
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib/rules/interactive-supports-focus');
+
+const alwaysValid = [
+  { code: 'html`<div />`' },
+  // { code: 'html`<div aria-hidden @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${true == true} @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${true === true} @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${hidden !== false} @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${hidden != false} @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${1 < 2} @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${1 <= 2} @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${2 > 1} @click=${() => void 0} />`' },
+  // { code: 'html`<div aria-hidden=${2 >= 1} @click=${() => void 0} />`' },
+  // { code: 'html`<div @click=${() => void 0} />`' },
+  // { code: 'html`<div @click=${() => void 0} tabIndex=${undefined} />`' },
+  // { code: 'html`<div @click=${() => void 0} tabIndex="bad" />`' },
+  // { code: 'html`<div @click=${() => void 0} role=${undefined} />`' },
+  // { code: 'html`<div role="section" @click=${() => void 0} />`' },
+  // { code: 'html`<div @click=${() => void 0} aria-hidden=${false} />`' },
+  // { code: 'html`<div @click=${() => void 0} {...props} />`' },
+  // { code: 'html`<input type="text" @click=${() => void 0} />`' },
+  // { code: 'html`<input type="hidden" @click=${() => void 0} tabIndex="-1" />`' },
+  // { code: 'html`<input type="hidden" @click=${() => void 0} tabIndex=${-1} />`' },
+  // { code: 'html`<input @click=${() => void 0} />`' },
+  // { code: 'html`<input @click=${() => void 0} role="combobox" />`' },
+  // { code: 'html`<button @click=${() => void 0} className="foo" />`' },
+  // { code: 'html`<option @click=${() => void 0} className="foo" />`' },
+  // { code: 'html`<select @click=${() => void 0} className="foo" />`' },
+  // { code: 'html`<area href="#" @click=${() => void 0} className="foo" />`' },
+  // { code: 'html`<area @click=${() => void 0} className="foo" />`' },
+  // { code: 'html`<summary @click=${() => void 0} />`' },
+  // { code: 'html`<textarea @click=${() => void 0} className="foo" />`' },
+  // { code: 'html`<a @click="${showNextPage()}">Next page</a>`' },
+  // { code: 'html`<a @click="${showNextPage()}" tabIndex=${undefined}>Next page</a>`' },
+  // { code: 'html`<a @click="${showNextPage()}" tabIndex="bad">Next page</a>`' },
+  // { code: 'html`<a @click=${() => void 0} />`' },
+  // { code: 'html`<a tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<a tabIndex=${dynamicTabIndex} @click=${() => void 0} />`' },
+  // { code: 'html`<a tabIndex=${0} @click=${() => void 0} />`' },
+  // { code: 'html`<a role="button" href="#" @click=${() => void 0} />`' },
+  // { code: 'html`<a @click=${() => void 0} href="http://x.y.z" />`' },
+  // { code: 'html`<a @click=${() => void 0} href="http://x.y.z" tabIndex="0" />`' },
+  // { code: 'html`<a @click=${() => void 0} href="http://x.y.z" tabIndex=${0} />`' },
+  // { code: 'html`<a @click=${() => void 0} href="http://x.y.z" role="button" />`' },
+  // { code: 'html`<TestComponent @click=${doFoo} />`' },
+  // { code: 'html`<input @click=${() => void 0} type="hidden" />`' },
+  // { code: 'html`<span @click="${submitForm()}">Submit</span>`' },
+  // { code: 'html`<span @click="${submitForm()}" tabIndex=${undefined}>Submit</span>`' },
+  // { code: 'html`<span @click="${submitForm()}" tabIndex="bad">Submit</span>`' },
+  // { code: 'html`<span @click="${doSomething()}" tabIndex="0">Click me!</span>`' },
+  // { code: 'html`<span @click="${doSomething()}" tabIndex=${0}>Click me!</span>`' },
+  // { code: 'html`<span @click="${doSomething()}" tabIndex="-1">Click me too!</span>`' },
+  // {
+  //   code: 'html`<a href="javascript:void(0);" @click="${doSomething()}">Click ALL the things!</`a>',
+  // },
+  // { code: 'html`<section @click=${() => void 0} />`' },
+  // { code: 'html`<main @click=${() => void 0} />`' },
+  // { code: 'html`<article @click=${() => void 0} />`' },
+  // { code: 'html`<header @click=${() => void 0} />`' },
+  // { code: 'html`<footer @click=${() => void 0} />`' },
+  // { code: 'html`<div role="button" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="checkbox" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="link" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="menuitem" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="menuitemcheckbox" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="menuitemradio" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="option" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="radio" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="spinbutton" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="switch" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="tablist" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="tab" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="textbox" tabIndex="0" @click=${() => void 0} />`' },
+  // { code: 'html`<div role="textbox" aria-disabled="true" @click=${() => void 0} />`' },
+  // { code: 'html`<Foo.Bar @click=${() => void 0} aria-hidden=${false} />`' },
+  // { code: 'html`<Input @click=${() => void 0} type="hidden" />`' },
+];
+
+const alwaysFail = [
+  { code: 'html`<span @click="${submitForm()}" role="button">Submit</span>`' }, // eslint-disable-line
+  { code: 'html`<a @click="${showNextPage()}" role="button">Next page</a>`' }, // eslint-disable-line
+];
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015,
+  },
+});
+ruleTester.run('interactive-supports-focus', rule, {
+  valid: [...alwaysValid],
+
+  invalid: [...alwaysFail],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,32 +2598,6 @@
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.13.21.tgz#718b9ec5f9a98935fc775e577ad094ae8d8b7dea"
   integrity sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==
 
-"@open-wc/testing-karma-bs@file:./packages/testing-karma-bs":
-  version "1.3.86"
-  dependencies:
-    "@open-wc/testing-karma" "^4.0.1"
-    "@types/node" "^11.13.0"
-    karma-browserstack-launcher "^1.0.0"
-
-"@open-wc/testing-karma@file:./packages/testing-karma":
-  version "4.0.1"
-  dependencies:
-    "@open-wc/karma-esm" "^3.0.1"
-    "@types/karma" "^5.0.0"
-    "@types/karma-coverage-istanbul-reporter" "^2.1.0"
-    "@types/karma-mocha" "^1.3.0"
-    "@types/karma-mocha-reporter" "^2.2.0"
-    axe-core "^3.5.3"
-    karma "^4.1.0"
-    karma-chrome-launcher "^3.1.0"
-    karma-coverage "^2.0.2"
-    karma-mocha "^1.0.0"
-    karma-mocha-reporter "^2.0.0"
-    karma-mocha-snapshot "^0.2.1"
-    karma-snapshot "^0.6.0"
-    karma-source-map-support "^1.3.0"
-    mocha "^6.2.2"
-
 "@reach/router@^1.2.1":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.3.tgz#58162860dce6c9449d49be86b0561b5ef46d80db"
@@ -4573,7 +4547,7 @@ array-ify@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
-array-includes@^3.0.3:
+array-includes@^3.0.3, array-includes@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
   integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==


### PR DESCRIPTION
Initial structure for https://github.com/open-wc/open-wc/pull/1781 interactive-supports-focus rule

Example: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md