### PR TITLE
fix(eslint-plugin-lit-a11y): support member and conditional expressions

### DIFF
--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -3,6 +3,7 @@
  * @author open-wc
  */
 
+const { roles } = require('aria-query');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 
@@ -10,44 +11,7 @@ const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const validAriaRoles = [
-  'alert',
-  'application',
-  'article',
-  'banner',
-  'button',
-  'cell',
-  'checkbox',
-  'comment',
-  'complementary',
-  'contentinfo',
-  'dialog',
-  'document',
-  'feed',
-  'figure',
-  'form',
-  'grid',
-  'gridcell',
-  'heading',
-  'img',
-  'list',
-  'listbox',
-  'listitem',
-  'main',
-  'mark',
-  'navigation',
-  'region',
-  'row',
-  'rowgroup',
-  'search',
-  'suggestion',
-  'switch',
-  'tab',
-  'table',
-  'tabpanel',
-  'textbox',
-  'timer',
-];
+const validAriaRoles = [...roles.keys()].filter(role => roles.get(role).abstract === false);
 
 /** @type {import("eslint").Rule.RuleModule} */
 const AriaRoleRule = {
@@ -75,7 +39,10 @@ const AriaRoleRule = {
                   return;
                 }
 
-                const role = rawValue.replace(/^{{(.*)}}$/, '$1');
+                const role = /** @type {import("aria-query").ARIARoleDefintionKey} */ (rawValue.replace(
+                  /^{{(.*)}}$/,
+                  '$1',
+                ));
 
                 if (/^{(.*)}$/.test(role)) {
                   return; // the value is interpolated with a name. assume it's legitimate and move on.

--- a/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
+++ b/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
@@ -241,13 +241,9 @@ function templateExpressionToHtml(node) {
     } else if (isCallExpression(expr)) {
       html += `{{{${getIdentifierName(expr.callee)}(${getCallExprValue(expr)})}}}`;
     } else if (isMemberExpressions(expr)) {
-      html += `{{{${expr.property.name}}}}`;
+      html += `{{}}`;
     } else if (isConditionalExpression(expr)) {
-      if (isMemberExpressions(expr.test.left)) {
-        html += `{{{${expr.test.left.property.name}}}}`;
-      } else {
-        html += `{{}}`;
-      }
+      html += `{{}}`;
     }
   }
   return html;

--- a/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
+++ b/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
@@ -241,9 +241,9 @@ function templateExpressionToHtml(node) {
     } else if (isCallExpression(expr)) {
       html += `{{{${getIdentifierName(expr.callee)}(${getCallExprValue(expr)})}}}`;
     } else if (isMemberExpressions(expr)) {
-      html += `{{}}`;
+      html += `{{{}}}`;
     } else if (isConditionalExpression(expr)) {
-      html += `{{}}`;
+      html += `{{{}}}`;
     }
   }
   return html;

--- a/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
+++ b/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
@@ -187,6 +187,22 @@ function isLiteral(expr) {
 
 /**
  * @param {import("estree").Expression} expr
+ * @return {expr is import("estree").MemberExpression}
+ */
+function isMemberExpressions(expr) {
+  return expr && expr.type === 'MemberExpression';
+}
+
+/**
+ * @param {import("estree").Expression} expr
+ * @return {expr is import("estree").ConditionalExpression}
+ */
+function isConditionalExpression(expr) {
+  return expr && expr.type === 'ConditionalExpression';
+}
+
+/**
+ * @param {import("estree").Expression} expr
  * @return {expr is import("estree").UnaryExpression} expr
  */
 function isUnaryExpression(expr) {
@@ -224,6 +240,14 @@ function templateExpressionToHtml(node) {
       html += `{{${expr.value}}}`;
     } else if (isCallExpression(expr)) {
       html += `{{{${getIdentifierName(expr.callee)}(${getCallExprValue(expr)})}}}`;
+    } else if (isMemberExpressions(expr)) {
+      html += `{{{${expr.property.name}}}}`;
+    } else if (isConditionalExpression(expr)) {
+      if (isMemberExpressions(expr.test.left)) {
+        html += `{{{${expr.test.left.property.name}}}}`;
+      } else {
+        html += `{{}}`;
+      }
     }
   }
   return html;

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-attr-valid-value.js
@@ -77,6 +77,7 @@ ruleTester.run('aria-attr-valid-value', rule, {
     // number
     { code: 'html`<div aria-valuemax="123" />`' },
     { code: 'html`<div aria-valuemax=${foo} />`' },
+    { code: 'html`<div aria-valuemax=${this.foo} />`' },
 
     // token
     { code: 'html`<div aria-sort="ascending" />`' },
@@ -113,6 +114,9 @@ ruleTester.run('aria-attr-valid-value', rule, {
     // FUNCTION CALL
     { code: 'html`<div aria-label="${foo("foo")}"></div>`' },
     { code: 'html`<div aria-label="${this.foo("foo")}"></div>`' },
+
+    // CONDITIONAL
+    { code: 'html`<div aria-disabled="${this.foo ? "true" : "false"}"></div>`' },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-role.js
@@ -24,6 +24,7 @@ const ruleTester = new RuleTester({
 ruleTester.run('aria-role', rule, {
   valid: [
     { code: "html`<div role='alert'></div>`;" },
+    { code: "html`<div role='progressbar'></div>`;" },
     { code: "html`<div role='navigation'></div>`;" },
     { code: 'html`<div role="navigation"></div>`;' },
     { code: "html`<div role=${'navigation'}></div>`;" },


### PR DESCRIPTION
fixes #1889

Maybe just "refs" #1889, but this allows for the following syntaxes to lint:
```
<input aria-valuemax=${this.max} />
<input aria-disabeld=${this.disabled ? 'true' : 'false'} />
```
Currently is replaces it with a placeholder, but I can see room (and reason) to want to follow these tests/properties down their path to ensure that the actual typings of the binding that they represent are achieved.