### PR TITLE
fix(scoped-elements): refactor to remove optional chain in Cache

### DIFF
--- a/.changeset/plenty-plants-hunt.md
+++ b/.changeset/plenty-plants-hunt.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+refactor to remove optional chaining syntax in Cache file for better tooling compatibility

--- a/packages/scoped-elements/src/Cache.js
+++ b/packages/scoped-elements/src/Cache.js
@@ -19,7 +19,7 @@ export class Cache {
    * @return {boolean}
    */
   has(key) {
-    return !!(this._cache.has(key) || this._parent?._cache.has(key));
+    return !!(this._cache.has(key) || (this._parent && this._parent._cache.has(key)));
   }
 
   /**
@@ -44,6 +44,6 @@ export class Cache {
    * @return {Q}
    */
   get(key) {
-    return this._cache.get(key) || this._parent?._cache.get(key);
+    return this._cache.get(key) || (this._parent && this._parent._cache.get(key));
   }
 }

--- a/packages/scoped-elements/test-web/Cache.test.js
+++ b/packages/scoped-elements/test-web/Cache.test.js
@@ -24,6 +24,12 @@ describe('Cache', () => {
       expect(cache.has('key')).to.be.false;
     });
 
+    it(`should return false if the key does not exist and no parent exists`, () => {
+      const cache = new Cache();
+
+      expect(cache.has('key')).to.be.false;
+    });
+
     it(`should return true if the key exist`, () => {
       const cache = new Cache();
       cache._cache.set('key', 'value');
@@ -89,6 +95,12 @@ describe('Cache', () => {
     it('should return undefined in case the key is not in hierarchy', () => {
       const parent = new Cache();
       const cache = new Cache(parent);
+
+      expect(cache.get('key')).to.be.undefined;
+    });
+
+    it('should return undefined in case key does not exist and parent does not exist', () => {
+      const cache = new Cache();
 
       expect(cache.get('key')).to.be.undefined;
     });


### PR DESCRIPTION
## What I did

1. Refactored code to improve tooling support. Optional chaining isn't fully supported yet (namely webpack 4). Though it does look like most tools are "close" to it.
2. Addresses https://github.com/open-wc/open-wc/issues/1979