### PR TITLE
doc: Update link to storybook templating folder

### DIFF
--- a/docs/docs/demoing/storybook.md
+++ b/docs/docs/demoing/storybook.md
@@ -45,7 +45,7 @@ When looking to have the Storybook configuration files added to you project, be 
 ### Manual
 
 - `yarn add @open-wc/demoing-storybook --dev`
-- Copy at minimum the [.storybook](https://github.com/open-wc/open-wc/tree/master/packages/create/src/generators/demoing-storybook/templates/static/.storybook) folder to `.storybook`
+- Copy at minimum the [.storybook](https://github.com/open-wc/create/tree/master/src/generators/demoing-storybook/templates/static/.storybook) folder to `.storybook`
 - If you want to bring along the examples, you may also copy the `stories` folder.
 - Be sure you have a [custom-elements.json](#custom-elementsjson) file.
 - Add the following scripts to your package.json


### PR DESCRIPTION
1. After moving create package in another repositories, a link in storybook.md isn't up to date.
