### PR TITLE
fix(eslint-plugin-lit-a11y): refactors and fixes rules

### DIFF
--- a/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
@@ -25,6 +25,10 @@ html` <span role="img" aria-label="Panda face">🐼</span> `;
 ```
 
 ```js
+html` <span role="img" alt="Panda face">🐼</span> `;
+```
+
+```js
 html`
   <label id="label">Clown</label>
   <span role="img" aria-labelledby="label">🤡</span>

--- a/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md
@@ -4,6 +4,8 @@
 
 - [Léonie Watson](https://tink.uk/accessible-emoji/)
 
+While many modern user agents are able to announce emoji to screen reader users, this rule is still useful for apps targetting older user agents.
+
 ## Rule Details
 
 This rule aims to prevent inaccessible use of emoji in lit-html templates.
@@ -37,7 +39,7 @@ html`
 
 ## When Not To Use It
 
-If you do not use emoji in your lit-html templates.
+If you exclusively target modern user agents which explicitly support emoji in plain text, or if you do not use emoji in your lit-html templates.
 
 ## Further Reading
 

--- a/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
@@ -2,12 +2,21 @@
 
 Enforce that all elements that require alternative text have meaningful information to relay back to the end user. This is a critical component of accessibility for screen reader users in order for them to understand the content's purpose on the page. By default, this rule checks for alternative text on `<img>` elements.
 
+This rule also permits images which are completely removed from the <acronym>AOM (Accessibility Object Model)</acronym>:
+
+> **Sometimes there is non-text content that really is not meant to be seen or understood by the user.** Transparent images used to move text over on a page; an invisible image that is used to track usage statistics; and a swirl in the corner that conveys no information but just fills up a blank space to create an aesthetic effect are all examples of this. Putting alternative text on such items just distracts people using screen readers from the content on the page. Not marking the content in any way, though, leaves users guessing what the non-text content is and what information they may have missed (even though they have not missed anything in reality). This type of non-text content, therefore, is marked or implemented in a way that assistive technologies (AT) will ignore it and not present anything to the user.
+
+- [WCAG 1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html#examples)
+
 ## Rule Details
 
 Examples of **incorrect** code for this rule:
 
 ```js
-html` <img src="${src}" /> `;
+html`
+  <img src="${src}" />
+  <div role="img"></div>
+`;
 ```
 
 Examples of **correct** code for this rule:
@@ -16,12 +25,20 @@ Examples of **correct** code for this rule:
 html`
   <img src="${src}" alt="" />
 
+  <img src="${src}" aria-hidden="true" />
+
   <img src="${src}" alt="foo" />
 
   <img src="${src}" aria-label="foo" />
 
-  <label id="label>foo</label>
+  <label id="label">foo</label>
   <img src="${src}" aria-labelledby="label" />
+
+  <div role="img" aria-label="foo"></div>
+
+  <div role="img" aria-labelledBy="label"></div>
+
+  <div role="img" aria-hidden="true"></div>
 `;
 ```
 

--- a/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md
@@ -13,11 +13,16 @@ html` <img src="${src}" /> `;
 Examples of **correct** code for this rule:
 
 ```js
-html` <img src="${src}" alt="" /> `;
-```
+html`
+  <img src="${src}" alt="" />
 
-```js
-html` <img src="${src}" alt="foo" /> `;
+  <img src="${src}" alt="foo" />
+
+  <img src="${src}" aria-label="foo" />
+
+  <label id="label>foo</label>
+  <img src="${src}" aria-labelledby="label" />
+`;
 ```
 
 ## Further Reading

--- a/packages/eslint-plugin-lit-a11y/docs/rules/click-events-have-key-events.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/click-events-have-key-events.md
@@ -4,19 +4,6 @@ Enforce `@click` is accompanied by at least one of `@keyup`, `@keydown`, or `@ke
 
 ## Rule Details
 
-```json
-{
-  "rules": {
-    "lit-a11y/click-events-have-key-events": [
-      "error",
-      {
-        "allowList": ["foo-button"]
-      }
-    ]
-  }
-}
-```
-
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -31,6 +18,36 @@ html` <button @click="${onClick}"></button> `;
 
 ```js
 html` <div @click="${onClick}" @keyup="${onKeyup}"></div> `;
+```
+
+### Options
+
+The `allowList` option lets you specify tag names to exclude from this rule. the `allowCustomElements` option (true by default) excludes all custom-elements from this rule.
+
+```json
+{
+  "rules": {
+    "lit-a11y/click-events-have-key-events": [
+      "error",
+      {
+        "allowList": ["foo-button"],
+        "allowCustomElements": false
+      }
+    ]
+  }
+}
+```
+
+Examples of **incorrect** code with `allowCustomElements: false`:
+
+```js
+html` <custom-element @click="${onClick}"></custom-element> `;
+```
+
+Examples of **correct** code with `allowCustomElements: false, allowList: ['custom-element']`:
+
+```js
+html` <custom-element @click="${onClick}"></custom-element> `;
 ```
 
 ## Further Reading

--- a/packages/eslint-plugin-lit-a11y/docs/rules/heading-has-content.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/heading-has-content.md
@@ -35,6 +35,78 @@ html`
 `;
 ```
 
+### Options
+
+The `customHeadingElements` option lets you specify tag names to include in this rule, for example, if you have a custom element which implements heading semantics.
+
+```js
+customElements.define(
+  'custom-heading',
+  class CustomHeading extends HTMLElement {
+    static get observedAttributes() {
+      return ['level'];
+    }
+
+    get level() {
+      const parsed = parseInt(this.getAttribute('level'));
+      if (!Number.isNaN(parsed)) return parsed;
+      else return null;
+    }
+
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+    }
+
+    connectedCallback() {
+      this.render();
+    }
+
+    attributeChangedCallback() {
+      if (typeof this.level === 'number') this.render();
+    }
+
+    render() {
+      const heading = `h${this.level}`;
+      this.shadowRoot.innerHTML = `
+      <${heading}>
+        <slot></slot>
+      </${heading}>
+    `;
+    }
+  },
+);
+```
+
+```json
+{
+  "rules": {
+    "lit-a11y/heading-has-content": [
+      "error",
+      {
+        "customHeadingElements": ["custom-heading"]
+      }
+    ]
+  }
+}
+```
+
+Examples of **incorrect** code with `customHeadingElements: ["custom-heading"]`:
+
+```js
+html` <custom-heading></custom-heading> `;
+```
+
+Examples of **incorrect** code with `customHeadingElements: ["custom-heading"]`:
+
+```js
+html`
+  <custom-heading>Heading</custom-heading>
+  <custom-heading><span>Heading</span></custom-heading>
+  <custom-heading>${foo}</custom-heading>
+`;
+```
+
 ## Further Reading
 
 - [WCAG 2.4.6](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)

--- a/packages/eslint-plugin-lit-a11y/docs/rules/mouse-events-have-key-events.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/mouse-events-have-key-events.md
@@ -7,21 +7,49 @@ Enforce `@mouseover`/`@mouseout` are accompanied by `@focus`/`@blur`. Coding for
 Examples of **incorrect** code for this rule:
 
 ```js
-html` <button @mouseout="${onMouseout}"></button> `;
-```
-
-```js
-html` <button @mouseover="${onMouseover}"></button> `;
+html`
+  <button @mouseout="${onMouseout}"></button>
+  <button @mouseover="${onMouseover}"></button>
+`;
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-html` <button @mouseout="${onMouseout}" @blur="${onBlur}"></button> `;
+html`
+  <button @mouseout="${onMouseout}" @blur="${onBlur}"></button>
+  <button @mouseover="${onMouseover}" @blur="${onBlur}"></button>
+`;
 ```
 
+### Options
+
+The `allowList` option lets you specify tag names to exclude from this rule. the `allowCustomElements` option (true by default) excludes all custom-elements from this rule.
+
+```json
+{
+  "rules": {
+    "lit-a11y/click-events-have-key-events": [
+      "error",
+      {
+        "allowList": ["foo-button"],
+        "allowCustomElements": false
+      }
+    ]
+  }
+}
+```
+
+Examples of **incorrect** code with `allowCustomElements: false`:
+
 ```js
-html` <button @mouseover="${onMouseover}" @blur="${onBlur}"></button> `;
+html` <custom-element @mouseout="${onClick}"></custom-element> `;
+```
+
+Examples of **correct** code with `allowCustomElements: false, allowList: ['custom-element']`:
+
+```js
+html` <custom-element @mouseout="${onClick}"></custom-element> `;
 ```
 
 ## Further Reading

--- a/packages/eslint-plugin-lit-a11y/docs/rules/no-autofocus.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/no-autofocus.md
@@ -7,16 +7,21 @@ Enforce that autofocus attribute is not used on elements. Autofocusing elements 
 Examples of **incorrect** code for this rule:
 
 ```js
-html` <div autofocus></div> `;
-html` <div autofocus="true"></div> `;
-html` <div autofocus="false"></div> `;
-html` <div autofocus=${foo}></div> `;
+html`
+  <input autofocus />
+  <input autofocus="true" />
+  <input autofocus="false" />
+  <input autofocus=${foo} />
+  <input .autofocus=${foo} />
+  <input .autofocus=${true} />
+  <input .autofocus=${false} />
+`;
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-html` <div></div> `;
+html` <input /> `;
 ```
 
 ### Resources

--- a/packages/eslint-plugin-lit-a11y/lib/index.js
+++ b/packages/eslint-plugin-lit-a11y/lib/index.js
@@ -20,7 +20,7 @@ module.exports.configs = {
   recommended: {
     plugins: ['lit-a11y'],
     rules: {
-      'lit-a11y/accessible-emoji': 'error',
+      'lit-a11y/accessible-emoji': 'off',
       'lit-a11y/alt-text': 'error',
       'lit-a11y/anchor-has-content': 'error',
       'lit-a11y/anchor-is-valid': 'error',

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -21,6 +21,8 @@ const AccessibleEmojiRule = {
       description: 'Enforce emojis are wrapped in <span> and provide screenreader access.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/accessible-emoji.md',
     },
     messages: {
       wrapEmoji:
@@ -58,7 +60,7 @@ const AccessibleEmojiRule = {
                 return; // element has no emoji text content
               }
 
-              if (isHiddenFromScreenReader(element.name, element.attribs)) {
+              if (isHiddenFromScreenReader(element)) {
                 return; // emoji is decorative
               }
 

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -6,6 +6,7 @@
 const emojiRegex = require('emoji-regex');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isTextNode } = require('../../template-analyzer/util.js');
+const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 
@@ -60,8 +61,11 @@ const AccessibleEmojiRule = {
 
               const rolePropValue = element.attribs.role;
               const ariaLabelProp = element.attribs['aria-label'];
-              const arialLabelledByProp = element.attribs['aria-labelledby'];
-              const hasLabel = ariaLabelProp !== undefined || arialLabelledByProp !== undefined;
+              const ariaLabelledByProp = element.attribs['aria-labelledby'];
+              const hasLabel =
+                ariaLabelProp !== undefined ||
+                ariaLabelledByProp !== undefined ||
+                elementHasAttribute(element, 'alt');
               const isSpan = element.name === 'span';
 
               if (hasLabel === false || rolePropValue !== 'img' || isSpan === false) {
@@ -69,7 +73,7 @@ const AccessibleEmojiRule = {
                 context.report({
                   loc,
                   message:
-                    'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+                    'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
                 });
               }
             },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -6,7 +6,6 @@
 const emojiRegex = require('emoji-regex');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isTextNode } = require('../../template-analyzer/util.js');
-const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 
@@ -22,6 +21,10 @@ const AccessibleEmojiRule = {
       description: 'Enforce emojis are wrapped in <span> and provide screenreader access.',
       category: 'Accessibility',
       recommended: false,
+    },
+    messages: {
+      wrapEmoji:
+        'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
     },
     fixable: null,
     schema: [],
@@ -62,19 +65,12 @@ const AccessibleEmojiRule = {
               const rolePropValue = element.attribs.role;
               const ariaLabelProp = element.attribs['aria-label'];
               const ariaLabelledByProp = element.attribs['aria-labelledby'];
-              const hasLabel =
-                ariaLabelProp !== undefined ||
-                ariaLabelledByProp !== undefined ||
-                elementHasAttribute(element, 'alt');
+              const hasLabel = ariaLabelProp !== undefined || ariaLabelledByProp !== undefined;
               const isSpan = element.name === 'span';
 
               if (hasLabel === false || rolePropValue !== 'img' || isSpan === false) {
                 const loc = analyzer.getLocationFor(element);
-                context.report({
-                  loc,
-                  message:
-                    'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-                });
+                context.report({ loc, messageId: 'wrapEmoji' });
               }
             },
           });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
@@ -5,7 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { elementHasAttribute, elementHasSomeAttribute } = require('../utils/elementHasAttribute.js');
-const { elementIsHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
+const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 
 if (!('ListFormat' in Intl)) {
@@ -30,6 +30,8 @@ const AltTextRule = {
       description: 'Images require alt text',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/alt-text.md',
     },
     messages: {
       roleImgAttrs: "elements with role '{{role}}' must have an {{attrs}} attribute.",
@@ -55,7 +57,7 @@ const AltTextRule = {
       return (
         element.name === 'img' &&
         element.attribs.role !== 'presentation' &&
-        !elementIsHiddenFromScreenReader(element) &&
+        !isHiddenFromScreenReader(element) &&
         !elementHasAttribute(element, 'alt')
       );
     }
@@ -69,7 +71,7 @@ const AltTextRule = {
       return (
         element.name !== 'img' &&
         element.attribs.role === 'img' &&
-        !elementIsHiddenFromScreenReader(element) &&
+        !isHiddenFromScreenReader(element) &&
         !elementHasSomeAttribute(element, ALT_ATTRS)
       );
     }

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-has-content.js
@@ -18,6 +18,8 @@ const AnchorHasContentRule = {
       description: 'Enforce anchor elements to contain accessible content.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/anchor-has-content.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
@@ -15,19 +15,6 @@ const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 /** @type {['noHref', 'invalidHref', 'preferButton']} */
 const allAspects = ['noHref', 'invalidHref', 'preferButton'];
 
-const preferButtonErrorMessage =
-  'Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
-
-const noHrefErrorMessage =
-  'The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
-
-const invalidHrefErrorMessage =
-  'The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
-
-const schema = generateObjSchema({
-  aspects: enumArraySchema(allAspects, 1),
-});
-
 /** @type {import("eslint").Rule.RuleModule} */
 const AnchorIsValidRule = {
   meta: {
@@ -36,9 +23,23 @@ const AnchorIsValidRule = {
       description: 'anchor-is-valid',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/anchor-is-valid.md',
+    },
+    messages: {
+      preferButtonErrorMessage:
+        'Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead.',
+      noHrefErrorMessage:
+        'The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles.',
+      invalidHrefErrorMessage:
+        'The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles.',
     },
     fixable: null,
-    schema: [schema],
+    schema: [
+      generateObjSchema({
+        aspects: enumArraySchema(allAspects, 1),
+      }),
+    ],
   },
 
   create(context) {
@@ -76,19 +77,13 @@ const AnchorIsValidRule = {
                     (!hasClickListener || (hasClickListener && !activeAspects.preferButton))
                   ) {
                     const loc = analyzer.getLocationFor(element);
-                    context.report({
-                      loc,
-                      message: noHrefErrorMessage,
-                    });
+                    context.report({ loc, messageId: 'noHrefErrorMessage' });
                   }
 
                   // If no spread operator is found but a click handler is preset it should be a button.
                   if (hasClickListener && activeAspects.preferButton) {
                     const loc = analyzer.getLocationFor(element);
-                    context.report({
-                      loc,
-                      message: preferButtonErrorMessage,
-                    });
+                    context.report({ loc, messageId: 'preferButtonErrorMessage' });
                   }
                   return;
                 }
@@ -104,16 +99,10 @@ const AnchorIsValidRule = {
                   // If a click handler is found it should be a button, otherwise it is an invalid link.
                   if (hasClickListener && activeAspects.preferButton) {
                     const loc = analyzer.getLocationFor(element);
-                    context.report({
-                      loc,
-                      message: preferButtonErrorMessage,
-                    });
+                    context.report({ loc, messageId: 'preferButtonErrorMessage' });
                   } else if (activeAspects.invalidHref) {
                     const loc = analyzer.getLocationFor(element);
-                    context.report({
-                      loc,
-                      message: invalidHrefErrorMessage,
-                    });
+                    context.report({ loc, messageId: 'invalidHrefErrorMessage' });
                   }
                 }
               }

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
@@ -18,6 +18,8 @@ const AriaActiveDescendantHasTabindexRule = {
       description: 'Enforce elements with aria-activedescendant are tabbable.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/aria-activedescendant-has-tabindex.md',
     },
     fixable: null,
     schema: [],
@@ -44,7 +46,7 @@ const AriaActiveDescendantHasTabindexRule = {
               // If this is an interactive element and the tabindex attribute is not specified,
               // or the tabIndex property was not mutated, then the tabIndex
               // property will be undefined.
-              if (isInteractiveElement(element.name, element.attribs) && tabindex === undefined) {
+              if (isInteractiveElement(element) && tabindex === undefined) {
                 return;
               }
 

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
@@ -101,6 +101,8 @@ const AriaAttrTypesRule = {
       description: 'aria-attr-valid-value',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/aria-attr-valid-value.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
@@ -19,6 +19,8 @@ const AriaAttrsRule = {
       description: 'Elements cannot use an invalid ARIA attribute.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/aria-attrs.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -21,6 +21,8 @@ const AriaRoleRule = {
       description: 'aria-role',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/aria-role.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
@@ -21,6 +21,8 @@ const AriaUnsupportedElementsRule = {
         'Certain reserved DOM elements do not support ARIA roles, states and properties.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/aria-unsupported-elements.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
@@ -20,6 +20,8 @@ const AutocompleteValidRule = {
       description: 'Ensure autocomplete attribute is correct.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/autocomplete-valid.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
@@ -4,11 +4,9 @@
  */
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
-const { isAriaHidden } = require('../utils/aria.js');
-const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
-const { isInteractiveElement } = require('../utils/isInteractiveElement.js');
+const { isIncludedInAOM } = require('../utils/isIncludedInAOM.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
-const { isPresentationRole } = require('../utils/isPresentationRole.js');
+const { isNonInteractiveElement } = require('../utils/isNonInteractiveElement.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -22,17 +20,33 @@ const ClickEventsHaveKeyEventsRule = {
       description: 'click-events-have-key-events',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/click-events-have-key-events.md',
+    },
+    messages: {
+      clickableNonInteractiveElements:
+        'Clickable non-interactive elements must have at least 1 keyboard event listener',
     },
     fixable: null,
     schema: [
       {
         allowList: {
           type: 'array',
-          items: {
-            type: 'string',
-          },
+          description:
+            'list of tag names which are permitted to have click listeners without key listeners',
+          default: [],
           uniqueItems: true,
           additionalItems: false,
+          items: {
+            type: 'string',
+            pattern: '^[a-z]\\w+-\\w+',
+          },
+        },
+        allowCustomElements: {
+          type: 'boolean',
+          description:
+            'When true, permits all custom elements to have click listeners without key listeners',
+          default: true,
         },
       },
     ],
@@ -63,27 +77,18 @@ const ClickEventsHaveKeyEventsRule = {
 
           analyzer.traverse({
             enterElement(element) {
-              const allowListOptions =
-                (context.options && context.options[0] && context.options[0].allowList) || [];
+              const options = (context.options && context.options[0]) || {};
 
               if (
-                !hasClickListener(element) || // not clickable
-                isHiddenFromScreenReader(element.name, element.attribs) || // excluded from AOM
-                isPresentationRole(element.attribs) || // excluded from AOM
-                isAriaHidden(element) || // excluded from AOM
-                hasKeyboardListener(element) || // has keyboard listeners
-                isInteractiveElement(element.name, element.attribs) || // keyboard-accesible by default
-                allowListOptions.includes(element.name) // button-like custom-elements allow list
+                hasClickListener(element) &&
+                !hasKeyboardListener(element) && // doesn't keyboard listeners
+                isIncludedInAOM(element) &&
+                isNonInteractiveElement(element, options)
               ) {
-                return;
+                const loc = analyzer.getLocationFor(element);
+
+                context.report({ loc, messageId: 'clickableNonInteractiveElements' });
               }
-
-              const loc = analyzer.getLocationFor(element);
-
-              const message =
-                'Clickable non-interactive elements must have at least 1 keyboard event listener';
-
-              context.report({ loc, message });
             },
           });
         }

--- a/packages/eslint-plugin-lit-a11y/lib/rules/heading-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/heading-has-content.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { hasAccessibleChildren } = require('../utils/hasAccessibleChildren.js');
+const { isCustomElement } = require('../utils/isCustomElement.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 
@@ -22,33 +23,62 @@ const HeadingHasContentRule = {
       description: 'Enforce heading (h1, h2, etc) elements contain accessible content.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/heading-has-content.md',
+    },
+    messages: {
+      headingHasContent: '<{{tagName}}> elements must have accessible content.',
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        customHeadingElements: {
+          type: 'array',
+          description: 'list of custom elements tag names which should be considered headings',
+          default: [],
+          uniqueItems: true,
+          additionalItems: false,
+          items: {
+            type: 'string',
+            pattern: '^[a-z]\\w+-\\w+',
+          },
+        },
+      },
+    ],
   },
   create(context) {
+    /**
+     * Is it a heading element?
+     * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+     * @param {string[]} customHeadingElements list of custom elements tag names which should be considered headings
+     * @return {boolean}
+     */
+    function isHeading(element, customHeadingElements = []) {
+      if (isCustomElement(element)) return customHeadingElements.includes(element.name);
+      return headings.includes(element.name);
+    }
+
     return {
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node)) {
           const analyzer = TemplateAnalyzer.create(node);
 
+          const options = (context.options && context.options[0]) || {};
+
           analyzer.traverse({
             enterElement(element) {
-              if (headings.includes(element.name)) {
-                if (
-                  hasAccessibleChildren(element) ||
-                  isHiddenFromScreenReader(element.name, element.attribs)
-                ) {
-                  return;
-                }
-
+              if (
+                isHeading(element, options.customHeadingElements) &&
+                !hasAccessibleChildren(element) &&
+                !isHiddenFromScreenReader(element)
+              ) {
                 const loc = analyzer.getLocationFor(element);
 
-                const message = `<{{tagName}}> elements must have accessible content.`;
+                const messageId = 'headingHasContent';
 
                 const data = { tagName: element.name };
 
-                context.report({ loc, message, data });
+                context.report({ loc, messageId, data });
               }
             },
           });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
@@ -18,11 +18,25 @@ const IframeTitleRule = {
       description: '<iframe> elements must have a unique title property.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/iframe-title.md',
+    },
+    messages: {
+      iframeTitle: '<iframe> elements must have a unique title property.',
     },
     fixable: null,
     schema: [],
   },
   create(context) {
+    /**
+     * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+     */
+    function isUntitledIframe(element) {
+      return (
+        element.name === 'iframe' && (!element.attribs.title || element.attribs.title === undefined)
+      );
+    }
+
     return {
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node)) {
@@ -30,15 +44,9 @@ const IframeTitleRule = {
 
           analyzer.traverse({
             enterElement(element) {
-              if (
-                element.name === 'iframe' &&
-                (!Object.keys(element.attribs).includes('title') || element.attribs.title === '')
-              ) {
+              if (isUntitledIframe(element)) {
                 const loc = analyzer.getLocationFor(element);
-                context.report({
-                  loc,
-                  message: '<iframe> elements must have a unique title property.',
-                });
+                context.report({ loc, messageId: 'iframeTitle' });
               }
             },
           });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
@@ -33,12 +33,19 @@ const ImgRedundantAltRule = {
       description: 'Enforce img alt attribute does not contain the word image, picture, or photo.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/img-redundant-alt.md',
+    },
+    messages: {
+      imgRedundantAlt:
+        '<img> alt attribute must be descriptive; it cannot contain the banned {{plural}} {{formatted}}.',
     },
     fixable: null,
     schema: [
       {
         keywords: {
           type: 'array',
+          default: DEFAULT_KEYWORDS,
           items: {
             type: 'string',
           },
@@ -78,14 +85,13 @@ const ImgRedundantAltRule = {
               );
 
               if (contraband.length > 0) {
-                const formatted = formatter.format(contraband);
+                const banned = formatter.format(contraband);
                 const loc = analyzer.getLocationForAttribute(element, 'alt');
                 context.report({
                   loc,
-                  message:
-                    '<img> alt attribute must be descriptive; it cannot contain the banned {{plural}} {{formatted}}.',
+                  messageId: 'imgRedundantAlt',
                   data: {
-                    formatted,
+                    banned,
                     plural: contraband.length > 1 ? 'words' : 'word',
                   },
                 });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
@@ -18,6 +18,8 @@ const NoAccessKeyRule = {
       description: 'Enforce no accesskey attribute on element.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/no-access-key.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
@@ -15,9 +15,14 @@ const NoAutofocusRule = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforce that autoFocus prop is not used on elements.',
+      description: 'Enforce that autofocus attribute or property are not used on elements.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/no-autofocus.md',
+    },
+    messages: {
+      noAutofocus: 'The autofocus {{type}} is not allowed.',
     },
     fixable: null,
     schema: [],
@@ -35,7 +40,16 @@ const NoAutofocusRule = {
                 const loc = analyzer.getLocationForAttribute(element, 'autofocus');
                 context.report({
                   loc,
-                  message: 'The autofocus attribute is not allowed.',
+                  messageId: 'noAutofocus',
+                  data: { type: 'attribute' },
+                });
+              }
+              if ('.autofocus' in element.attribs) {
+                const loc = analyzer.getLocationForAttribute(element, '.autofocus');
+                context.report({
+                  loc,
+                  messageId: 'noAutofocus',
+                  data: { type: 'property' },
                 });
               }
             },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
@@ -20,6 +20,8 @@ const NoDistractingElementsRule = {
       description: 'Enforce distracting elements are not used.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/no-distracting-elements.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
@@ -20,6 +20,8 @@ const NoInvalidChangeHandlerRule = {
       description: 'Enforce usage of @blur over @change with <select> and <option>.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/no-invalid-change-handler.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
@@ -23,6 +23,8 @@ const NoRedundantRoleRule = {
         'Enforce explicit role property is not the same as implicit/default role property on element.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/no-redundant-role.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
@@ -31,6 +31,8 @@ const RoleHasRequiredAriaAttrsRule = {
         'Enforce that elements with ARIA roles must have all required attributes for that role.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/role-has-required-aria-attrs.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
@@ -21,6 +21,8 @@ const RoleSupportsAriaAttrRule = {
         'Enforce that elements with a defined role contain only supported ARIA attributes for that role.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/role-supports-aria-attrs.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
@@ -21,6 +21,8 @@ const ScopeRule = {
       description: 'Enforce scope prop is only used on <th> elements.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/scope.md',
     },
     fixable: null,
     schema: [],

--- a/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
@@ -19,6 +19,12 @@ const TabindexNoPositiveRule = {
       description: 'Enforce tabIndex value is not greater than zero.',
       category: 'Accessibility',
       recommended: false,
+      url:
+        'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/tabindex-no-positive.md',
+    },
+    messages: {
+      tabindexNoPositive: 'Invalid tabindex value {{val}}.',
+      avoidPositiveTabindex: 'Avoid positive tabindex.',
     },
     fixable: null,
     schema: [],
@@ -33,30 +39,25 @@ const TabindexNoPositiveRule = {
           analyzer.traverse({
             enterElement(element) {
               if (Object.keys(element.attribs).includes('tabindex')) {
-                const val = getAttrVal(element.attribs.tabindex);
+                const attributeValue = getAttrVal(element.attribs.tabindex);
 
-                if (val && val.startsWith('{{')) return;
+                if (attributeValue && attributeValue.startsWith('{{')) return;
 
-                const value = Number(val);
+                const value = Number(attributeValue);
 
                 if (Number.isNaN(value)) {
                   const loc = analyzer.getLocationForAttribute(element, 'tabindex');
                   context.report({
                     loc,
-                    message: `Invalid tabindex value {{val}}.`,
-                    data: {
-                      val,
-                    },
+                    messageId: 'tabindexNoPositive',
+                    data: { val: attributeValue },
                   });
                   return;
                 }
 
                 if (value > 0) {
                   const loc = analyzer.getLocationForAttribute(element, 'tabindex');
-                  context.report({
-                    loc,
-                    message: `Avoid positive tabindex.`,
-                  });
+                  context.report({ loc, messageId: 'avoidPositiveTabindex' });
                 }
               }
             },

--- a/packages/eslint-plugin-lit-a11y/lib/utils/elementHasAttribute.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/elementHasAttribute.js
@@ -7,6 +7,16 @@ function elementHasAttribute(element, attr) {
   return Object.keys(element.attribs).includes(attr);
 }
 
+/**
+ * Does the element have the attribute?
+ * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+ * @param {string[]} attrs
+ */
+function elementHasSomeAttribute(element, attrs) {
+  return attrs.some(elementHasAttribute.bind(attrs, element));
+}
+
 module.exports = {
   elementHasAttribute,
+  elementHasSomeAttribute,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/hasAccessibleChildren.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/hasAccessibleChildren.js
@@ -1,9 +1,27 @@
 const { isHiddenFromScreenReader } = require('./isHiddenFromScreenReader.js');
 
+/**
+ * @param {import('parse5-htmlparser2-tree-adapter').Node} node
+ * @return {node is import("parse5-htmlparser2-tree-adapter").Element}
+ */
+function isElement(node) {
+  // NB: this isn't accurate, but suffices for use in `hasAccessibleChildren`.
+  return node.type !== 'text';
+}
+
+/**
+ * @param {import('parse5-htmlparser2-tree-adapter').Node} node
+ * @return {boolean}
+ */
+function isAccessibleChild(node) {
+  return node.type === 'text' || (isElement(node) && !isHiddenFromScreenReader(node));
+}
+
+/**
+ * @param {import('parse5-htmlparser2-tree-adapter').Element} element
+ */
 function hasAccessibleChildren(element) {
-  return element.children.some(
-    el => el.type === 'text' || !isHiddenFromScreenReader(el.name, el.attribs),
-  );
+  return element.children.some(isAccessibleChild);
 }
 
 module.exports = {

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isCustomElement.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isCustomElement.js
@@ -1,0 +1,13 @@
+const CE_TAGNAME_RE = /^[a-z]\w+-\w+/;
+
+/**
+ * Is the element a custom element (i.e. does it contain a '-')?
+ * @param {import('parse5-htmlparser2-tree-adapter').Element} element
+ */
+function isCustomElement(element) {
+  return !!(element && typeof element.name === 'string' && CE_TAGNAME_RE.test(element.name));
+}
+
+module.exports = {
+  isCustomElement,
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
@@ -1,3 +1,8 @@
+/**
+ * Do the parameters describe an element that's hidden from the screen-reader?
+ * @param {string} type element tagName (e.g. element.name)
+ * @param {*} attributes element attributes object (e.g. element.attribs)
+ */
 const isHiddenFromScreenReader = (type, attributes) => {
   if (type.toUpperCase() === 'INPUT') {
     const hidden = attributes.type;
@@ -11,6 +16,16 @@ const isHiddenFromScreenReader = (type, attributes) => {
   return ariaHidden === 'true' || ariaHidden === '';
 };
 
+/**
+ * Is the element hidden from the screen-reader?
+ * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+ * @return {boolean}
+ */
+function elementIsHiddenFromScreenReader(element) {
+  return isHiddenFromScreenReader(element.type, element.attribs);
+}
+
 module.exports = {
   isHiddenFromScreenReader,
+  elementIsHiddenFromScreenReader,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
@@ -18,16 +18,6 @@ function isHiddenFromScreenReader(element) {
   return ariaHidden === 'true' || ariaHidden === '';
 }
 
-/**
- * Is the element hidden from the screen-reader?
- * @param {import("parse5-htmlparser2-tree-adapter").Element} element
- * @return {boolean}
- */
-function elementIsHiddenFromScreenReader(element) {
-  return isHiddenFromScreenReader(element.type, element.attribs);
-}
-
 module.exports = {
   isHiddenFromScreenReader,
-  elementIsHiddenFromScreenReader,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isHiddenFromScreenReader.js
@@ -1,9 +1,11 @@
 /**
- * Do the parameters describe an element that's hidden from the screen-reader?
- * @param {string} type element tagName (e.g. element.name)
- * @param {*} attributes element attributes object (e.g. element.attribs)
+ * Is the element hidden from the screen-reader?
+ * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+ * @return {boolean}
  */
-const isHiddenFromScreenReader = (type, attributes) => {
+function isHiddenFromScreenReader(element) {
+  const type = element.name;
+  const attributes = element.attribs;
   if (type.toUpperCase() === 'INPUT') {
     const hidden = attributes.type;
 
@@ -14,18 +16,8 @@ const isHiddenFromScreenReader = (type, attributes) => {
 
   const ariaHidden = attributes['aria-hidden'];
   return ariaHidden === 'true' || ariaHidden === '';
-};
-
-/**
- * Is the element hidden from the screen-reader?
- * @param {import("parse5-htmlparser2-tree-adapter").Element} element
- * @return {boolean}
- */
-function elementIsHiddenFromScreenReader(element) {
-  return isHiddenFromScreenReader(element.type, element.attribs);
 }
 
 module.exports = {
   isHiddenFromScreenReader,
-  elementIsHiddenFromScreenReader,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isIncludedInAOM.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isIncludedInAOM.js
@@ -1,0 +1,19 @@
+const { isAriaHidden } = require('./aria.js');
+const { isHiddenFromScreenReader } = require('./isHiddenFromScreenReader.js');
+const { isPresentationRole } = require('./isPresentationRole.js');
+
+/**
+ * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+ * @return {boolean}
+ */
+function isIncludedInAOM(element) {
+  return (
+    !isHiddenFromScreenReader(element) &&
+    !isPresentationRole(element.attribs) &&
+    !isAriaHidden(element)
+  );
+}
+
+module.exports = {
+  isIncludedInAOM,
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isInteractiveElement.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isInteractiveElement.js
@@ -113,15 +113,14 @@ function checkIsInteractiveElement(tagName, attributes) {
  * interactive on the DOM or not. Usually used when an element
  * has a dynamic handler on it and we need to discern whether or not
  * it's intention is to be interacted with on the DOM.
+ * @param {import('parse5-htmlparser2-tree-adapter').Element} element
  */
-const isInteractiveElement = (tagName, attributes) => {
-  // Do not test higher level JSX components, as we do not know what
-  // low-level DOM element this maps to.
-  if (!domKeys.includes(tagName)) {
+const isInteractiveElement = element => {
+  if (!domKeys.includes(element.name)) {
     return false;
   }
 
-  return checkIsInteractiveElement(tagName, attributes);
+  return checkIsInteractiveElement(element.name, element.attribs);
 };
 
 module.exports = {

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isNonInteractiveElement.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isNonInteractiveElement.js
@@ -1,0 +1,21 @@
+const { isCustomElement } = require('./isCustomElement.js');
+const { isInteractiveElement } = require('./isInteractiveElement.js');
+
+/**
+ * @param {import("parse5-htmlparser2-tree-adapter").Element} element
+ * @return {boolean}
+ */
+function isNonInteractiveElement(element, options) {
+  if (!isCustomElement(element)) return !isInteractiveElement(element); // keyboard-accesible by default
+
+  // NOTE: nullish coalescing would be nice here
+  const allowCustomElements = 'allowCustomElements' in options ? options.allowCustomElements : true;
+
+  const allowList = options.allowList || [];
+
+  return !allowCustomElements && !allowList.includes(element.name);
+}
+
+module.exports = {
+  isNonInteractiveElement,
+};

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
@@ -27,6 +27,7 @@ ruleTester.run('accessible-emoji', rule, {
     { code: 'html`<div>asdf</div>`' },
     { code: 'html`<span></span>`' },
     { code: 'html`<span>No emoji here!</span>`' },
+    { code: 'html`<span role="img" alt="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Snowman">&#9731;</span>`' },
     { code: 'html`<span role="img" aria-labelledby="id1">🐼</span>`' },
@@ -45,7 +46,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -54,7 +55,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -63,7 +64,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -72,7 +73,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -81,7 +82,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },
@@ -90,7 +91,7 @@ ruleTester.run('accessible-emoji', rule, {
       errors: [
         {
           message:
-            'Emojis must either be wrapped in <span role="img"> with a label, or hidden from the AOM.',
+            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
         },
       ],
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
@@ -27,7 +27,6 @@ ruleTester.run('accessible-emoji', rule, {
     { code: 'html`<div>asdf</div>`' },
     { code: 'html`<span></span>`' },
     { code: 'html`<span>No emoji here!</span>`' },
-    { code: 'html`<span role="img" alt="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Panda face">🐼</span>`' },
     { code: 'html`<span role="img" aria-label="Snowman">&#9731;</span>`' },
     { code: 'html`<span role="img" aria-labelledby="id1">🐼</span>`' },
@@ -43,57 +42,31 @@ ruleTester.run('accessible-emoji', rule, {
   invalid: [
     {
       code: 'html`<span>🐼</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<span>foo🐼bar</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<span>foo 🐼 bar</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<i role="img" aria-label="Panda face">🐼</i>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<i role="img" aria-labelledby="id1">🐼</i>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
     },
     {
       code: 'html`<span aria-hidden="false">🐼</span>`',
-      errors: [
-        {
-          message:
-            'Emojis must either be wrapped in <span role="img"> with a label or alt attribute, or hidden from the AOM.',
-        },
-      ],
+      errors: [{ messageId: 'wrapEmoji' }],
+    },
+    {
+      code: 'html`<span role="img" alt="Panda face">🐼</span>`',
+      errors: [{ messageId: 'wrapEmoji' }],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
@@ -25,7 +25,9 @@ ruleTester.run('alt-text', rule, {
     { code: "html`<img alt=''/>`" },
     { code: "html`<img alt='foo'/>`" },
     { code: "html`<img alt='${foo}'/>`" },
-    { code: "html`<div role='img' alt='foo'/>`" },
+    { code: "html`<div role='img' alt='foo'></div>`" },
+    { code: "html`<div role='img' aria-label='foo'></div>`" },
+    { code: "html`<label id=\"foo\">foo</label><div role='img' aria-labelledby='foo'></div>`" },
     { code: "html`<img role='presentation'/>`" },
   ],
 
@@ -39,10 +41,11 @@ ruleTester.run('alt-text', rule, {
       ],
     },
     {
-      code: "html`<div role='img'/>`",
+      code: "html`<div role='img'></div>`",
       errors: [
         {
-          message: 'role="img" elements must have an alt attribute.',
+          message:
+            "elements with role 'img' must have an alt, aria-label, or aria-labelledby attribute.",
         },
       ],
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
@@ -20,13 +20,17 @@ const ruleTester = new RuleTester({
     ecmaVersion: 2015,
   },
 });
+
+const roleImgAttrs = 'aria-label or aria-labelledby';
+
 ruleTester.run('alt-text', rule, {
   valid: [
     { code: "html`<img alt=''/>`" },
+    { code: 'html`<img aria-hidden="true"/>`' },
     { code: "html`<img alt='foo'/>`" },
     { code: "html`<img alt='${foo}'/>`" },
-    { code: "html`<div role='img' alt='foo'></div>`" },
     { code: "html`<div role='img' aria-label='foo'></div>`" },
+    { code: 'html`<div role=\'img\' aria-hidden="true"></div>`' },
     { code: "html`<label id=\"foo\">foo</label><div role='img' aria-labelledby='foo'></div>`" },
     { code: "html`<img role='presentation'/>`" },
   ],
@@ -36,7 +40,7 @@ ruleTester.run('alt-text', rule, {
       code: "html`<img src='./myimg.png'/>`",
       errors: [
         {
-          message: '<img> elements must have an alt attribute.',
+          messageId: 'imgAttrs',
         },
       ],
     },
@@ -44,8 +48,23 @@ ruleTester.run('alt-text', rule, {
       code: "html`<div role='img'></div>`",
       errors: [
         {
-          message:
-            "elements with role 'img' must have an alt, aria-label, or aria-labelledby attribute.",
+          messageId: 'roleImgAttrs',
+          data: {
+            role: 'img',
+            attrs: roleImgAttrs,
+          },
+        },
+      ],
+    },
+    {
+      code: "html`<div role='img' alt='foo'></div>`",
+      errors: [
+        {
+          messageId: 'roleImgAttrs',
+          data: {
+            role: 'img',
+            attrs: roleImgAttrs,
+          },
         },
       ],
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/anchor-is-valid.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/anchor-is-valid.js
@@ -10,58 +10,6 @@
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/anchor-is-valid.js');
 
-const preferButtonErrorMessage =
-  'Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
-
-const noHrefErrorMessage =
-  'The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
-
-const invalidHrefErrorMessage =
-  'The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
-
-const preferButtonexpectedError = {
-  message: preferButtonErrorMessage,
-};
-
-const noHrefexpectedError = {
-  message: noHrefErrorMessage,
-};
-
-const invalidHrefexpectedError = {
-  message: invalidHrefErrorMessage,
-};
-
-const noHrefAspect = [
-  {
-    aspects: ['noHref'],
-  },
-];
-const invalidHrefAspect = [
-  {
-    aspects: ['invalidHref'],
-  },
-];
-const preferButtonAspect = [
-  {
-    aspects: ['preferButton'],
-  },
-];
-const noHrefInvalidHrefAspect = [
-  {
-    aspects: ['noHref', 'invalidHref'],
-  },
-];
-const noHrefPreferButtonAspect = [
-  {
-    aspects: ['noHref', 'preferButton'],
-  },
-];
-const preferButtonInvalidHrefAspect = [
-  {
-    aspects: ['preferButton', 'invalidHref'],
-  },
-];
-
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -94,165 +42,200 @@ ruleTester.run('anchor-is-valid', rule, {
     { code: 'html`<a href=${`#foo`} @click=${foo} />`' },
     { code: 'html`<a href="#foo" @click=${foo} />`' },
 
-    { code: 'html`<a href="" />;`', options: preferButtonAspect },
-    { code: 'html`<a href="#" />`', options: preferButtonAspect },
-    { code: 'html`<a href=${"#"} />`', options: preferButtonAspect },
-    { code: 'html`<a href="javascript:void(0)" />`', options: preferButtonAspect },
-    { code: 'html`<a href=${"javascript:void(0)"} />`', options: preferButtonAspect },
-    { code: 'html`<a href="" />;`', options: noHrefAspect },
-    { code: 'html`<a href="#" />`', options: noHrefAspect },
-    { code: 'html`<a href=${"#"} />`', options: noHrefAspect },
-    { code: 'html`<a href="javascript:void(0)" />`', options: noHrefAspect },
-    { code: 'html`<a href=${"javascript:void(0)"} />`', options: noHrefAspect },
-    { code: 'html`<a href="" />;`', options: noHrefPreferButtonAspect },
-    { code: 'html`<a href="#" />`', options: noHrefPreferButtonAspect },
-    { code: 'html`<a href=${"#"} />`', options: noHrefPreferButtonAspect },
-    { code: 'html`<a href="javascript:void(0)" />`', options: noHrefPreferButtonAspect },
-    { code: 'html`<a href=${"javascript:void(0)"} />`', options: noHrefPreferButtonAspect },
+    { code: 'html`<a href="" />;`', options: [{ aspects: ['preferButton'] }] },
+    { code: 'html`<a href="#" />`', options: [{ aspects: ['preferButton'] }] },
+    { code: 'html`<a href=${"#"} />`', options: [{ aspects: ['preferButton'] }] },
+    { code: 'html`<a href="javascript:void(0)" />`', options: [{ aspects: ['preferButton'] }] },
+    { code: 'html`<a href=${"javascript:void(0)"} />`', options: [{ aspects: ['preferButton'] }] },
+    { code: 'html`<a href="" />;`', options: [{ aspects: ['noHref'] }] },
+    { code: 'html`<a href="#" />`', options: [{ aspects: ['noHref'] }] },
+    { code: 'html`<a href=${"#"} />`', options: [{ aspects: ['noHref'] }] },
+    { code: 'html`<a href="javascript:void(0)" />`', options: [{ aspects: ['noHref'] }] },
+    { code: 'html`<a href=${"javascript:void(0)"} />`', options: [{ aspects: ['noHref'] }] },
+    { code: 'html`<a href="" />;`', options: [{ aspects: ['noHref', 'preferButton'] }] },
+    { code: 'html`<a href="#" />`', options: [{ aspects: ['noHref', 'preferButton'] }] },
+    { code: 'html`<a href=${"#"} />`', options: [{ aspects: ['noHref', 'preferButton'] }] },
+    {
+      code: 'html`<a href="javascript:void(0)" />`',
+      options: [{ aspects: ['noHref', 'preferButton'] }],
+    },
+    {
+      code: 'html`<a href=${"javascript:void(0)"} />`',
+      options: [{ aspects: ['noHref', 'preferButton'] }],
+    },
 
-    { code: 'html`<a @click=${foo} />`', options: invalidHrefAspect },
-    { code: 'html`<a href="#" @click=${foo} />`', options: noHrefAspect },
-    { code: 'html`<a href="javascript:void(0)" @click=${foo} />`', options: noHrefAspect },
+    { code: 'html`<a @click=${foo} />`', options: [{ aspects: ['invalidHref'] }] },
+    { code: 'html`<a href="#" @click=${foo} />`', options: [{ aspects: ['noHref'] }] },
+    {
+      code: 'html`<a href="javascript:void(0)" @click=${foo} />`',
+      options: [{ aspects: ['noHref'] }],
+    },
     {
       code: 'html`<a href=${"javascript:void(0)"} @click=${foo} />`',
-      options: noHrefAspect,
+      options: [{ aspects: ['noHref'] }],
     },
   ],
 
   invalid: [
-    { code: 'html`<a />`', errors: [noHrefexpectedError] },
+    { code: 'html`<a />`', errors: [{ messageId: 'noHrefErrorMessage' }] },
     // INVALID HREF
-    { code: 'html`<a href="" />;`', errors: [invalidHrefexpectedError] },
-    { code: 'html`<a href="#" />`', errors: [invalidHrefErrorMessage] },
-    { code: 'html`<a href="javascript:void(0)" />`', errors: [invalidHrefexpectedError] },
+    { code: 'html`<a href="" />;`', errors: [{ messageId: 'invalidHrefErrorMessage' }] },
+    { code: 'html`<a href="#" />`', errors: [{ messageId: 'invalidHrefErrorMessage' }] },
+    {
+      code: 'html`<a href="javascript:void(0)" />`',
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
+    },
     // SHOULD BE BUTTON
-    { code: 'html`<a @click=${foo} />`', errors: [preferButtonexpectedError] },
-    { code: 'html`<a href="#" @click=${foo} />`', errors: [preferButtonexpectedError] },
+    { code: 'html`<a @click=${foo} />`', errors: [{ messageId: 'preferButtonErrorMessage' }] },
+    {
+      code: 'html`<a href="#" @click=${foo} />`',
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
+    },
     {
       code: 'html`<a href="javascript:void(0)" @click=${foo} />`',
-      errors: [preferButtonexpectedError],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
 
     // WITH ASPECTS TESTS
     // NO HREF
-    { code: 'html`<a />`', options: noHrefAspect, errors: [noHrefErrorMessage] },
-    { code: 'html`<a />`', options: noHrefPreferButtonAspect, errors: [noHrefErrorMessage] },
-    { code: 'html`<a />`', options: noHrefInvalidHrefAspect, errors: [noHrefErrorMessage] },
+    {
+      code: 'html`<a />`',
+      options: [{ aspects: ['noHref'] }],
+      errors: [{ messageId: 'noHrefErrorMessage' }],
+    },
+    {
+      code: 'html`<a />`',
+      options: [{ aspects: ['noHref', 'preferButton'] }],
+      errors: [{ messageId: 'noHrefErrorMessage' }],
+    },
+    {
+      code: 'html`<a />`',
+      options: [{ aspects: ['noHref', 'invalidHref'] }],
+      errors: [{ messageId: 'noHrefErrorMessage' }],
+    },
 
     // INVALID HREF
-    { code: 'html`<a href="" />;`', options: invalidHrefAspect, errors: [invalidHrefErrorMessage] },
     {
       code: 'html`<a href="" />;`',
-      options: noHrefInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="" />;`',
-      options: preferButtonInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['noHref', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
+    },
+    {
+      code: 'html`<a href="" />;`',
+      options: [{ aspects: ['preferButton', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="#" />;`',
-      options: invalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="#" />;`',
-      options: noHrefInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['noHref', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="#" />;`',
-      options: preferButtonInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['preferButton', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" />;`',
-      options: invalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" />;`',
-      options: noHrefInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['noHref', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" />;`',
-      options: preferButtonInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['preferButton', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
 
     // SHOULD BE BUTTON
     {
       code: 'html`<a @click=${foo} />`',
-      options: preferButtonAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['preferButton'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a @click=${foo} />`',
-      options: preferButtonInvalidHrefAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['preferButton', 'invalidHref'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a @click=${foo} />`',
-      options: noHrefPreferButtonAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['noHref', 'preferButton'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
-    { code: 'html`<a @click=${foo} />`', options: noHrefAspect, errors: [noHrefErrorMessage] },
     {
       code: 'html`<a @click=${foo} />`',
-      options: noHrefInvalidHrefAspect,
-      errors: [noHrefErrorMessage],
+      options: [{ aspects: ['noHref'] }],
+      errors: [{ messageId: 'noHrefErrorMessage' }],
+    },
+    {
+      code: 'html`<a @click=${foo} />`',
+      options: [{ aspects: ['noHref', 'invalidHref'] }],
+      errors: [{ messageId: 'noHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="#" @click=${foo} />`',
-      options: preferButtonAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['preferButton'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a href="#" @click=${foo} />`',
-      options: noHrefPreferButtonAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['noHref', 'preferButton'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a href="#" @click=${foo} />`',
-      options: preferButtonInvalidHrefAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['preferButton', 'invalidHref'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a href="#" @click=${foo} />`',
-      options: invalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="#" @click=${foo} />`',
-      options: noHrefInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['noHref', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" @click=${foo} />`',
-      options: preferButtonAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['preferButton'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" @click=${foo} />`',
-      options: noHrefPreferButtonAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['noHref', 'preferButton'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" @click=${foo} />`',
-      options: preferButtonInvalidHrefAspect,
-      errors: [preferButtonErrorMessage],
+      options: [{ aspects: ['preferButton', 'invalidHref'] }],
+      errors: [{ messageId: 'preferButtonErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" @click=${foo} />`',
-      options: invalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
     {
       code: 'html`<a href="javascript:void(0)" @click=${foo} />`',
-      options: noHrefInvalidHrefAspect,
-      errors: [invalidHrefErrorMessage],
+      options: [{ aspects: ['noHref', 'invalidHref'] }],
+      errors: [{ messageId: 'invalidHrefErrorMessage' }],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/click-events-have-key-events.js
@@ -23,110 +23,87 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('click-events-have-key-events', rule, {
   valid: [
-    { code: 'html`<div @click=${foo} aria-hidden />`' },
-    { code: 'html`<div @click=${foo} aria-hidden="true" />`' },
-    { code: 'html`<div @click=${foo} aria-hidden=${true} />`' },
-    { code: 'html`<div @click=${foo} aria-hidden=${false} @keydown=${foo} />`' },
-    { code: 'html`<a @click=${foo} href="http://x.y.z" />`' },
-    { code: 'html`<a @click=${foo} href="http://x.y.z" tabindex="0" />`' },
-    { code: 'html`<div @click=${foo} @keydown=${foo}/>`' },
-    { code: 'html`<div @click=${foo} @keyup=${foo} />`' },
-    { code: 'html`<div @click=${foo} @keypress=${foo}/>`' },
+    { code: 'html`<div @click=${foo} aria-hidden></div>`' },
+    { code: 'html`<div @click=${foo} aria-hidden="true"></div>`' },
+    { code: 'html`<div @click=${foo} aria-hidden=${true}></div>`' },
+    { code: 'html`<div @click=${foo} aria-hidden=${false} @keydown=${foo}></div>`' },
+    { code: 'html`<a @click=${foo} href="http://x.y.z"></a>`' },
+    { code: 'html`<a @click=${foo} href="http://x.y.z" tabindex="0"></a>`' },
+    { code: 'html`<div @click=${foo} @keydown=${foo}></div>`' },
+    { code: 'html`<div @click=${foo} @keyup=${foo}></div>`' },
+    { code: 'html`<div @click=${foo} @keypress=${foo}></div>`' },
     { code: 'html`<input @click=${foo} />`' },
-    { code: 'html`<div @click=${foo} @keydown=${foo} />`' },
-    { code: 'html`<custom-button @click=${foo} />`', options: [{ allowList: ['custom-button'] }] },
+    { code: 'html`<div @click=${foo} @keydown=${foo}></div>`' },
+    {
+      code: 'html`<custom-button @click=${foo}></custom-button>`',
+      options: [{ allowList: ['custom-button'] }],
+    },
+    {
+      code: 'html`<another-button @click=${foo}></another-button>`',
+      options: [{ allowList: ['another-button'] }],
+    },
+    {
+      code: 'html`<custom-button @click=${foo}></custom-button>`',
+      options: [{ allowCustomElements: true }],
+    },
+    {
+      code: 'html`<another-button @click=${foo}></another-button>`',
+      options: [{ allowCustomElements: true }],
+    },
   ],
 
   invalid: [
     {
       code: 'html`<div @click=${foo}></div>`',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<div @click=${foo} ></div>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<div @click=${foo}></div>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<section @click=${foo} ></section>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<section @click=${foo}></section>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<main @click=${foo} ></main>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<main @click=${foo}></main>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<article @click=${foo} ></article>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<article @click=${foo}></article>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<header @click=${foo} ></header>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<header @click=${foo}></header>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<footer @click=${foo} ></footer>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<footer @click=${foo}></footer>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<a @click=${foo} ></a>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<a @click=${foo}></a>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
     },
     {
-      code: 'html`<custom-button @click=${foo} ></custom-button>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<custom-button @click=${foo}></custom-button>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
+      options: [{ allowCustomElements: false }],
     },
     {
-      code: 'html`<another-button @click=${foo} ></another-button>`;',
-      errors: [
-        {
-          message:
-            'Clickable non-interactive elements must have at least 1 keyboard event listener',
-        },
-      ],
+      code: 'html`<another-button @click=${foo}></another-button>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
+      options: [{ allowCustomElements: false }],
+    },
+    {
+      code: 'html`<custom-button @click=${foo}></custom-button>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
+      options: [{ allowCustomElements: false, allowList: ['another-button'] }],
+    },
+    {
+      code: 'html`<another-button @click=${foo}></another-button>`;',
+      errors: [{ messageId: 'clickableNonInteractiveElements' }],
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/heading-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/heading-has-content.js
@@ -43,36 +43,53 @@ ruleTester.run('heading-has-content', rule, {
     { code: 'html`<h1>${foo(bar)}</h1>`' },
     { code: 'html`<h1>${foo(bar, "hello", 1, true)}</h1>`' },
     { code: 'html`<h1>${this.foo()}</h1>`' },
+    {
+      code: 'html`<custom-heading level="1">${this.foo()}</custom-heading>`',
+      options: [
+        {
+          customHeadingElements: 'custom-heading',
+        },
+      ],
+    },
   ],
 
   invalid: [
     {
       code: "html`<h1><div aria-hidden='true'>foo</div></h1>`",
-      errors: [{ message: '<h1> elements must have accessible content.' }],
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'h1' } }],
     },
     {
       code: 'html`<h1></h1>`',
-      errors: [{ message: '<h1> elements must have accessible content.' }],
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'h1' } }],
     },
     {
       code: 'html`<h2></h2>`',
-      errors: [{ message: '<h2> elements must have accessible content.' }],
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'h2' } }],
     },
     {
       code: 'html`<h3></h3>`',
-      errors: [{ message: '<h3> elements must have accessible content.' }],
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'h3' } }],
     },
     {
       code: 'html`<h4></h4>`',
-      errors: [{ message: '<h4> elements must have accessible content.' }],
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'h4' } }],
     },
     {
       code: 'html`<h5></h5>`',
-      errors: [{ message: '<h5> elements must have accessible content.' }],
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'h5' } }],
     },
     {
       code: 'html`<h6></h6>`',
-      errors: [{ message: '<h6> elements must have accessible content.' }],
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'h6' } }],
+    },
+    {
+      code: 'html`<custom-heading level="1"></custom-heading>`',
+      errors: [{ messageId: 'headingHasContent', data: { tagName: 'custom-heading' } }],
+      options: [
+        {
+          customHeadingElements: 'custom-heading',
+        },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/iframe-title.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/iframe-title.js
@@ -31,19 +31,11 @@ ruleTester.run('iframe-title', rule, {
   invalid: [
     {
       code: 'html`<iframe></iframe>`',
-      errors: [
-        {
-          message: '<iframe> elements must have a unique title property.',
-        },
-      ],
+      errors: [{ messageId: 'iframeTitle' }],
     },
     {
       code: "html`<iframe title=''></iframe>`",
-      errors: [
-        {
-          message: '<iframe> elements must have a unique title property.',
-        },
-      ],
+      errors: [{ messageId: 'iframeTitle' }],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/img-redundant-alt.js
@@ -20,85 +20,49 @@ const ruleTester = new RuleTester({
     ecmaVersion: 2015,
   },
 });
+
 ruleTester.run('img-redundant-alt', rule, {
   valid: [
     { code: 'html`<img src="foo" alt="Foo eating a sandwich." />`' },
-    {
-      code: 'html`<img src="bar" aria-hidden alt="Picture of me taking a photo of an image" /> `',
-    },
-    {
-      code: 'html`<img src="baz" alt=${`Baz taking a ${photo}`} />`',
-    },
-    {
-      code: 'html`<img src="baz" alt=${"foo"} />`',
-    },
-    // give me some code that won't trigger a warning
+    { code: 'html`<img src="bar" aria-hidden alt="Picture of me taking a photo of an image" /> `' },
+    { code: 'html`<img src="baz" alt=${`Baz taking a ${photo}`} />`' },
+    { code: 'html`<img src="baz" alt=${"foo"} />`' },
   ],
 
   invalid: [
     {
       code: "html`<img src='foo' alt='Photo of foo being weird.' />`",
-      errors: [
-        {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned word photo.',
-        },
-      ],
+      errors: [{ messageId: 'imgRedundantAlt', data: { banned: 'photo', plural: 'word' } }],
     },
     {
       code: 'html`<img src="baz" alt=${"photo of dog"} />`',
-      errors: [
-        {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned word photo.',
-        },
-      ],
+      errors: [{ messageId: 'imgRedundantAlt', data: { banned: 'photo', plural: 'word' } }],
     },
     {
       code: "html`<img src='foo' alt='Image of me at a bar!' />`",
-      errors: [
-        {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned word image.',
-        },
-      ],
+      errors: [{ messageId: 'imgRedundantAlt', data: { banned: 'image', plural: 'word' } }],
     },
     {
       code: "html`<img src='foo' alt='Picture of baz fixing a bug.' />`",
-      errors: [
-        {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned word picture.',
-        },
-      ],
+      errors: [{ messageId: 'imgRedundantAlt', data: { banned: 'picture', plural: 'word' } }],
     },
     {
       code: "html`<img src='foo' alt='baz foo bar.' />`",
       options: [{ keywords: ['foo'] }],
-      errors: [
-        {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned word foo.',
-        },
-      ],
+      errors: [{ messageId: 'imgRedundantAlt', data: { banned: 'foo', plural: 'word' } }],
     },
     {
       code: "html`<img src='foo' alt='image of baz foo bar.' />`",
       options: [{ keywords: ['foo'] }],
-      errors: [
-        {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned words image or foo.',
-        },
-      ],
+      errors: [{ messageId: 'imgRedundantAlt', data: { banned: 'image or foo', plural: 'words' } }],
     },
     {
       code: "html`<img src='foo' alt='image of picture baz foo bar.' />`",
       options: [{ keywords: ['foo'] }],
       errors: [
         {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned words image, picture, or foo.',
+          messageId: 'imgRedundantAlt',
+          data: { banned: 'image, picture, or foo', plural: 'words' },
         },
       ],
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/mouse-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/mouse-events-have-key-events.js
@@ -23,35 +23,145 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('mouse-events-have-key-events', rule, {
   valid: [
-    { code: 'html`<div @mouseover=${foo} @focus=${foo} />;`' },
-    { code: 'html`<div @mouseover=${foo} @focus=${foo} />;`' },
-    { code: 'html`<div @mouseover=${handleMouseOver} @focus=${handleFocus} />`' },
-    { code: 'html`<div @mouseover=${handleMouseOver} @focus=${handleFocus} />`' },
-    { code: 'html`<div />;`' },
-    { code: 'html`<div @blur=${() => {}} />`' },
-    { code: 'html`<div @focus=${() => {}} />`' },
-    { code: 'html`<div @mouseout=${foo} @blur=${foo} />`' },
-    { code: 'html`<div @mouseout=${foo} @blur=${foo} />`' },
-    { code: 'html`<div @mouseout=${handleMouseOut} @blur=${handleOnBlur} />`' },
-    { code: 'html`<div @mouseout=${handleMouseOut} @blur=${handleOnBlur} />`' },
+    { code: 'html`<div></div>;`' },
+    { code: 'html`<div @mouseover=${foo} @focus=${foo}></div>;`' },
+    { code: 'html`<div @mouseover=${handleMouseOver} @focus=${handleFocus}></div>`' },
+    { code: 'html`<div @blur=${() => {}}></div>`' },
+    { code: 'html`<div @focus=${() => {}}></div>`' },
+    { code: 'html`<div @mouseout=${foo} @blur=${foo}></div>`' },
+    { code: 'html`<div @mouseout=${handleMouseOut} @blur=${handleOnBlur}></div>`' },
+
+    {
+      code: 'html`<custom-button></custom-button>;`',
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
+    },
+    {
+      code: 'html`<custom-button @mouseover=${foo} @focus=${foo}></custom-button>;`',
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
+    },
+    {
+      code:
+        'html`<custom-button @mouseover=${handleMouseOver} @focus=${handleFocus}></custom-button>`',
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
+    },
+    {
+      code: 'html`<custom-button @blur=${() => {}}></custom-button>`',
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
+    },
+    {
+      code: 'html`<custom-button @focus=${() => {}}></custom-button>`',
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
+    },
+    {
+      code: 'html`<custom-button @mouseout=${foo} @blur=${foo}></custom-button>`',
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
+    },
+    {
+      code:
+        'html`<custom-button @mouseout=${handleMouseOut} @blur=${handleOnBlur}></custom-button>`',
+      options: [{ allowCustomElements: false, allowList: ['custom-button'] }],
+    },
   ],
 
   invalid: [
     {
-      code: 'html`<div @mouseover=${foo} />;`',
-      errors: ['@mouseover must be accompanied by @focus.'],
+      code: 'html`<div @mouseover=${foo}></div>;`',
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseover', keyevent: 'focus' },
+        },
+      ],
     },
     {
-      code: 'html`<div @mouseout=${foo} />`',
-      errors: ['@mouseout must be accompanied by @blur.'],
+      code: 'html`<div @mouseout=${foo}></div>`',
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseout', keyevent: 'blur' },
+        },
+      ],
     },
     {
-      code: 'html`<div @mouseover=${foo} />`',
-      errors: ['@mouseover must be accompanied by @focus.'],
+      code: 'html`<div @mouseover=${foo}></div>`',
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseover', keyevent: 'focus' },
+        },
+      ],
     },
     {
-      code: 'html`<div @mouseout=${foo} />`',
-      errors: ['@mouseout must be accompanied by @blur.'],
+      code: 'html`<div @mouseout=${foo}></div>`',
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseout', keyevent: 'blur' },
+        },
+      ],
+    },
+    {
+      code: 'html`<div @mouseout=${foo} @mouseover=${bar}></div>`',
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseover', keyevent: 'focus' },
+        },
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseout', keyevent: 'blur' },
+        },
+      ],
+    },
+
+    {
+      code: 'html`<custom-button @mouseout=${foo}></custom-button>`;',
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseout', keyevent: 'blur' },
+        },
+      ],
+      options: [{ allowCustomElements: false }],
+    },
+    {
+      code: 'html`<custom-button @mouseout=${foo} @mouseover=${bar}></custom-button>`;',
+      options: [{ allowCustomElements: false }],
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseover', keyevent: 'focus' },
+        },
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseout', keyevent: 'blur' },
+        },
+      ],
+    },
+
+    {
+      code: 'html`<custom-button @mouseout=${foo}></custom-button>`;',
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseout', keyevent: 'blur' },
+        },
+      ],
+      options: [{ allowCustomElements: false, allowList: ['another-button'] }],
+    },
+    {
+      code: 'html`<custom-button @mouseout=${foo} @mouseover=${bar}></custom-button>`;',
+      options: [{ allowCustomElements: false, allowList: ['another-button'] }],
+      errors: [
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseover', keyevent: 'focus' },
+        },
+        {
+          messageId: 'mouseEventsHaveKeyEvents',
+          data: { mouseevent: 'mouseout', keyevent: 'blur' },
+        },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-autofocus.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-autofocus.js
@@ -29,35 +29,32 @@ ruleTester.run('no-autofocus', rule, {
   invalid: [
     {
       code: 'html`<div autofocus></div>`',
-      errors: [
-        {
-          message: 'The autofocus attribute is not allowed.',
-        },
-      ],
+      errors: [{ messageId: 'noAutofocus', data: { type: 'attribute' } }],
     },
     {
       code: "html`<div autofocus='true'></div>`",
-      errors: [
-        {
-          message: 'The autofocus attribute is not allowed.',
-        },
-      ],
+      errors: [{ messageId: 'noAutofocus', data: { type: 'attribute' } }],
     },
     {
       code: "html`<div autofocus='false'></div>`",
-      errors: [
-        {
-          message: 'The autofocus attribute is not allowed.',
-        },
-      ],
+      errors: [{ messageId: 'noAutofocus', data: { type: 'attribute' } }],
     },
     {
       code: 'html`<div autofocus=${foo}></div>`',
-      errors: [
-        {
-          message: 'The autofocus attribute is not allowed.',
-        },
-      ],
+      errors: [{ messageId: 'noAutofocus', data: { type: 'attribute' } }],
+    },
+
+    {
+      code: "html`<div .autofocus='true'></div>`",
+      errors: [{ messageId: 'noAutofocus', data: { type: 'property' } }],
+    },
+    {
+      code: "html`<div .autofocus='false'></div>`",
+      errors: [{ messageId: 'noAutofocus', data: { type: 'property' } }],
+    },
+    {
+      code: 'html`<div .autofocus=${foo}></div>`',
+      errors: [{ messageId: 'noAutofocus', data: { type: 'property' } }],
     },
   ],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/tabindex-no-positive.js
@@ -42,39 +42,39 @@ ruleTester.run('tabindex-no-positive', rule, {
   invalid: [
     {
       code: "html`<div tabindex='foo'></div>`",
-      errors: [{ message: 'Invalid tabindex value foo.' }],
+      errors: [{ messageId: 'tabindexNoPositive', data: { val: 'foo' } }],
     },
     {
       code: "html`<div tabindex=${'bar'}></div>`",
-      errors: [{ message: 'Invalid tabindex value bar.' }],
+      errors: [{ messageId: 'tabindexNoPositive', data: { val: 'bar' } }],
     },
     {
       code: 'html`<div tabindex=${true}></div>`',
-      errors: [{ message: 'Invalid tabindex value true.' }],
+      errors: [{ messageId: 'tabindexNoPositive', data: { val: 'true' } }],
     },
     {
       code: 'html`<div tabindex=${undefined}></div>`',
-      errors: [{ message: 'Invalid tabindex value undefined.' }],
+      errors: [{ messageId: 'tabindexNoPositive', data: { val: 'undefined' } }],
     },
     {
       code: 'html`<div tabindex=${null}></div>`',
-      errors: [{ message: 'Invalid tabindex value null.' }],
+      errors: [{ messageId: 'tabindexNoPositive', data: { val: 'null' } }],
     },
     {
       code: 'html`<div tabindex=${1}></div>`',
-      errors: [{ message: 'Avoid positive tabindex.' }],
+      errors: [{ messageId: 'avoidPositiveTabindex' }],
     },
     {
       code: "html`<div tabindex=${'1'}></div>`",
-      errors: [{ message: 'Avoid positive tabindex.' }],
+      errors: [{ messageId: 'avoidPositiveTabindex' }],
     },
     {
       code: "html`<div tabindex='1'></div>`",
-      errors: [{ message: 'Avoid positive tabindex.' }],
+      errors: [{ messageId: 'avoidPositiveTabindex' }],
     },
     {
       code: "html`<div tabindex='2'></div>`",
-      errors: [{ message: 'Avoid positive tabindex.' }],
+      errors: [{ messageId: 'avoidPositiveTabindex' }],
     },
   ],
 });


### PR DESCRIPTION
- *: add rule docs url to meta.docs
- utils: refactor utils to take Element
- anchor-is-valid: error messages by id
- click-events-have-key-events: add `allowCustomElements` option
- click-events-have-key-events: schematize `allowList` option
- heading-has-content: add `customHeadingElements` option
- iframe-title: error messages by id, refactor
- img-redundant-alt: add defaults to schema
- mouse-events-have-key-events: add `allowCustomElements` option
- mouse-events-have-key-events: schematize `allowList` option
- no-autofocus: include `.autofocus` DOM property

blocked by #1899 