### PR TITLE
Adding Application publishing link to developing-components/publishin…

### DIFF
--- a/docs/guides/developing-components/publishing.md
+++ b/docs/guides/developing-components/publishing.md
@@ -1,5 +1,7 @@
 # Developing Components >> Publishing ||60
 
+Refer for [Application publishing](../../docs/building/rollup.md) guide as it is different from Component. 
+
 When you are ready to publish your package to npm, be sure that you've addressed the recommendations below to ensure the code you publish is as easy for your users to consume as possible. Your package should already have [demos](/demoing/), [documentation](/demoing/storybook-addon-markdown-docs.html), [tests](/testing/), et al, as each of these plays a role in making the clearest example of the benefits on your work, outlining the easiest path to integrating that work into other projects, and ensuring that the package as a whole is resilient to change over time. With this reality in mind, they will not be discussed directly below. If you're looking for information on including these things in your published packages, take a look at our [guides](/guide/index.html) or learn about [getting started](#getting-started) below.
 
 ```js script

--- a/docs/guides/developing-components/publishing.md
+++ b/docs/guides/developing-components/publishing.md
@@ -1,6 +1,6 @@
 # Developing Components >> Publishing ||60
 
-Refer for [Application publishing](../../docs/building/rollup.md) guide as it is different from Component. 
+> Note: This guide is intended for publishing components, not applications. You can find more information about bundling applications [here](../../docs/building/rollup.md).
 
 When you are ready to publish your package to npm, be sure that you've addressed the recommendations below to ensure the code you publish is as easy for your users to consume as possible. Your package should already have [demos](/demoing/), [documentation](/demoing/storybook-addon-markdown-docs.html), [tests](/testing/), et al, as each of these plays a role in making the clearest example of the benefits on your work, outlining the easiest path to integrating that work into other projects, and ensuring that the package as a whole is resilient to change over time. With this reality in mind, they will not be discussed directly below. If you're looking for information on including these things in your published packages, take a look at our [guides](/guide/index.html) or learn about [getting started](#getting-started) below.
 


### PR DESCRIPTION
…g.md

Component publishing is surfaced before application and when looking for "publishing" or "build" info. Hence I assumed that build is not really applicable in open-wc overall. Which is obviously not true as it is in scope of application publishing. The cross-reference on different approaches to publishing in Component and in Application docs would clear the difference. 
Unfortunately for application I have not found similar page, so used rollup build page for this reference.

## What I did

1. Added link to App publish docs
