### PR TITLE
Properly capitalize "GitHub" in site footer

### DIFF
--- a/docs/_data/footer.json
+++ b/docs/_data/footer.json
@@ -20,7 +20,7 @@
     "name": "Follow",
     "children": [
       {
-        "text": "Github",
+        "text": "GitHub",
         "href": "https://github.com/open-wc/open-wc"
       },
       {


### PR DESCRIPTION
## What I did

1. Changed "Github" to "GitHub" in the site footer.
