### PR TITLE
fix: report errors on correct location, not entire quasi

### DIFF
--- a/packages/eslint-plugin-lit-a11y/template-analyzer/template-analyzer.js
+++ b/packages/eslint-plugin-lit-a11y/template-analyzer/template-analyzer.js
@@ -153,15 +153,10 @@ class TemplateAnalyzer {
    * @return {import("estree").SourceLocation}
    */
   resolveLocation(loc) {
-    let offset = 0;
-    for (const quasi of this._node.quasi.quasis) {
-      const placeholder = util_1.getExpressionPlaceholder(this._node, quasi);
-      offset += quasi.value.raw.length + placeholder.length;
-      if (loc.startOffset < offset) {
-        return quasi.loc;
-      }
-    }
-    return null;
+    return {
+      start: { line: loc.startLine - 1 + this._node.loc.start.line, column: loc.startCol - 1 },
+      end: { line: loc.endLine - 1 + this._node.loc.start.line, column: loc.endCol - 1 },
+    };
   }
 
   /**


### PR DESCRIPTION
fixes https://github.com/open-wc/open-wc/issues/1891

before:
![image](https://user-images.githubusercontent.com/17054057/96332957-38780e00-1067-11eb-9435-c791efdf5c0b.png)

after:
<img width="636" alt="Screenshot 2020-10-16 at 19 57 57" src="https://user-images.githubusercontent.com/17054057/96332963-3dd55880-1067-11eb-9da2-469261247d9e.png">
