### PR TITLE
feat: define lazy components by element instance instead of by class

### DIFF
--- a/.changeset/eighty-sheep-agree.md
+++ b/.changeset/eighty-sheep-agree.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': minor
+---
+
+Define lazy components per Scoped Element instance instead of by Scoped Element class. This forces `getScopedTagName` method to stop being a static method.

--- a/packages/scoped-elements/README.md
+++ b/packages/scoped-elements/README.md
@@ -148,7 +148,7 @@ export class MyElement extends ScopedElementsMixin(LitElement) {
 
 ### Obtaining a scoped tag name
 
-Maybe you want to create a scoped element programmatically and don't know which one is the scoped tag name? No problem, there is a static method called `getScopedTagName` that would help you for that.
+Maybe you want to create a scoped element programmatically and don't know which one is the scoped tag name? No problem, there is a method called `getScopedTagName` that would help you for that.
 
 ```js
 import { LitElement } from 'lit-element';
@@ -167,7 +167,7 @@ export class MyElement extends ScopedElementsMixin(LitElement) {
   constructor() {
     super();
 
-    const scopedTagName = this.constructor.getScopedTagName('my-button');
+    const scopedTagName = this.getScopedTagName('my-button');
 
     // do whatever you need with the scopedTagName
   }

--- a/packages/scoped-elements/src/Cache.js
+++ b/packages/scoped-elements/src/Cache.js
@@ -1,0 +1,49 @@
+/**
+ * Cache class that allows to search in a cache hierarchy.
+ * @template T, Q
+ */
+export class Cache {
+  /**
+   * Creates a Cache instance
+   * @param {Cache} [parent]
+   */
+  constructor(parent) {
+    this._parent = parent;
+    this._cache = new Map();
+  }
+
+  /**
+   * Returns a boolean indicating whether an element with the specified key exists or not.
+   *
+   * @param {T} key - The key of the element to test for presence in the Cache object.
+   * @return {boolean}
+   */
+  has(key) {
+    return !!(this._cache.has(key) || this._parent?._cache.has(key));
+  }
+
+  /**
+   * Adds or updates an element with a specified key and a value to a Cache object.
+   *
+   * @param {T} key - The key of the element to add to the Cache object.
+   * @param {Q} value - The value of the element to add to the Cache object.
+   * @return {Cache<T, Q>} the cache object
+   */
+  set(key, value) {
+    this._cache.set(key, value);
+
+    return this;
+  }
+
+  /**
+   * Returns a specified element from a Map object. If the value that is associated to the provided key is an
+   * object, then you will get a reference to that object and any change made to that object will effectively modify
+   * it inside the Map object.
+   *
+   * @param {T} key - The key of the element to return from the Cache object.
+   * @return {Q}
+   */
+  get(key) {
+    return this._cache.get(key) || this._parent?._cache.get(key);
+  }
+}

--- a/packages/scoped-elements/src/globalTagsCache.js
+++ b/packages/scoped-elements/src/globalTagsCache.js
@@ -1,9 +1,9 @@
 /**
  * The global cache for tag names
  *
- * @type {Map<typeof HTMLElement, string>}
+ * @type {WeakMap<typeof HTMLElement, string>}
  */
-const globalTagsCache = new Map();
+const globalTagsCache = new WeakMap();
 
 /**
  * Adds a tag to the global tags cache

--- a/packages/scoped-elements/src/registerElement.js
+++ b/packages/scoped-elements/src/registerElement.js
@@ -26,7 +26,7 @@ const defineElement = (tagName, klass, registry = customElements) => {
  *
  * @param {string} tagName
  * @param {CustomElementRegistry} registry
- * @param {Map<string, string>} tagsCache
+ * @param {import('./Cache.js').Cache<string, string>} tagsCache
  * @returns {string}
  */
 const storeLazyElementInCache = (tagName, registry, tagsCache) => {
@@ -46,7 +46,7 @@ const storeLazyElementInCache = (tagName, registry, tagsCache) => {
  *
  * @param {string} tagName
  * @param {typeof HTMLElement} klass
- * @param {Map<string, string>} tagsCache
+ * @param {import('./Cache.js').Cache<string, string>} tagsCache
  * @returns {string}
  */
 const defineElementAndStoreInCache = (tagName, klass, tagsCache) => {
@@ -76,7 +76,7 @@ const defineElementAndStoreInCache = (tagName, klass, tagsCache) => {
  * @exports
  * @param {string} tagName
  * @param {typeof HTMLElement} klass
- * @param {Map<string, string>} tagsCache
+ * @param {import('./Cache.js').Cache<string, string>} tagsCache
  * @returns {string}
  */
 export function registerElement(tagName, klass, tagsCache = undefined) {
@@ -93,7 +93,7 @@ export function registerElement(tagName, klass, tagsCache = undefined) {
  *
  * @param {string} tagName
  * @param {typeof HTMLElement} klass
- * @param {Map<string, string>} tagsCache
+ * @param {import('./Cache.js').Cache<string, string>} tagsCache
  */
 export function defineScopedElement(tagName, klass, tagsCache) {
   const tag = tagsCache.get(tagName);

--- a/packages/scoped-elements/src/transform.js
+++ b/packages/scoped-elements/src/transform.js
@@ -1,4 +1,5 @@
 import { registerElement } from './registerElement.js';
+import { Cache } from './Cache.js';
 
 /**
  * @typedef {import('./types').ScopedElementsMap} ScopedElementsMap
@@ -21,9 +22,9 @@ const re = new RegExp(`<\\/?([a-z](${chars})*-(${chars})*)`, 'g');
 /**
  * The global cache of processed string arrays
  *
- * @type {Map<TemplateStringsArray, TemplateStringsArray>}
+ * @type {Cache<TemplateStringsArray, TemplateStringsArray>}
  */
-const globalCache = new Map();
+const globalCache = new Cache();
 
 /**
  * Find custom element tags in the string
@@ -47,8 +48,8 @@ const matchAll = str => {
  *
  * @param {TemplateStringsArray} strings
  * @param {ScopedElementsMap} scopedElements
- * @param {Map<TemplateStringsArray, TemplateStringsArray>} templateCache
- * @param {Map<string, string>} tagsCache
+ * @param {Cache<TemplateStringsArray, TemplateStringsArray>} templateCache
+ * @param {Cache<string, string>} tagsCache
  * @returns {TemplateStringsArray}
  */
 const transformTemplate = (strings, scopedElements, templateCache, tagsCache) => {
@@ -88,8 +89,8 @@ const transformTemplate = (strings, scopedElements, templateCache, tagsCache) =>
  * @exports
  * @param {TemplateStringsArray} strings
  * @param {ScopedElementsMap} scopedElements
- * @param {Map<TemplateStringsArray, TemplateStringsArray>} templateCache
- * @param {Map<string, string>} tagsCache
+ * @param {import('./Cache.js').Cache<TemplateStringsArray, TemplateStringsArray>} templateCache
+ * @param {import('./Cache.js').Cache<string, string>} tagsCache
  * @returns {TemplateStringsArray}
  */
 export function transform(strings, scopedElements, templateCache = globalCache, tagsCache) {

--- a/packages/scoped-elements/test-web/Cache.test.js
+++ b/packages/scoped-elements/test-web/Cache.test.js
@@ -1,0 +1,122 @@
+import { expect } from '@open-wc/testing';
+import { Cache } from '../src/Cache.js';
+
+describe('Cache', () => {
+  it('should be constructable', () => {
+    const cache = new Cache();
+
+    expect(cache).to.be.instanceof(Cache);
+  });
+
+  it('should be constructable specifying a parent cache', () => {
+    const parent = new Cache();
+    const cache = new Cache(parent);
+
+    expect(cache).to.be.instanceof(Cache);
+    expect(cache._parent).to.be.instanceof(Cache);
+  });
+
+  describe('has', () => {
+    it(`should return false if the key doesn't exist in hierarchy`, () => {
+      const parent = new Cache();
+      const cache = new Cache(parent);
+
+      expect(cache.has('key')).to.be.false;
+    });
+
+    it(`should return true if the key exist`, () => {
+      const cache = new Cache();
+      cache._cache.set('key', 'value');
+
+      expect(cache.has('key')).to.be.true;
+    });
+
+    it(`should return true if the key exist in hierarchy`, () => {
+      const parent = new Cache();
+      const cache = new Cache(parent);
+      parent._cache.set('key', 'value');
+
+      expect(cache.has('key')).to.be.true;
+    });
+  });
+
+  describe('set', () => {
+    it('should store a value with the specified key', () => {
+      const key = 'key';
+      const value = 'value';
+      const cache = new Cache();
+      cache.set(key, value);
+
+      expect(cache._cache.has(key)).to.be.true;
+      expect(cache._cache.get(key)).to.be.equal(value);
+    });
+
+    it(`shouldn't store a value in the parent cache`, () => {
+      const key = 'key';
+      const value = 'value';
+      const parent = new Cache();
+      const cache = new Cache(parent);
+      cache.set(key, value);
+
+      expect(parent._cache.has(key)).to.be.false;
+    });
+
+    it('should update an existing key value in case it exists', () => {
+      const key = 'key';
+      const value = 'value';
+      const previousValue = 'previous';
+      const cache = new Cache();
+      cache._cache.set(key, previousValue);
+
+      expect(cache._cache.has(key)).to.be.true;
+      expect(cache._cache.get(key)).to.be.equal(previousValue);
+
+      cache.set(key, value);
+
+      expect(cache._cache.get(key)).to.be.equal(value);
+    });
+
+    it('should return the cache object', () => {
+      const cache = new Cache();
+
+      const returnedObject = cache.set('key', 'value');
+
+      expect(returnedObject).to.be.equal(cache);
+    });
+  });
+
+  describe('get', () => {
+    it('should return undefined in case the key is not in hierarchy', () => {
+      const parent = new Cache();
+      const cache = new Cache(parent);
+
+      expect(cache.get('key')).to.be.undefined;
+    });
+
+    it('should return undefined in case the key is not provided', () => {
+      const parent = new Cache();
+      const cache = new Cache(parent);
+
+      expect(cache.get(undefined)).to.be.undefined;
+    });
+
+    it('should return a stored key', () => {
+      const key = 'key';
+      const value = 'value';
+      const cache = new Cache();
+      cache._cache.set(key, value);
+
+      expect(cache.get(key)).to.be.equal(value);
+    });
+
+    it('should return a stored key in hierarchy', () => {
+      const key = 'key';
+      const value = 'value';
+      const parent = new Cache();
+      const cache = new Cache(parent);
+      parent._cache.set(key, value);
+
+      expect(cache.get(key)).to.be.equal(value);
+    });
+  });
+});


### PR DESCRIPTION
## What I did

1. Allows lazy components to be defined by scoped element instances instead of by scoped elements classes.

this change makes scoped elements to be more aligned with the scoped registries proposal.