### PR TITLE
docs: ensure that landing on the docs page does not strand mobile users

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -7,4 +7,14 @@ eleventyNavigation:
 
 Our documentation is hand crafted and optimized to serve as a dictionary to look up details once the need arises.
 
+Go deeper in the following areas:
+
+- [Development](./development/generator.md)
+- [Testing](./testing/testing-package.md)
+- [Demoing](./demoing/storybook.md)
+- [Building](./building/overview.md)
+- [Linting](./linting/eslint-plugin-lit-a11y/overview.md)
+- [Legacy](./legacy/legacy-projects.md)
+- [Experimental](./experimental/mdjs.md)
+
 For a more guided learning experience please visit our [Guides](../guides/).


### PR DESCRIPTION
## What I did

1. Added a list of top level pages in the Documentation section to prevent mobile entry to the section to look empty.
