### PR TITLE
fix(eslint-plugin-lit-a11y): aria-label img role

### DIFF
--- a/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
@@ -1,8 +1,10 @@
-# Enforce emojis are wrapped in <span> and provide screenreader access. (accessible-emoji)
+# Enforce emojis are wrapped in <span> and provide screenreader access. (accessible-emoji) (DEPRECATED)
 
 > Emoji help us communicate complex ideas very easily. When used in native apps and applications, emoji are reasonably accessible to screen readers, but on the web we need to do a little more to make sure everyone can understand emoji.
 
 - [Léonie Watson](https://tink.uk/accessible-emoji/)
+
+While many modern user agents are able to announce emoji to screen reader users, this rule is still useful for apps targetting older user agents.
 
 ## Rule Details
 
@@ -11,25 +13,19 @@ This rule aims to prevent inaccessible use of emoji in lit-html templates.
 Examples of **incorrect** code for this rule:
 
 ```js
-html` <span>🐼</span> `;
-```
-
-```js
-html` <i role="img" aria-label="Panda face">🐼</i> `;
+html`
+  <span>🐼</span>
+  <i role="img" aria-label="Panda face">🐼</i>
+`;
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-html` <span role="img" aria-label="Panda face">🐼</span> `;
-```
-
-```js
-html` <span role="img" alt="Panda face">🐼</span> `;
-```
-
-```js
 html`
+  <span role="img" aria-label="Panda face">🐼</span>
+  <span role="img" alt="Panda face">🐼</span>
+
   <label id="label">Clown</label>
   <span role="img" aria-labelledby="label">🤡</span>
 `;
@@ -37,7 +33,7 @@ html`
 
 ## When Not To Use It
 
-If you do not use emoji in your lit-html templates.
+If you exclusively target modern user agents which explicitly support emoji in plain text, or if you do not use emoji in your lit-html templates.
 
 ## Further Reading
 

--- a/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
@@ -25,6 +25,10 @@ html` <span role="img" aria-label="Panda face">🐼</span> `;
 ```
 
 ```js
+html` <span role="img" alt="Panda face">🐼</span> `;
+```
+
+```js
 html`
   <label id="label">Clown</label>
   <span role="img" aria-labelledby="label">🤡</span>

--- a/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
@@ -2,12 +2,21 @@
 
 Enforce that all elements that require alternative text have meaningful information to relay back to the end user. This is a critical component of accessibility for screen reader users in order for them to understand the content's purpose on the page. By default, this rule checks for alternative text on `<img>` elements.
 
+This rule also permits images which are completely removed from the <acronym>AOM (Accessibility Object Model)</acronym>:
+
+> **Sometimes there is non-text content that really is not meant to be seen or understood by the user.** Transparent images used to move text over on a page; an invisible image that is used to track usage statistics; and a swirl in the corner that conveys no information but just fills up a blank space to create an aesthetic effect are all examples of this. Putting alternative text on such items just distracts people using screen readers from the content on the page. Not marking the content in any way, though, leaves users guessing what the non-text content is and what information they may have missed (even though they have not missed anything in reality). This type of non-text content, therefore, is marked or implemented in a way that assistive technologies (AT) will ignore it and not present anything to the user.
+
+- [WCAG 1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html#examples)
+
 ## Rule Details
 
 Examples of **incorrect** code for this rule:
 
 ```js
-html` <img src="${src}" /> `;
+html`
+  <img src="${src}" />
+  <div role="img"></div>
+`;
 ```
 
 Examples of **correct** code for this rule:
@@ -16,12 +25,20 @@ Examples of **correct** code for this rule:
 html`
   <img src="${src}" alt="" />
 
+  <img src="${src}" aria-hidden="true" />
+
   <img src="${src}" alt="foo" />
 
   <img src="${src}" aria-label="foo" />
 
-  <label id="label>foo</label>
+  <label id="label">foo</label>
   <img src="${src}" aria-labelledby="label" />
+
+  <div role="img" aria-label="foo"></div>
+
+  <div role="img" aria-labelledBy="label"></div>
+
+  <div role="img" aria-hidden="true"></div>
 `;
 ```
 

--- a/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
@@ -13,11 +13,16 @@ html` <img src="${src}" /> `;
 Examples of **correct** code for this rule:
 
 ```js
-html` <img src="${src}" alt="" /> `;
-```
+html`
+  <img src="${src}" alt="" />
 
-```js
-html` <img src="${src}" alt="foo" /> `;
+  <img src="${src}" alt="foo" />
+
+  <img src="${src}" aria-label="foo" />
+
+  <label id="label>foo</label>
+  <img src="${src}" aria-labelledby="label" />
+`;
 ```
 
 ## Further Reading

--- a/packages/eslint-plugin-lit-a11y/lib/index.js
+++ b/packages/eslint-plugin-lit-a11y/lib/index.js
@@ -20,7 +20,7 @@ module.exports.configs = {
   recommended: {
     plugins: ['lit-a11y'],
     rules: {
-      'lit-a11y/accessible-emoji': 'error',
+      'lit-a11y/accessible-emoji': 'off',
       'lit-a11y/alt-text': 'error',
       'lit-a11y/anchor-has-content': 'error',
       'lit-a11y/anchor-is-valid': 'error',

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -6,7 +6,6 @@
 const emojiRegex = require('emoji-regex');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isTextNode } = require('../../template-analyzer/util.js');
-const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 
@@ -18,10 +17,15 @@ const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const AccessibleEmojiRule = {
   meta: {
     type: 'suggestion',
+    deprecated: true,
     docs: {
       description: 'Enforce emojis are wrapped in <span> and provide screenreader access.',
       category: 'Accessibility',
       recommended: false,
+    },
+    messages: {
+      wrapEmoji:
+        'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
     },
     fixable: null,
     schema: [],
@@ -62,19 +66,12 @@ const AccessibleEmojiRule = {
               const rolePropValue = element.attribs.role;
               const ariaLabelProp = element.attribs['aria-label'];
               const ariaLabelledByProp = element.attribs['aria-labelledby'];
-              const hasLabel =
-                ariaLabelProp !== undefined ||
-                ariaLabelledByProp !== undefined ||
-                elementHasAttribute(element, 'alt');
+              const hasLabel = ariaLabelProp !== undefined || ariaLabelledByProp !== undefined;
               const isSpan = element.name === 'span';
 
               if (hasLabel === false || rolePropValue !== 'img' || isSpan === false) {
                 const loc = analyzer.getLocationFor(element);
-                context.report({
-                  loc,
-                  message:
-                    'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-                });
+                context.report({ loc, messageId: 'wrapEmoji' });
               }
             },
           });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -6,6 +6,7 @@
 const emojiRegex = require('emoji-regex');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isTextNode } = require('../../template-analyzer/util.js');
+const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 
@@ -60,8 +61,11 @@ const AccessibleEmojiRule = {
 
               const rolePropValue = element.attribs.role;
               const ariaLabelProp = element.attribs['aria-label'];
-              const arialLabelledByProp = element.attribs['aria-labelledby'];
-              const hasLabel = ariaLabelProp !== undefined || arialLabelledByProp !== undefined;
+              const ariaLabelledByProp = element.attribs['aria-labelledby'];
+              const hasLabel =
+                ariaLabelProp !== undefined ||
+                ariaLabelledByProp !== undefined ||
+                elementHasAttribute(element, 'alt');
               const isSpan = element.name === 'span';
 
               if (hasLabel === false || rolePropValue !== 'img' || isSpan === false) {
@@ -69,7 +73,7 @@ const AccessibleEmojiRule = {
                 context.report({
                   loc,
                   message:
-                    'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+                    'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
                 });
               }
             },

--- a/packages/eslint-plugin-lit-a11y/lib/utils/elementHasAttribute.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/elementHasAttribute.js
@@ -7,6 +7,16 @@ function elementHasAttribute(element, attr) {
   return Object.keys(element.attribs).includes(attr);
 }
 
+/**
+ * Does the element have the attribute?
+ * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+ * @param {string[]} attrs
+ */
+function elementHasSomeAttribute(element, attrs) {
+  return attrs.some(elementHasAttribute.bind(attrs, element));
+}
+
 module.exports = {
   elementHasAttribute,
+  elementHasSomeAttribute,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
@@ -1,3 +1,8 @@
+/**
+ * Do the parameters describe an element that's hidden from the screen-reader?
+ * @param {string} type element tagName (e.g. element.name)
+ * @param {*} attributes element attributes object (e.g. element.attribs)
+ */
 const isHiddenFromScreenReader = (type, attributes) => {
   if (type.toUpperCase() === 'INPUT') {
     const hidden = attributes.type;
@@ -11,6 +16,16 @@ const isHiddenFromScreenReader = (type, attributes) => {
   return ariaHidden === 'true' || ariaHidden === '';
 };
 
+/**
+ * Is the element hidden from the screen-reader?
+ * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+ * @return {boolean}
+ */
+function elementIsHiddenFromScreenReader(element) {
+  return isHiddenFromScreenReader(element.type, element.attribs);
+}
+
 module.exports = {
   isHiddenFromScreenReader,
+  elementIsHiddenFromScreenReader,
 };

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
@@ -27,6 +27,7 @@ ruleTester.run('accessible-emoji', rule, {
     { code: 'html`<div>asdf</div>`' },
     { code: 'html`<span></span>`' },
     { code: 'html`<span>No emoji here!</span>`' },
+    { code: 'html`<span role="img" alt="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Snowman">&#9731;</span>`' },
     { code: 'html`<span role="img" aria-labelledby="id1">🐼</span>`' },
@@ -45,7 +46,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -54,7 +55,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -63,7 +64,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -72,7 +73,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -81,7 +82,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -90,7 +91,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
@@ -27,7 +27,6 @@ ruleTester.run('accessible-emoji', rule, {
     { code: 'html`<div>asdf</div>`' },
     { code: 'html`<span></span>`' },
     { code: 'html`<span>No emoji here!</span>`' },
-    { code: 'html`<span role="img" alt="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Snowman">&#9731;</span>`' },
     { code: 'html`<span role="img" aria-labelledby="id1">🐼</span>`' },
@@ -43,57 +42,31 @@ ruleTester.run('accessible-emoji', rule, {
   invalid: [
     {
       code: 'html`<span>🐼</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<span>foo🐼bar</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<span>foo 🐼 bar</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<i role="img" aria-label="Panda face">🐼</i>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<i role="img" aria-labelledby="id1">🐼</i>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<span aria-hidden="false">🐼</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
+    },
+    {
+      code: 'html`<span role="img" alt="Panda face">🐼</span>`',
+      errors: [{ messageId: 'wrapEmoji' }],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
@@ -25,7 +25,9 @@ ruleTester.run('alt-text', rule, {
     { code: "html`<img alt=''/>`" },
     { code: "html`<img alt='foo'/>`" },
     { code: "html`<img alt='${foo}'/>`" },
-    { code: "html`<div role='img' alt='foo'/>`" },
+    { code: "html`<div role='img' alt='foo'></div>`" },
+    { code: "html`<div role='img' aria-label='foo'></div>`" },
+    { code: "html`<label id=\"foo\">foo</label><div role='img' aria-labelledby='foo'></div>`" },
     { code: "html`<img role='presentation'/>`" },
   ],
 
@@ -39,10 +41,11 @@ ruleTester.run('alt-text', rule, {
       ],
     },
     {
-      code: "html`<div role='img'/>`",
+      code: "html`<div role='img'></div>`",
       errors: [
         {
-          message: 'role="img" elements must have an alt attribute.',
+          message:
+            "elements with role 'img' must have an alt, aria-label, or aria-labelledby attribute.",
         },
       ],
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
@@ -20,13 +20,17 @@ const ruleTester = new RuleTester({
     ecmaVersion: 2015,
   },
 });
+
+const roleImgAttrs = 'aria-label or aria-labelledby';
+
 ruleTester.run('alt-text', rule, {
   valid: [
     { code: "html`<img alt=''/>`" },
+    { code: 'html`<img aria-hidden="true"/>`' },
     { code: "html`<img alt='foo'/>`" },
     { code: "html`<img alt='${foo}'/>`" },
-    { code: "html`<div role='img' alt='foo'></div>`" },
     { code: "html`<div role='img' aria-label='foo'></div>`" },
+    { code: 'html`<div role=\'img\' aria-hidden="true"></div>`' },
     { code: "html`<label id=\"foo\">foo</label><div role='img' aria-labelledby='foo'></div>`" },
     { code: "html`<img role='presentation'/>`" },
   ],
@@ -36,7 +40,7 @@ ruleTester.run('alt-text', rule, {
       code: "html`<img src='./myimg.png'/>`",
       errors: [
         {
-          message: '<img> elements must have an alt attribute.',
+          messageId: 'imgAttrs',
         },
       ],
     },
@@ -44,8 +48,23 @@ ruleTester.run('alt-text', rule, {
       code: "html`<div role='img'></div>`",
       errors: [
         {
-          message:
-            "elements with role 'img' must have an alt, aria-label, or aria-labelledby attribute.",
+          messageId: 'roleImgAttrs',
+          data: {
+            role: 'img',
+            attrs: roleImgAttrs,
+          },
+        },
+      ],
+    },
+    {
+      code: "html`<div role='img' alt='foo'></div>`",
+      errors: [
+        {
+          messageId: 'roleImgAttrs',
+          data: {
+            role: 'img',
+            attrs: roleImgAttrs,
+          },
         },
       ],
     },


### PR DESCRIPTION
allows
```js
html`
  <div role="img" aria-label="foo"></div>
  <div role="img" aria-labelledby="label"></div>
`;
```
also allows
```js
html`
  <span role="img" alt="Panda">🐼</span>
`
```