### PR TITLE
feat(eslint-plugin-lit-a11y): interactive-supports-focus

### DIFF
--- a/packages/eslint-plugin-lit-a11y/README.md
+++ b/packages/eslint-plugin-lit-a11y/README.md
@@ -66,6 +66,7 @@ You may also extend the recommended configuration like so:
 - [lit-a11y/heading-has-content](./docs/rules/heading-has-content.md)
 - [lit-a11y/iframe-title](./docs/rules/iframe-title.md)
 - [lit-a11y/img-redundant-alt](./docs/rules/img-redundant-alt.md)
+- [lit-a11y/interactive-supports-focus](./docs/rules/interactive-supports-focus.md)
 - [lit-a11y/mouse-events-have-key-events](./docs/rules/mouse-events-have-key-events.md)
 - [lit-a11y/no-access-key](./docs/rules/no-access-key.md)
 - [lit-a11y/no-autofocus](./docs/rules/no-autofocus.md)

--- a/packages/eslint-plugin-lit-a11y/docs/rules/interactive-supports-focus.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/interactive-supports-focus.md
@@ -1,0 +1,160 @@
+# Elements with an interactive role and interaction handlers (mouse or key press) must be focusable. (interactive-supports-focus)
+
+## How do I resolve this error?
+
+### Case: I got the error "Elements with the '\${role}' interactive role must be tabbable". How can I fix this?
+
+This element is a stand-alone control like a button, a link or a form element. A user should be able to reach this element by pressing the tab key on their keyboard.
+
+Add the `tabindex` property to your component. A value of zero indicates that this element can be tabbed to.
+
+```js
+html` <div role="button" tabindex=${0} /> `;
+```
+
+-- or --
+
+Replace the component with one that renders semantic html element like `<button>`, `<a href>` or `<input>` -- whichever fits your purpose.
+
+Generally buttons, links and form elements should be reachable via tab key presses. An element that can be tabbed to is said to be in the _tab ring_.
+
+### Case: I got the error "Elements with the '\${role}' interactive role must be focusable". How can I fix this?
+
+This element is part of a group of buttons, links, menu items, etc. Or this element is part of a composite widget. Composite widgets prescribe standard [keyboard interaction patterns](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav). Within a group of similar elements -- like a button bar -- or within a composite widget, elements that can be focused are given a tabindex of -1. This makes the element _focusable_ but not _tabbable_. Generally one item in a group should have a tabindex of zero so that a user can tab to the component. Once an element in the component has focus, your key management behaviors will control traversal within the component's pieces. As the UI author, you will need to implement the key handling behaviors such as listening for traversal key (up/down/left/right) presses and moving the page focus between the focusable elements in your widget.
+
+```js
+html`
+  <div role="menu">
+    <div role="menuitem" tabindex="0">Open</div>
+    <div role="menuitem" tabindex="-1">Save</div>
+    <div role="menuitem" tabindex="-1">Close</div>
+  </div>
+`;
+```
+
+In the example above, the first item in the group can be tabbed to. The developer provides the ability to traverse to the subsequent items via the up/down/left/right arrow keys. Traversing via arrow keys is not provided by the browser or the assistive technology. See [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav) for information about established traversal behaviors for various UI widgets.
+
+### Case: This element is not a button, link, menuitem, etc. It is catching bubbled events from elements that it contains
+
+If your element is catching bubbled click or key events from descendant elements, then the proper role for this element is `presentation`.
+
+```js
+html`
+  <div @click=${onClickHandler} role="presentation">
+    <button>Save</button>
+  </div>
+`;
+```
+
+Marking an element with the role `presentation` indicates to assistive technology that this element should be ignored; it exists to support the web application and is not meant for humans to interact with directly.
+
+## Rule details
+
+This rule takes an options object with the key `tabbable`. The value is an array of interactive ARIA roles that should be considered tabbable, not just focusable. Any interactive role not included in this list will be flagged as needing to be focusable (tabindex of -1).
+
+```js
+{
+  'lit-a11y/interactive-supports-focus': [
+    'error',
+    {
+      tabbable: [
+        'button',
+        'checkbox',
+        'link',
+        'searchbox',
+        'spinbutton',
+        'switch',
+        'textbox',
+      ],
+    },
+  ]
+}
+```
+
+The recommended options list interactive roles that act as form elements. Generally, elements with a role like `menuitem` are a part of a composite widget. Focus in a composite widget is controlled and moved programmatically to satisfy the prescribed [keyboard interaction pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav) for the widget.
+
+The list of possible values includes:
+
+```js
+[
+  'button',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'grid',
+  'gridcell',
+  'link',
+  'listbox',
+  'menu',
+  'menubar',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'progressbar',
+  'radio',
+  'radiogroup',
+  'row',
+  'rowheader',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'tablist',
+  'textbox',
+  'toolbar',
+  'tree',
+  'treegrid',
+  'treeitem',
+  'doc-backlink',
+  'doc-biblioref',
+  'doc-glossref',
+  'doc-noteref',
+];
+```
+
+Examples of **incorrect** code for this rule:
+
+```js
+// Bad: span with @click attribute has no tabindex
+html` <span @click="${submitForm()}" role="button">Submit</span> `;
+// Bad: anchor element without href is not focusable
+html` <a @click="${showNextPage()}" role="button">Next page</a> `;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// Good: div with @click attribute is hidden from screen reader
+html` <div aria-hidden @click=${() => void 0} /> `;
+// Good: span with @click attribute is in the tab order
+html` <span @click="${doSomething()}" tabIndex="0" role="button">Click me!</span> `;
+// Good: span with @click attribute may be focused programmatically
+html` <span @click="${doSomething()}" tabIndex="-1" role="menuitem">Click me too!</span> `;
+// Good: anchor element with href is inherently focusable
+html` <a href="javascript:void(0);" @click="${doSomething()}">Click ALL the things!</a> `;
+// Good: buttons are inherently focusable
+html` <button @click="${doSomething()}">Click the button :)</button> `;
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+## Accessibility guidelines
+
+- [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
+
+### Resources
+
+- [Chrome Audit Rules, AX_FOCUS_02](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_02)
+- [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
+- [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
+- [WAI-ARIA Authoring Practices Guide - Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex)

--- a/packages/eslint-plugin-lit-a11y/lib/rules/interactive-supports-focus.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/interactive-supports-focus.js
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview
+ * @author open-wc
+ */
+
+const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
+const { eventHandlersByType } = require('../utils/eventsHandlers.js');
+const { getAttrVal } = require('../utils/getAttrVal.js');
+const { getTabIndex } = require('../utils/getTabIndex.js');
+const { isDisabledElement } = require('../utils/isDisabledElement.js');
+const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
+const {
+  isInteractiveElement,
+  isNonInteractiveElement,
+} = require('../utils/isInteractiveElement.js');
+const { isInteractiveRole, isNonInteractiveRole } = require('../utils/isInteractiveRole.js');
+const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { isPresentationRole } = require('../utils/isPresentationRole.js');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Elements with an interactive role and interaction handlers (mouse or key press) must be focusable.',
+      category: 'Fill me in',
+      recommended: false,
+    },
+    messages: {
+      elementWithRoleMustBe: "Elements with the '{{role}}' interactive role must be {{type}}.",
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          tabbable: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            uniqueItems: true,
+            additionalItems: false,
+          },
+        },
+        required: ['tabbable'],
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    const tabbable = (context.options && context.options[0] && context.options[0].tabbable) || [];
+    const interactiveProps = [...eventHandlersByType.mouse, ...eventHandlersByType.keyboard];
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      TaggedTemplateExpression(node) {
+        // 1. only target html`` tagged template literals
+        if (isHtmlTaggedTemplate(node)) {
+          const analyzer = TemplateAnalyzer.create(node);
+
+          analyzer.traverse({
+            enterElement(element) {
+              // TODO: review this statement
+              // if (!includes(domElements, type)) {
+              //   // Do not test higher level JSX components, as we do not know what
+              //   // low-level DOM element this maps to.
+              //   return;
+              // }
+
+              const { attribs, name } = element;
+
+              const hasInteractiveProps = Object.keys(attribs).some(attr =>
+                interactiveProps.includes(attr),
+              );
+
+              if (
+                !hasInteractiveProps ||
+                isDisabledElement(attribs) ||
+                isHiddenFromScreenReader(name, attribs) ||
+                isPresentationRole(attribs)
+              ) {
+                // Presentation is an intentional signal from the author that this
+                // element is not meant to be perceivable. For example, a click screen
+                // to close a dialog.
+                return;
+              }
+
+              const hasTabindex = getTabIndex(getAttrVal(attribs.tabindex)) !== undefined;
+
+              if (
+                hasInteractiveProps &&
+                isInteractiveRole(attribs) &&
+                !isInteractiveElement(name, attribs) &&
+                !isNonInteractiveElement(name, attribs) &&
+                !isNonInteractiveRole(name, attribs) &&
+                !hasTabindex
+              ) {
+                const role = getAttrVal(attribs.role);
+
+                if (tabbable.includes(role)) {
+                  // Always tabbable, tabIndex = 0
+                  context.report({
+                    node,
+                    messageId: 'elementWithRoleMustBe',
+                    data: {
+                      role,
+                      type: 'tabbable',
+                    },
+                  });
+                } else {
+                  // Focusable, tabIndex = -1 or 0
+                  context.report({
+                    node,
+                    messageId: 'elementWithRoleMustBe',
+                    data: {
+                      role,
+                      type: 'focusable',
+                    },
+                  });
+                }
+              }
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/eventsHandlers.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/eventsHandlers.js
@@ -1,0 +1,74 @@
+/**
+ * Common event handlers for HTML element event binding.
+ */
+
+const eventHandlersByType = {
+  clipboard: ['@copy', '@cut', '@paste'],
+  composition: ['@compositionend', '@compositionstart', '@compositionupdate'],
+  keyboard: ['@keydown', '@keypress', '@keyup'],
+  focus: ['@focus', '@blur'],
+  form: ['@change', '@input', '@submit'],
+  mouse: [
+    '@click',
+    '@contextmenu',
+    '@dblclick',
+    '@doubleclick',
+    '@drag',
+    '@dragend',
+    '@dragenter',
+    '@dragexit',
+    '@dragleave',
+    '@dragover',
+    '@dragstart',
+    '@drop',
+    '@mousedown',
+    '@mouseenter',
+    '@mouseleave',
+    '@mousemove',
+    '@mouseout',
+    '@mouseover',
+    '@mouseup',
+  ],
+  selection: ['@select'],
+  touch: ['@touchcancel', '@touchend', '@touchmove', '@touchstart'],
+  ui: ['@scroll'],
+  wheel: ['@wheel'],
+  media: [
+    '@abort',
+    '@canplay',
+    '@canplaythrough',
+    '@durationchange',
+    '@emptied',
+    '@encrypted',
+    '@ended',
+    '@error',
+    '@loadeddata',
+    '@loadedmetadata',
+    '@loadstart',
+    '@pause',
+    '@play',
+    '@playing',
+    '@progress',
+    '@ratechange',
+    '@seeked',
+    '@seeking',
+    '@stalled',
+    '@suspend',
+    '@timeupdate',
+    '@volumechange',
+    '@waiting',
+  ],
+  image: ['@load', '@error'],
+  animation: ['@animationstart', '@animationend', '@animationiteration'],
+  transition: ['@transitionend'],
+};
+
+const eventHandlers = Object.keys(eventHandlersByType).reduce(
+  (accumulator, type) => accumulator.concat(eventHandlersByType[type]),
+  [],
+);
+
+module.exports = {
+  eventHandlers,
+  eventHandlersByType,
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getAttrVal.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getAttrVal.js
@@ -2,7 +2,7 @@
  * Gets the attribute value by stripping interpolation markers, except for interpolated variables.
  * @param {string} val
  */
-function getAttrVal(val) {
+function getAttrVal(val = '') {
   // is expression
   if (val.startsWith('{{')) {
     // is expression with a variable

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getTabIndex.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getTabIndex.js
@@ -1,0 +1,27 @@
+const getTabIndex = tabIndexAttrValue => {
+  // String and number values.
+  if (['string', 'number'].includes(tabIndexAttrValue)) {
+    // Empty string will convert to zero, so check for it explicity.
+    if (typeof tabIndexAttrValue === 'string' && tabIndexAttrValue.length === 0) {
+      return undefined;
+    }
+
+    const value = Number(tabIndexAttrValue);
+    if (Number.isNaN(value)) {
+      return undefined;
+    }
+
+    return Number.isInteger(value) ? value : undefined;
+  }
+
+  // Booleans are not valid values, return undefined.
+  if (tabIndexAttrValue === true || tabIndexAttrValue === false) {
+    return undefined;
+  }
+
+  return tabIndexAttrValue;
+};
+
+module.exports = {
+  getTabIndex,
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isDisabledElement.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isDisabledElement.js
@@ -1,0 +1,32 @@
+const { getAttrVal } = require('./getAttrVal');
+
+const isDisabledElement = attributes => {
+  if (Object.keys(attributes).includes('disabled')) {
+    const disabledAttr = attributes.disabled;
+    const disabledAttrValue = getAttrVal(disabledAttr);
+    const isHTML5Disabled = disabledAttr && disabledAttrValue !== undefined;
+    if (isHTML5Disabled) {
+      return true;
+    }
+  }
+
+  if (Object.keys(attributes).includes('aria-disabled')) {
+    const ariaDisabledAttr = attributes['aria-disabled'];
+    const ariaDisabledAttrValue = getAttrVal(ariaDisabledAttr);
+
+    if (
+      ariaDisabledAttr &&
+      ariaDisabledAttrValue !== undefined &&
+      ariaDisabledAttrValue === 'true'
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  return false;
+};
+
+module.exports = {
+  isDisabledElement,
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isInteractiveRole.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isInteractiveRole.js
@@ -1,0 +1,95 @@
+const { dom, roles: rolesMap } = require('aria-query');
+const { getAttrVal } = require('./getAttrVal');
+
+const domKeys = [...dom.keys()];
+const roles = [...rolesMap.keys()];
+const interactiveRoles = roles
+  .filter(name => !rolesMap.get(name).abstract)
+  .filter(name => rolesMap.get(name).superClass.some(klasses => klasses.includes('widget')));
+
+// 'toolbar' does not descend from widget, but it does support
+// aria-activedescendant, thus in practice we treat it as a widget.
+interactiveRoles.push('toolbar');
+/**
+ * Returns boolean indicating whether the given element has a role
+ * that is associated with an interactive component. Used when an element
+ * has a dynamic handler on it and we need to discern whether or not
+ * its intention is to be interacted with in the DOM.
+ */
+const isInteractiveRole = attributes => {
+  const value = getAttrVal(attributes.role);
+
+  // If value is undefined, then the role attribute will be dropped in the DOM.
+  // If value is null, then getLiteralAttributeValue is telling us that the
+  // value isn't in the form of a literal
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  let isInteractive = false;
+  const normalizedValues = String(value).toLowerCase().split(' ');
+  const validRoles = normalizedValues.reduce((accumulator, name) => {
+    if (roles.includes(name)) {
+      accumulator.push(name);
+    }
+    return accumulator;
+  }, []);
+  if (validRoles.length > 0) {
+    // The first role value is a series takes precedence.
+    isInteractive = interactiveRoles.includes(validRoles[0]);
+  }
+
+  return isInteractive;
+};
+
+const nonInteractiveRoles = roles
+  .filter(name => !rolesMap.get(name).abstract)
+  .filter(name => !rolesMap.get(name).superClass.some(klasses => klasses.includes('widget')));
+
+/**
+ * Returns boolean indicating whether the given element has a role
+ * that is associated with a non-interactive component. Non-interactive roles
+ * include `listitem`, `article`, or `dialog`. These are roles that indicate
+ * for the most part containers.
+ *
+ * Elements with these roles should not respond or handle user interactions.
+ * For example, an `onClick` handler should not be assigned to an element with
+ * the role `listitem`. An element inside the `listitem`, like a button or a
+ * link, should handle the click.
+ *
+ * This utility returns true for elements that are assigned a non-interactive
+ * role. It will return false for elements that do not have a role. So whereas
+ * a `div` might be considered non-interactive, for the purpose of this utility,
+ * it is considered neither interactive nor non-interactive -- a determination
+ * cannot be made in this case and false is returned.
+ */
+
+const isNonInteractiveRole = (tagName, attributes) => {
+  // Do not test higher level JSX components, as we do not know what
+  // low-level DOM element this maps to.
+  if (!domKeys.includes(tagName)) {
+    return false;
+  }
+
+  const value = getAttrVal(attributes.role);
+
+  let isNonInteractive = false;
+  const normalizedValues = String(value).toLowerCase().split(' ');
+  const validRoles = normalizedValues.reduce((accumulator, name) => {
+    if (roles.includes(name)) {
+      accumulator.push(name);
+    }
+    return accumulator;
+  }, []);
+  if (validRoles.length > 0) {
+    // The first role value is a series takes precedence.
+    isNonInteractive = nonInteractiveRoles.includes(validRoles[0]);
+  }
+
+  return isNonInteractive;
+};
+
+module.exports = {
+  isInteractiveRole,
+  isNonInteractiveRole,
+};

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/interactive-supports-focus.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/interactive-supports-focus.js
@@ -1,0 +1,154 @@
+/**
+ * @fileoverview Elements with an interactive role and interaction handlers (mouse or key press) must be focusable.
+ * @author open-wc
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib/rules/interactive-supports-focus');
+const { parserOptionsMapper } = require('../utils/parserOptionsMapper');
+const { ruleOptionsMapperFactory } = require('../utils/ruleOptionsMapperFactory');
+
+const recommendedOptions = {
+  tabbable: ['button', 'checkbox', 'link', 'searchbox', 'spinbutton', 'switch', 'textbox'],
+};
+
+const strictOptions = {
+  tabbable: [
+    'button',
+    'checkbox',
+    'link',
+    'progressbar',
+    'searchbox',
+    'slider',
+    'spinbutton',
+    'switch',
+    'textbox',
+  ],
+};
+
+const alwaysValid = [
+  { code: 'html`<div></div>`' },
+  { code: 'html`<div aria-hidden @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${true == true} @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${true === true} @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${hidden !== false} @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${hidden != false} @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${1 < 2} @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${1 <= 2} @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${2 > 1} @click=${() => void 0} />`' },
+  { code: 'html`<div aria-hidden=${2 >= 1} @click=${() => void 0} />`' },
+  { code: 'html`<div @click=${() => void 0} />`' },
+  { code: 'html`<div @click=${() => void 0} tabindex=${undefined} />`' },
+  { code: 'html`<div @click=${() => void 0} tabindex="bad" />`' },
+  { code: 'html`<div @click=${() => void 0} role=${undefined} />`' },
+  { code: 'html`<div role="section" @click=${() => void 0} />`' },
+  { code: 'html`<div @click=${() => void 0} aria-hidden=${false} />`' },
+  { code: 'html`<input type="text" @click=${() => void 0} />`' },
+  { code: 'html`<input type="hidden" @click=${() => void 0} tabindex="-1" />`' },
+  { code: 'html`<input type="hidden" @click=${() => void 0} tabindex=${-1} />`' },
+  { code: 'html`<input @click=${() => void 0} />`' },
+  { code: 'html`<input @click=${() => void 0} role="combobox" />`' },
+  { code: 'html`<button @click=${() => void 0} className="foo" />`' },
+  { code: 'html`<option @click=${() => void 0} className="foo" />`' },
+  { code: 'html`<select @click=${() => void 0} className="foo" />`' },
+  { code: 'html`<area href="#" @click=${() => void 0} className="foo" />`' },
+  { code: 'html`<area @click=${() => void 0} className="foo" />`' },
+  { code: 'html`<summary @click=${() => void 0} />`' },
+  { code: 'html`<textarea @click=${() => void 0} className="foo" />`' },
+  { code: 'html`<a @click="${showNextPage()}">Next page</a>`' },
+  { code: 'html`<a @click="${showNextPage()}" tabindex=${undefined}>Next page</a>`' },
+  { code: 'html`<a @click="${showNextPage()}" tabindex="bad">Next page</a>`' },
+  { code: 'html`<a @click=${() => void 0} />`' },
+  { code: 'html`<a tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<a tabindex=${dynamictabindex} @click=${() => void 0} />`' },
+  { code: 'html`<a tabindex=${0} @click=${() => void 0} />`' },
+  { code: 'html`<a role="button" href="#" @click=${() => void 0} />`' },
+  { code: 'html`<a @click=${() => void 0} href="http://x.y.z" />`' },
+  { code: 'html`<a @click=${() => void 0} href="http://x.y.z" tabindex="0" />`' },
+  { code: 'html`<a @click=${() => void 0} href="http://x.y.z" tabindex=${0} />`' },
+  { code: 'html`<a @click=${() => void 0} href="http://x.y.z" role="button" />`' },
+  { code: 'html`<foo-bar @click=${doFoo}><foo-bar/>`' },
+  { code: 'html`<input @click=${() => void 0} type="hidden" />`' },
+  { code: 'html`<span @click="${submitForm()}">Submit</span>`' },
+  { code: 'html`<span @click="${submitForm()}" tabindex=${undefined}>Submit</span>`' },
+  { code: 'html`<span @click="${submitForm()}" tabindex="bad">Submit</span>`' },
+  { code: 'html`<span @click="${doSomething()}" tabindex="0">Click me!</span>`' },
+  { code: 'html`<span @click="${doSomething()}" tabindex=${0}>Click me!</span>`' },
+  { code: 'html`<span @click="${doSomething()}" tabindex="-1">Click me too!</span>`' },
+  {
+    code: 'html`<a href="javascript:void(0);" @click="${doSomething()}">Click ALL the things!</a>`',
+  },
+  { code: 'html`<section @click=${() => void 0} />`' },
+  { code: 'html`<main @click=${() => void 0} />`' },
+  { code: 'html`<article @click=${() => void 0} />`' },
+  { code: 'html`<header @click=${() => void 0} />`' },
+  { code: 'html`<footer @click=${() => void 0} />`' },
+  { code: 'html`<div role="button" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="checkbox" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="link" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="menuitem" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="menuitemcheckbox" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="menuitemradio" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="option" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="radio" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="spinbutton" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="switch" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="tablist" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="tab" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="textbox" tabindex="0" @click=${() => void 0} />`' },
+  { code: 'html`<div role="textbox" aria-disabled="true" @click=${() => void 0} />`' },
+  { code: 'html`<foo-bar @click=${() => void 0} aria-hidden=${false}><foo-bar/>`' },
+  { code: 'html`<input @click=${() => void 0} type="hidden" />`' },
+];
+
+const alwaysFail = [
+  {
+    code: 'html`<span @click="${submitForm()}" role="button">Submit</span>`', // eslint-disable-line
+    errors: [
+      {
+        messageId: 'elementWithRoleMustBe',
+        data: {
+          role: 'button',
+          type: 'focusable',
+        },
+      },
+    ],
+  },
+  {
+    code: 'html`<a @click="${showNextPage()}" role="button">Next page</a>`', // eslint-disable-line
+    errors: [
+      {
+        messageId: 'elementWithRoleMustBe',
+        data: {
+          role: 'button',
+          type: 'focusable',
+        },
+      },
+    ],
+  },
+];
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+ruleTester.run('interactive-supports-focus:recommended', rule, {
+  valid: [...alwaysValid]
+    .map(ruleOptionsMapperFactory(recommendedOptions))
+    .map(parserOptionsMapper),
+
+  invalid: [...alwaysFail]
+    .map(ruleOptionsMapperFactory(recommendedOptions))
+    .map(parserOptionsMapper),
+});
+
+ruleTester.run('interactive-supports-focus:strict', rule, {
+  valid: [...alwaysValid].map(ruleOptionsMapperFactory(strictOptions)).map(parserOptionsMapper),
+
+  invalid: [...alwaysFail].map(ruleOptionsMapperFactory(strictOptions)).map(parserOptionsMapper),
+});

--- a/packages/eslint-plugin-lit-a11y/tests/lib/utils/parserOptionsMapper.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/utils/parserOptionsMapper.js
@@ -1,0 +1,20 @@
+const defaultParserOptions = {
+  sourceType: 'module',
+  ecmaVersion: 2015,
+};
+
+function parserOptionsMapper({ code, errors, options = [], parserOptions = {} }) {
+  return {
+    code,
+    errors,
+    options,
+    parserOptions: {
+      ...defaultParserOptions,
+      ...parserOptions,
+    },
+  };
+}
+
+module.exports = {
+  parserOptionsMapper,
+};

--- a/packages/eslint-plugin-lit-a11y/tests/lib/utils/ruleOptionsMapperFactory.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/utils/ruleOptionsMapperFactory.js
@@ -1,0 +1,24 @@
+function ruleOptionsMapperFactory(ruleOptions = []) {
+  // eslint-disable-next-line
+  return ({ code, errors, options, parserOptions }) => {
+    return {
+      code,
+      errors,
+      // Flatten the array of objects in an array of one object.
+      options: (options || []).concat(ruleOptions).reduce(
+        (acc, item) => [
+          {
+            ...acc[0],
+            ...item,
+          },
+        ],
+        [{}],
+      ),
+      parserOptions,
+    };
+  };
+}
+
+module.exports = {
+  ruleOptionsMapperFactory,
+};


### PR DESCRIPTION
Second strike after https://github.com/open-wc/open-wc/pull/1869

interactive-supports-focus rule
#1781 

Example: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md