### PR TITLE
Add DataFormsJS to [docs/_data/baseLibraries.js]

### DIFF
--- a/docs/_data/baseLibraries.js
+++ b/docs/_data/baseLibraries.js
@@ -128,6 +128,12 @@ const baseLibraries = [
     description: 'µhtml based Custom Elements.',
     url: 'https://github.com/WebReflection/uce',
   },
+  {
+    name: 'DataFormsJS',
+    package: 'dataformsjs',
+    description: 'Set of Web Components that can be used to build Single Page Apps (SPA), Display JSON data from API’s and Web Services, and bind data to different elements on screen. All Web Components are plain JavaScript and require no build process.',
+    url: 'https://github.com/dataformsjs/dataformsjs',
+  },
 ];
 
 module.exports = async function getBaseLibraries() {


### PR DESCRIPTION
## What I did

1. Add DataFormsJS Web Components https://www.dataformsjs.com/ to data file so they can appear in https://open-wc.org/guides/community/base-libraries/
