### PR TITLE
feat: detect lit-html

### DIFF
--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.37.0](https://github.com/open-wc/open-wc/compare/@open-wc/create@0.36.0...@open-wc/create@0.37.0) (2020-10-17)
+
+
+### Features
+
+* add eslint-plugin-lit-a11y ([#1781](https://github.com/open-wc/open-wc/issues/1781)) ([3232d0d](https://github.com/open-wc/open-wc/commit/3232d0db5dc411fa191a9b8f74757902cde2f98a)), closes [#1871](https://github.com/open-wc/open-wc/issues/1871)
+
+
+
+
+
 # [0.36.0](https://github.com/open-wc/open-wc/compare/@open-wc/create@0.35.0...@open-wc/create@0.36.0) (2020-10-05)
 
 

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wc/create",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-plugin-lit-a11y/README.md
+++ b/packages/eslint-plugin-lit-a11y/README.md
@@ -62,6 +62,8 @@ In this case, you can configure `@apollo-elements/lit-apollo` as a valid lit-htm
 }
 ```
 
+The reason for this check is that project may make use of multiple rendering libraries, which may have similar apis, like for example [`htm`](https://github.com/developit/htm), which also uses a `html` tagged template literal, but handles syntax differently.
+
 ## Supported Rules
 
 - [lit-a11y/accessible-emoji](./docs/rules/accessible-emoji.md)

--- a/packages/eslint-plugin-lit-a11y/README.md
+++ b/packages/eslint-plugin-lit-a11y/README.md
@@ -50,6 +50,18 @@ You may also extend the recommended configuration like so:
 }
 ```
 
+By default, only templates imported from `'lit-html'` or `'lit-element'` are exported. It may be the case, however, that you're importing `html` from a package that re-exports lit-html, like for example `@apollo-elements/lit-apollo` does.
+
+In this case, you can configure `@apollo-elements/lit-apollo` as a valid lit-html source like so:
+
+```json
+{
+    "settings": {
+        "litHtmlSources": ["@apollo-elements/lit-apollo"]
+    }
+}
+```
+
 ## Supported Rules
 
 - [lit-a11y/accessible-emoji](./docs/rules/accessible-emoji.md)

--- a/packages/eslint-plugin-lit-a11y/README.md
+++ b/packages/eslint-plugin-lit-a11y/README.md
@@ -56,9 +56,9 @@ In this case, you can configure `@apollo-elements/lit-apollo` as a valid lit-htm
 
 ```json
 {
-    "settings": {
-        "litHtmlSources": ["@apollo-elements/lit-apollo"]
-    }
+  "settings": {
+    "litHtmlSources": ["@apollo-elements/lit-apollo"]
+  }
 }
 ```
 

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -54,7 +54,7 @@ const AccessibleEmojiRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -8,6 +8,7 @@ const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.
 const { isTextNode } = require('../../template-analyzer/util.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,6 +28,9 @@ const AccessibleEmojiRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     /**
      * @param {import('parse5-htmlparser2-tree-adapter').Element} element
      * @return {boolean}
@@ -44,8 +48,13 @@ const AccessibleEmojiRule = {
     }
 
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
@@ -79,7 +79,7 @@ const AltTextRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
@@ -6,6 +6,7 @@
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -25,9 +26,17 @@ const AltTextRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-has-content.js
@@ -6,6 +6,8 @@
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { hasAccessibleChildren } = require('../utils/hasAccessibleChildren.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -24,9 +26,17 @@ const AnchorHasContentRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-has-content.js
@@ -31,7 +31,7 @@ const AnchorHasContentRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
@@ -7,6 +7,7 @@ const { getAttrVal } = require('../utils/getAttrVal.js');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { generateObjSchema, enumArraySchema } = require('../utils/schemas.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -42,9 +43,17 @@ const AnchorIsValidRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
@@ -48,7 +48,7 @@ const AnchorIsValidRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
@@ -6,6 +6,8 @@
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isInteractiveElement } = require('../utils/isInteractiveElement.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -24,9 +26,17 @@ const AriaActiveDescendantHasTabindexRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
@@ -31,7 +31,7 @@ const AriaActiveDescendantHasTabindexRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
@@ -113,7 +113,7 @@ const AriaAttrTypesRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
@@ -8,6 +8,7 @@ const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.
 const { getElementAriaAttributes } = require('../utils/aria.js');
 const { getAttrVal } = require('../utils/getAttrVal.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -107,9 +108,17 @@ const AriaAttrTypesRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
@@ -31,7 +31,7 @@ const AriaAttrsRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
@@ -6,6 +6,7 @@
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isInvalidAriaAttribute } = require('../utils/aria.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -25,9 +26,17 @@ const AriaAttrsRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -6,6 +6,7 @@
 const { roles } = require('aria-query');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,9 +28,17 @@ const AriaRoleRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -33,7 +33,7 @@ const AriaRoleRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
@@ -33,7 +33,7 @@ const AriaUnsupportedElementsRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,9 +28,17 @@ const AriaUnsupportedElementsRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
@@ -43,7 +43,7 @@ const AutocompleteValidRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
@@ -7,6 +7,7 @@
 const { runVirtualRule } = require('axe-core');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -37,9 +38,17 @@ const AutocompleteValidRule = {
       );
     }
 
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
@@ -62,7 +62,7 @@ const ClickEventsHaveKeyEventsRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
@@ -9,6 +9,7 @@ const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.
 const { isInteractiveElement } = require('../utils/isInteractiveElement.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { isPresentationRole } = require('../utils/isPresentationRole.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -39,6 +40,9 @@ const ClickEventsHaveKeyEventsRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     /**
      * @param {import("parse5-htmlparser2-tree-adapter").Element} element
      * @return {boolean}
@@ -57,8 +61,13 @@ const ClickEventsHaveKeyEventsRule = {
     }
 
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/heading-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/heading-has-content.js
@@ -33,7 +33,7 @@ const HeadingHasContentRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/heading-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/heading-has-content.js
@@ -7,6 +7,7 @@ const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.
 const { hasAccessibleChildren } = require('../utils/hasAccessibleChildren.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,9 +28,17 @@ const HeadingHasContentRule = {
     schema: [],
   },
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
@@ -29,7 +29,7 @@ const IframeTitleRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -23,9 +24,17 @@ const IframeTitleRule = {
     schema: [],
   },
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
@@ -8,6 +8,7 @@ const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { isAriaHidden } = require('../utils/aria.js');
 const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 if (!('ListFormat' in Intl)) {
   /* eslint-disable global-require */
@@ -52,10 +53,17 @@ const ImgRedundantAltRule = {
   create(context) {
     // @ts-expect-error: since we allow node 10. Remove when we require node >= 12
     const formatter = new Intl.ListFormat('en', { style: 'long', type: 'disjunction' });
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
 
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
@@ -58,7 +58,7 @@ const ImgRedundantAltRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/mouse-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/mouse-events-have-key-events.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -24,9 +25,17 @@ const MouseEventsHaveKeyEventsRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/mouse-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/mouse-events-have-key-events.js
@@ -30,7 +30,7 @@ const MouseEventsHaveKeyEventsRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -24,9 +25,17 @@ const NoAccessKeyRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
@@ -30,7 +30,7 @@ const NoAccessKeyRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -24,9 +25,17 @@ const NoAutofocusRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
@@ -30,7 +30,7 @@ const NoAutofocusRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
@@ -31,13 +31,12 @@ const NoDistractingElementsRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node) && isLitHtml) {
-
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -25,9 +26,18 @@ const NoDistractingElementsRule = {
     schema: [],
   },
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
+
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
@@ -32,13 +32,12 @@ const NoInvalidChangeHandlerRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node) && isLitHtml) {
-
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
@@ -5,6 +5,7 @@
 
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -26,9 +27,18 @@ const NoInvalidChangeHandlerRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
+
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
@@ -34,7 +34,7 @@ const NoRedundantRoleRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
@@ -7,6 +7,7 @@ const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.
 const { getImplicitRole } = require('../utils/getImplicitRole.js');
 const { getExplicitRole } = require('../utils/getExplicitRole.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -28,9 +29,17 @@ const NoRedundantRoleRule = {
     schema: [],
   },
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
           const analyzer = TemplateAnalyzer.create(node);
           analyzer.traverse({
             enterElement(element) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
@@ -7,6 +7,7 @@ const { roles } = require('aria-query');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isAriaRole } = require('../utils/aria.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 if (!('ListFormat' in Intl)) {
   /* eslint-disable global-require */
@@ -39,10 +40,18 @@ const RoleHasRequiredAriaAttrsRule = {
   create(context) {
     // @ts-expect-error: since we allow node 10. Remove when we require node >= 12
     const formatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
 
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
+
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
@@ -45,13 +45,12 @@ const RoleHasRequiredAriaAttrsRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node) && isLitHtml) {
-
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
@@ -33,13 +33,12 @@ const RoleSupportsAriaAttrRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node) && isLitHtml) {
-
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
@@ -7,6 +7,7 @@ const { roles, aria } = require('aria-query');
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { isAriaPropertyName } = require('../utils/aria.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,9 +28,18 @@ const RoleSupportsAriaAttrRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
+
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
@@ -6,6 +6,7 @@
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -26,9 +27,18 @@ const ScopeRule = {
     schema: [],
   },
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
+
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
@@ -32,13 +32,12 @@ const ScopeRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node) && isLitHtml) {
-
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
@@ -6,6 +6,7 @@
 const { TemplateAnalyzer } = require('../../template-analyzer/template-analyzer.js');
 const { getAttrVal } = require('../utils/getAttrVal.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { hasLitHtmlImport, createValidLitHtmlSources } = require('../utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -25,9 +26,18 @@ const TabindexNoPositiveRule = {
   },
 
   create(context) {
+    let isLitHtml = false;
+    const validLitHtmlSources = createValidLitHtmlSources(context);
+
     return {
+      ImportDeclaration(node) {
+        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+          isLitHtml = true;
+        }
+      },
       TaggedTemplateExpression(node) {
-        if (isHtmlTaggedTemplate(node)) {
+        if (isHtmlTaggedTemplate(node) && isLitHtml) {
+
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
@@ -31,13 +31,12 @@ const TabindexNoPositiveRule = {
 
     return {
       ImportDeclaration(node) {
-        if(hasLitHtmlImport(node, validLitHtmlSources)) {
+        if (hasLitHtmlImport(node, validLitHtmlSources)) {
           isLitHtml = true;
         }
       },
       TaggedTemplateExpression(node) {
         if (isHtmlTaggedTemplate(node) && isLitHtml) {
-
           const analyzer = TemplateAnalyzer.create(node);
 
           analyzer.traverse({

--- a/packages/eslint-plugin-lit-a11y/lib/utils/utils.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/utils.js
@@ -8,6 +8,29 @@ function hasAttr(attributes, attribute) {
   return Object.keys(attributes).includes(attribute);
 }
 
+function createValidLitHtmlSources(context) {
+  return ['lit-html', 'lit-element', ...context.settings.litHtmlSources || []];
+}
+
+function hasLitHtmlImport(node, validLitHtmlSources) {
+  return node.specifiers && node.specifiers.some((specifier) => { // eslint-disable-line
+    return specifier.type
+    && specifier.type === "ImportSpecifier"
+    && specifier.local.name === 'html'
+    && validLitHtmlSources.includes(node.source.value)
+  })
+}
+
+function prependLitHtmlImport(i) {
+  return {
+    ...i,
+    code: `import {html} from 'lit-html';${i.code}`
+  }
+}
+
 module.exports = {
   hasAttr,
+  prependLitHtmlImport,
+  hasLitHtmlImport,
+  createValidLitHtmlSources
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/utils.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/utils.js
@@ -9,28 +9,34 @@ function hasAttr(attributes, attribute) {
 }
 
 function createValidLitHtmlSources(context) {
-  return ['lit-html', 'lit-element', ...context.settings.litHtmlSources || []];
+  return ['lit-html', 'lit-element', ...(context.settings.litHtmlSources || [])];
 }
 
 function hasLitHtmlImport(node, validLitHtmlSources) {
-  return node.specifiers && node.specifiers.some((specifier) => { // eslint-disable-line
-    return specifier.type
-    && specifier.type === "ImportSpecifier"
-    && specifier.local.name === 'html'
-    && validLitHtmlSources.includes(node.source.value)
-  })
+  return (
+    node.specifiers &&
+    node.specifiers.some(specifier => {
+      // eslint-disable-line
+      return (
+        specifier.type &&
+        specifier.type === 'ImportSpecifier' &&
+        specifier.local.name === 'html' &&
+        validLitHtmlSources.includes(node.source.value)
+      );
+    })
+  );
 }
 
 function prependLitHtmlImport(i) {
   return {
     ...i,
-    code: `import {html} from 'lit-html';${i.code}`
-  }
+    code: `import {html} from 'lit-html';${i.code}`,
+  };
 }
 
 module.exports = {
   hasAttr,
   prependLitHtmlImport,
   hasLitHtmlImport,
-  createValidLitHtmlSources
+  createValidLitHtmlSources,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/utils.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/utils.js
@@ -15,8 +15,8 @@ function createValidLitHtmlSources(context) {
 function hasLitHtmlImport(node, validLitHtmlSources) {
   return (
     node.specifiers &&
+    // eslint-disable-next-line
     node.specifiers.some(specifier => {
-      // eslint-disable-line
       return (
         specifier.type &&
         specifier.type === 'ImportSpecifier' &&

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-emoji.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/accessible-emoji');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -37,7 +38,7 @@ ruleTester.run('accessible-emoji', rule, {
     { code: 'html`<span aria-hidden="true">🐼</span>`' },
     { code: 'html`<span aria-hidden>🐼</span>`' },
     { code: 'html`<div aria-hidden="true">🐼</div>`' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -94,5 +95,5 @@ ruleTester.run('accessible-emoji', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/alt-text.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/alt-text');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -22,12 +23,12 @@ const ruleTester = new RuleTester({
 });
 ruleTester.run('alt-text', rule, {
   valid: [
-    { code: "html`<img alt=''/>`" },
+    { code: "html`<img alt=''/>`", settings: { litHtmlSources: ['ing-web']} },
     { code: "html`<img alt='foo'/>`" },
     { code: "html`<img alt='${foo}'/>`" },
     { code: "html`<div role='img' alt='foo'/>`" },
     { code: "html`<img role='presentation'/>`" },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -46,5 +47,5 @@ ruleTester.run('alt-text', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/anchor-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/anchor-has-content.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/anchor-has-content');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -27,7 +28,7 @@ ruleTester.run('anchor-has-content', rule, {
     { code: "html`<a href='#'><div>asdf</div></a>`" },
     { code: "html`<a><div aria-hidden='true'>foo</div>foo</a>`" },
     { code: "html`<a><div aria-hidden='true'>foo</div><div>foo</div></a>`" },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -46,5 +47,5 @@ ruleTester.run('anchor-has-content', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/anchor-is-valid.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/anchor-is-valid.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/anchor-is-valid.js');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 const preferButtonErrorMessage =
   'Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
@@ -117,7 +118,7 @@ ruleTester.run('anchor-is-valid', rule, {
       code: 'html`<a href=${"javascript:void(0)"} @click=${foo} />`',
       options: noHrefAspect,
     },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     { code: 'html`<a />`', errors: [noHrefexpectedError] },
@@ -254,5 +255,5 @@ ruleTester.run('anchor-is-valid', rule, {
       options: noHrefInvalidHrefAspect,
       errors: [invalidHrefErrorMessage],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-activedescendant-has-tabindex.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-activedescendant-has-tabindex.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/aria-activedescendant-has-tabindex');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -56,7 +57,7 @@ ruleTester.run('aria-activedescendant-has-tabindex', rule, {
     {
       code: 'html`<input aria-activedescendant=${someID} tabindex=${-1} />`;',
     },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -67,5 +68,5 @@ ruleTester.run('aria-activedescendant-has-tabindex', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-attr-valid-value.js
@@ -10,6 +10,7 @@
 const { RuleTester } = require('eslint');
 const { aria } = require('aria-query');
 const rule = require('../../../lib/rules/aria-attr-valid-value');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -117,7 +118,7 @@ ruleTester.run('aria-attr-valid-value', rule, {
 
     // CONDITIONAL
     { code: 'html`<div aria-disabled="${this.foo ? "true" : "false"}"></div>`' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     // BOOLEAN
@@ -158,5 +159,5 @@ ruleTester.run('aria-attr-valid-value', rule, {
       code: 'html`<div aria-relevant="additions removalss " />`',
       errors: [errorMessage('aria-relevant')],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-attrs.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/aria-attrs');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -26,7 +27,7 @@ ruleTester.run('aria-attrs', rule, {
       code: "html`<div aria-labelledby='foo'></div>`",
     },
     // give me some code that won't trigger a warning
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -37,5 +38,5 @@ ruleTester.run('aria-attrs', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-role.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/aria-role');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -33,7 +34,7 @@ ruleTester.run('aria-role', rule, {
     { code: "html`<div role='${foo}'></div>`;" },
     { code: 'html`<div role=${foo}></div>`;' },
     { code: 'html`<div></div>`;' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -52,21 +53,5 @@ ruleTester.run('aria-role', rule, {
       code: 'html`<div role="foo">`;',
       errors: [{ message: 'Invalid role "foo".' }],
     },
-    {
-      code: 'html`<div role="${\'foo\'}">`;',
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: 'html`<div role="${"foo"}">`;',
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: "html`<div role=${'foo'}>`;",
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-    {
-      code: 'html`<div role=${"foo"}>`;',
-      errors: [{ message: 'Invalid role "foo".' }],
-    },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-unsupported-elements.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/aria-unsupported-elements.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/aria-unsupported-elements');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -26,7 +27,7 @@ ruleTester.run('aria-unsupported-elements', rule, {
     { code: "html`<meta charset='UTF-8'/>`" },
     { code: 'html`<style></style>`' },
     // give me some code that won't trigger a warning
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -64,5 +65,5 @@ ruleTester.run('aria-unsupported-elements', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/autocomplete-valid.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/autocomplete-valid.js
@@ -10,6 +10,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/autocomplete-valid');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -34,7 +35,7 @@ ruleTester.run('autocomplete-valid', rule, {
     { code: 'html`<input type="text" autocomplete=${autocompl} />;`' },
     { code: 'html`<input type="text" autocomplete="${autocompl || \'name\'}" />;`' },
     { code: 'html`<input type="text" autocomplete="${autocompl || \'foo\'}" />;`' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -93,5 +94,5 @@ ruleTester.run('autocomplete-valid', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/click-events-have-key-events.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/click-events-have-key-events');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -35,7 +36,7 @@ ruleTester.run('click-events-have-key-events', rule, {
     { code: 'html`<input @click=${foo} />`' },
     { code: 'html`<div @click=${foo} @keydown=${foo} />`' },
     { code: 'html`<custom-button @click=${foo} />`', options: [{ allowList: ['custom-button'] }] },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -128,5 +129,5 @@ ruleTester.run('click-events-have-key-events', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/heading-has-content.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/heading-has-content.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/heading-has-content');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -43,7 +44,7 @@ ruleTester.run('heading-has-content', rule, {
     { code: 'html`<h1>${foo(bar)}</h1>`' },
     { code: 'html`<h1>${foo(bar, "hello", 1, true)}</h1>`' },
     { code: 'html`<h1>${this.foo()}</h1>`' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -74,5 +75,5 @@ ruleTester.run('heading-has-content', rule, {
       code: 'html`<h6></h6>`',
       errors: [{ message: '<h6> elements must have accessible content.' }],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/iframe-title.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/iframe-title.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/iframe-title');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -26,7 +27,7 @@ ruleTester.run('iframe-title', rule, {
     { code: 'html`<iframe title="Unique title"></iframe>`' },
     { code: 'html`<iframe title=${foo} ></iframe>`' },
     // give me some code that won't trigger a warning
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -45,5 +46,5 @@ ruleTester.run('iframe-title', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/img-redundant-alt.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/img-redundant-alt');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -33,7 +34,7 @@ ruleTester.run('img-redundant-alt', rule, {
       code: 'html`<img src="baz" alt=${"foo"} />`',
     },
     // give me some code that won't trigger a warning
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -102,5 +103,5 @@ ruleTester.run('img-redundant-alt', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/lit-html-imports.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/lit-html-imports.js
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Images require alt text
+ * @author open-wc
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib/rules/alt-text');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015,
+  },
+});
+ruleTester.run('lit-html-imports', rule, {
+  valid: [
+    { code: "import {html} from 'ing-web'; html`<img alt=''/>`", settings: { litHtmlSources: ['ing-web']} },
+    { code: "import {html} from 'lit-html'; html`<img alt=''/>`", settings: { litHtmlSources: ['ing-web']} },
+    { code: "import {html} from 'lit-element'; html`<img alt=''/>`", settings: { litHtmlSources: ['ing-web']} },
+    { code: "import {html} from 'foo'; html`<img/>`", settings: { litHtmlSources: ['ing-web']} }, // invalid, but no error because `foo` is not a valid lithtmlsource
+    { code: "import html from 'foo'; html`<img/>`", settings: { litHtmlSources: ['ing-web']} }, // invalid, but no error because default export html is not a valid lithtmlsource
+  ],
+  invalid:[]
+});

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/lit-html-imports.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/lit-html-imports.js
@@ -27,6 +27,16 @@ ruleTester.run('lit-html-imports', rule, {
       settings: { litHtmlSources: ['ing-web'] },
     },
     {
+      code: `
+        import bar from 'foo';
+        import * as foo from 'bar';
+        import {baz} from 'baz';
+        import {html} from 'ing-web';
+        html\`<img alt=''/>\`
+      `,
+      settings: { litHtmlSources: ['ing-web'] },
+    },
+    {
       code: "import {html} from 'lit-html'; html`<img alt=''/>`",
       settings: { litHtmlSources: ['ing-web'] },
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/lit-html-imports.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/lit-html-imports.js
@@ -22,11 +22,20 @@ const ruleTester = new RuleTester({
 });
 ruleTester.run('lit-html-imports', rule, {
   valid: [
-    { code: "import {html} from 'ing-web'; html`<img alt=''/>`", settings: { litHtmlSources: ['ing-web']} },
-    { code: "import {html} from 'lit-html'; html`<img alt=''/>`", settings: { litHtmlSources: ['ing-web']} },
-    { code: "import {html} from 'lit-element'; html`<img alt=''/>`", settings: { litHtmlSources: ['ing-web']} },
-    { code: "import {html} from 'foo'; html`<img/>`", settings: { litHtmlSources: ['ing-web']} }, // invalid, but no error because `foo` is not a valid lithtmlsource
-    { code: "import html from 'foo'; html`<img/>`", settings: { litHtmlSources: ['ing-web']} }, // invalid, but no error because default export html is not a valid lithtmlsource
+    {
+      code: "import {html} from 'ing-web'; html`<img alt=''/>`",
+      settings: { litHtmlSources: ['ing-web'] },
+    },
+    {
+      code: "import {html} from 'lit-html'; html`<img alt=''/>`",
+      settings: { litHtmlSources: ['ing-web'] },
+    },
+    {
+      code: "import {html} from 'lit-element'; html`<img alt=''/>`",
+      settings: { litHtmlSources: ['ing-web'] },
+    },
+    { code: "import {html} from 'foo'; html`<img/>`", settings: { litHtmlSources: ['ing-web'] } }, // invalid, but no error because `foo` is not a valid lithtmlsource
+    { code: "import html from 'foo'; html`<img/>`", settings: { litHtmlSources: ['ing-web'] } }, // invalid, but no error because default export html is not a valid lithtmlsource
   ],
-  invalid:[]
+  invalid: [],
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/mouse-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/mouse-events-have-key-events.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/mouse-events-have-key-events.js');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -34,7 +35,7 @@ ruleTester.run('mouse-events-have-key-events', rule, {
     { code: 'html`<div @mouseout=${foo} @blur=${foo} />`' },
     { code: 'html`<div @mouseout=${handleMouseOut} @blur=${handleOnBlur} />`' },
     { code: 'html`<div @mouseout=${handleMouseOut} @blur=${handleOnBlur} />`' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -53,5 +54,5 @@ ruleTester.run('mouse-events-have-key-events', rule, {
       code: 'html`<div @mouseout=${foo} />`',
       errors: ['@mouseout must be accompanied by @blur.'],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-access-key.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-access-key.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/no-access-key');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -24,7 +25,7 @@ ruleTester.run('no-access-key', rule, {
   valid: [
     { code: 'html`<a></a>`' },
     // give me some code that won't trigger a warning
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -51,5 +52,5 @@ ruleTester.run('no-access-key', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-autofocus.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-autofocus.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/no-autofocus');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -24,7 +25,7 @@ ruleTester.run('no-autofocus', rule, {
   valid: [
     { code: 'html`<div></div>`' },
     // give me some code that won't trigger a warning
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -59,5 +60,5 @@ ruleTester.run('no-autofocus', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-distracting-elements.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-distracting-elements.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/no-distracting-elements');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -22,7 +23,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-distracting-elements', rule, {
-  valid: [{ code: 'html`<div></div>`' }],
+  valid: [{ code: 'html`<div></div>`' }].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -41,5 +42,5 @@ ruleTester.run('no-distracting-elements', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-invalid-change-handler.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-invalid-change-handler.js
@@ -22,7 +22,9 @@ const ruleTester = new RuleTester({
   },
 });
 ruleTester.run('no-invalid-change-handler', rule, {
-  valid: [{ code: 'html`<select @blur=${foo}></select>`' }, { code: 'html`<div></div>`' }].map(prependLitHtmlImport),
+  valid: [{ code: 'html`<select @blur=${foo}></select>`' }, { code: 'html`<div></div>`' }].map(
+    prependLitHtmlImport,
+  ),
 
   invalid: [
     {

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-invalid-change-handler.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-invalid-change-handler.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/no-invalid-change-handler');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -21,7 +22,7 @@ const ruleTester = new RuleTester({
   },
 });
 ruleTester.run('no-invalid-change-handler', rule, {
-  valid: [{ code: 'html`<select @blur=${foo}></select>`' }, { code: 'html`<div></div>`' }],
+  valid: [{ code: 'html`<select @blur=${foo}></select>`' }, { code: 'html`<div></div>`' }].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -42,5 +43,5 @@ ruleTester.run('no-invalid-change-handler', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-redundant-role.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-redundant-role.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/no-redundant-role');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -27,7 +28,7 @@ ruleTester.run('no-redundant-role', rule, {
     { code: 'html`<button></button>`' },
     { code: 'html`<div role="button"></div>`' },
     { code: 'html`<img role="presentation"/>`' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -82,5 +83,5 @@ ruleTester.run('no-redundant-role', rule, {
       code: "html`<img role='img'></img>`",
       errors: [{ message: '"img" role is implicit in <img> element.' }],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/role-has-required-aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/role-has-required-aria-attrs.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/role-has-required-aria-attrs');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -30,7 +31,7 @@ ruleTester.run('role-has-required-aria-attrs', rule, {
     { code: 'html`<span role="row"></span>`' },
     { code: 'html`<input type="checkbox" role="switch" aria-checked="true" />`' },
     { code: 'html`<div role="combobox" aria-controls="foo"  aria-expanded="foo"></div>`' },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -50,5 +51,5 @@ ruleTester.run('role-has-required-aria-attrs', rule, {
       code: 'html`<div role="slider" ></div>`',
       errors: [{ message: 'The "slider" role requires the attribute "aria-valuenow".' }],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/role-supports-aria-attr.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/role-supports-aria-attr.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/role-supports-aria-attr');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -24,7 +25,7 @@ ruleTester.run('role-supports-aria-attr', rule, {
   valid: [
     { code: "html`<div role='checkbox' aria-checked='true'></div>`" },
     { code: "html`<div role='presentation'></div>`" },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -39,5 +40,5 @@ ruleTester.run('role-supports-aria-attr', rule, {
         { message: 'The "combobox" role must not be used with the "aria-checked" attribute.\'' },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/scope.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/scope.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/scope');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -29,7 +30,7 @@ ruleTester.run('scope', rule, {
     { code: "html`<th scope='colgroup'></th>`" },
     { code: "html`<foo-bar scope='col'></foo-bar>`" },
     { code: "html`<foo-bar scope='foo'></foo-bar>`" },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -66,5 +67,5 @@ ruleTester.run('scope', rule, {
         },
       ],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/tabindex-no-positive.js
@@ -9,6 +9,7 @@
 
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib/rules/tabindex-no-positive');
+const { prependLitHtmlImport } = require('../../../lib/utils/utils.js');
 
 //------------------------------------------------------------------------------
 // Tests
@@ -37,7 +38,7 @@ ruleTester.run('tabindex-no-positive', rule, {
     {
       code: 'html`<div tabindex=${foo}></div>`',
     },
-  ],
+  ].map(prependLitHtmlImport),
 
   invalid: [
     {
@@ -76,5 +77,5 @@ ruleTester.run('tabindex-no-positive', rule, {
       code: "html`<div tabindex='2'></div>`",
       errors: [{ message: 'Avoid positive tabindex.' }],
     },
-  ],
+  ].map(prependLitHtmlImport),
 });


### PR DESCRIPTION
Only run rules if lit-html is imported from a valid lit-html source. Default valid sources are: `['lit-html', 'lit-element']`, and additional valid lit-html sources (in case a package re-exports lit-html) can be configured via

```js
settings: {
  litHtmlSources: ['ing-web']
}
```

closes https://github.com/open-wc/open-wc/issues/1904