### PR TITLE
fix: revert custom placeholder logic

### DIFF
--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
@@ -122,7 +122,7 @@ const AriaAttrTypesRule = {
 
                   // Ignore the attribute if its value is null or undefined.
                   if (val == null) return;
-                  if (val.startsWith('{{')) return;
+                  if (val.startsWith('__')) return;
 
                   // These are the attributes of the property/state to check against.
                   // @ts-expect-error: see https://github.com/A11yance/aria-query/pull/74

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -43,7 +43,11 @@ const AriaRoleRule = {
                   return; // the value is interpolated with a name. assume it's legitimate and move on.
                 }
 
-                if (!validAriaRoles.includes(rawValue)) {
+                if (
+                  !validAriaRoles.includes(
+                    /** @type {import("aria-query").ARIARoleDefintionKey} */ (rawValue),
+                  )
+                ) {
                   const loc = analyzer.getLocationForAttribute(element, attr);
                   context.report({
                     loc,

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -39,22 +39,17 @@ const AriaRoleRule = {
                   return;
                 }
 
-                const role = /** @type {import("aria-query").ARIARoleDefintionKey} */ (rawValue.replace(
-                  /^{{(.*)}}$/,
-                  '$1',
-                ));
-
-                if (/^{(.*)}$/.test(role)) {
+                if (rawValue.startsWith('{{')) {
                   return; // the value is interpolated with a name. assume it's legitimate and move on.
                 }
 
-                if (!validAriaRoles.includes(role)) {
+                if (!validAriaRoles.includes(rawValue)) {
                   const loc = analyzer.getLocationForAttribute(element, attr);
                   context.report({
                     loc,
-                    message: `Invalid role "{{role}}".`,
+                    message: `Invalid role "{{rawValue}}".`,
                     data: {
-                      role,
+                      rawValue,
                     },
                   });
                 }

--- a/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
@@ -35,7 +35,7 @@ const TabindexNoPositiveRule = {
               if (Object.keys(element.attribs).includes('tabindex')) {
                 const val = getAttrVal(element.attribs.tabindex);
 
-                if (val && val.startsWith('{{')) return;
+                if (val && val.startsWith('__')) return;
 
                 const value = Number(val);
 

--- a/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
+++ b/packages/eslint-plugin-lit-a11y/template-analyzer/util.js
@@ -151,74 +151,6 @@ function isExpressionPlaceholder(value) {
 exports.isExpressionPlaceholder = isExpressionPlaceholder;
 
 /**
- *
- * @param {import("estree").Expression} expr
- * @return {expr is import("estree").Identifier}
- */
-function isIdentifier(expr) {
-  // @ts-expect-error: disambiguating a type
-  return expr && expr.name;
-}
-
-/**
- *
- * @param {import("estree").Expression} expr
- * @return {expr is import("estree").CallExpression}
- */
-function isCallExpression(expr) {
-  return expr && expr.type === 'CallExpression';
-}
-
-/**
- * @param {import('estree').CallExpression} expr
- * @return {string|number|boolean}
- */
-function getCallExprValue(expr) {
-  return expr && expr.arguments && expr.arguments.map(arg => getIdentifierName(arg)).join(', ');
-}
-
-/**
- * @param {import("estree").Expression} expr
- * @return {expr is import("estree").SimpleLiteral}
- */
-function isLiteral(expr) {
-  return expr && expr.type === 'Literal';
-}
-
-/**
- * @param {import("estree").Expression} expr
- * @return {expr is import("estree").MemberExpression}
- */
-function isMemberExpressions(expr) {
-  return expr && expr.type === 'MemberExpression';
-}
-
-/**
- * @param {import("estree").Expression} expr
- * @return {expr is import("estree").ConditionalExpression}
- */
-function isConditionalExpression(expr) {
-  return expr && expr.type === 'ConditionalExpression';
-}
-
-/**
- * @param {import("estree").Expression} expr
- * @return {expr is import("estree").UnaryExpression} expr
- */
-function isUnaryExpression(expr) {
-  return expr && expr.type === 'UnaryExpression';
-}
-
-/**
- * @param {import('estree').UnaryExpression} expr
- * @return {string|number|boolean}
- */
-function getUnaryExprValue(expr) {
-  // TODO: handle more complex cases like `-someValue`, `-Number(something)`
-  return isLiteral(expr.argument) ? expr.argument.value : '';
-}
-
-/**
  * Converts a template expression into HTML
  *
  * @param {import("estree").TaggedTemplateExpression} node Node to convert
@@ -232,18 +164,8 @@ function templateExpressionToHtml(node) {
     const quasi = node.quasi.quasis[i];
     const expr = node.quasi.expressions[i];
     html += quasi.value.raw;
-    if (isIdentifier(expr)) {
-      html += `{{{${expr.name}}}}`;
-    } else if (isUnaryExpression(expr)) {
-      html += `{{${expr.operator}${getUnaryExprValue(expr)}}}`;
-    } else if (isLiteral(expr)) {
-      html += `{{${expr.value}}}`;
-    } else if (isCallExpression(expr)) {
-      html += `{{{${getIdentifierName(expr.callee)}(${getCallExprValue(expr)})}}}`;
-    } else if (isMemberExpressions(expr)) {
-      html += `{{{}}}`;
-    } else if (isConditionalExpression(expr)) {
-      html += `{{{}}}`;
+    if (expr) {
+      html += getExpressionPlaceholder(node, quasi);
     }
   }
   return html;

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-role.js
@@ -41,31 +41,7 @@ ruleTester.run('aria-role', rule, {
       errors: [{ message: 'Invalid role "foo".' }],
     },
     {
-      code: 'html`<div role=\'${"foo"}\'>`;',
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: "html`<div role='${'foo'}'>`;",
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
       code: 'html`<div role="foo">`;',
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: 'html`<div role="${\'foo\'}">`;',
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: 'html`<div role="${"foo"}">`;',
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: "html`<div role=${'foo'}>`;",
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: 'html`<div role=${"foo"}>`;',
       errors: [{ message: 'Invalid role "foo".' }],
     },
   ],

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/img-redundant-alt.js
@@ -46,15 +46,6 @@ ruleTester.run('img-redundant-alt', rule, {
       ],
     },
     {
-      code: 'html`<img src="baz" alt=${"photo of dog"} />`',
-      errors: [
-        {
-          message:
-            '<img> alt attribute must be descriptive; it cannot contain the banned word photo.',
-        },
-      ],
-    },
-    {
       code: "html`<img src='foo' alt='Image of me at a bar!' />`",
       errors: [
         {

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/tabindex-no-positive.js
@@ -45,34 +45,6 @@ ruleTester.run('tabindex-no-positive', rule, {
       errors: [{ message: 'Invalid tabindex value foo.' }],
     },
     {
-      code: "html`<div tabindex=${'bar'}></div>`",
-      errors: [{ message: 'Invalid tabindex value bar.' }],
-    },
-    {
-      code: 'html`<div tabindex=${true}></div>`',
-      errors: [{ message: 'Invalid tabindex value true.' }],
-    },
-    {
-      code: 'html`<div tabindex=${undefined}></div>`',
-      errors: [{ message: 'Invalid tabindex value undefined.' }],
-    },
-    {
-      code: 'html`<div tabindex=${null}></div>`',
-      errors: [{ message: 'Invalid tabindex value null.' }],
-    },
-    {
-      code: 'html`<div tabindex=${1}></div>`',
-      errors: [{ message: 'Avoid positive tabindex.' }],
-    },
-    {
-      code: "html`<div tabindex=${'1'}></div>`",
-      errors: [{ message: 'Avoid positive tabindex.' }],
-    },
-    {
-      code: "html`<div tabindex='1'></div>`",
-      errors: [{ message: 'Avoid positive tabindex.' }],
-    },
-    {
       code: "html`<div tabindex='2'></div>`",
       errors: [{ message: 'Avoid positive tabindex.' }],
     },


### PR DESCRIPTION
Reverting the custom placeholder logic for now. We could revisit this in the future, but currently there are many edgecases that we miss, and it also throws a spanner in the works with regard to reporting in the correct location. I think its better if we iterate on this in a later version, and then we could potentially also upstream it to eslint-plugin-lit. But to get an initial version out of the door, I think its good enough to simply ignore expressions for now.

The consequence of this change is that we no longer check simple literal values in expression `<div tabindex=${0}>`, for example.