### PR TITLE
fix(dev-server-hmr): allow prototype modification

### DIFF
--- a/.changeset/stale-ways-unite.md
+++ b/.changeset/stale-ways-unite.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/dev-server-hmr': patch
+---
+
+allow prototype modification

--- a/packages/dev-server-hmr/demo/fast-element/src/todo-app.ts
+++ b/packages/dev-server-hmr/demo/fast-element/src/todo-app.ts
@@ -10,6 +10,4 @@ const template = html<TodoApp>`
   name: 'todo-app',
   template,
 })
-class TodoApp extends FASTElement {
-  static definition = { name: 'todo-app', template };
-}
+class TodoApp extends FASTElement {}

--- a/packages/dev-server-hmr/src/presets/haunted.js
+++ b/packages/dev-server-hmr/src/presets/haunted.js
@@ -1,7 +1,7 @@
 const patch = `import { WebComponentHmr } from '/__web-dev-server__/wc-hmr/runtime.js';
 
 HTMLElement.prototype.hotReplacedCallback = function hotReplacedCallback() {
-  const temp = new this.constructor();
+  const temp = document.createElement(this.localName);
   this._scheduler.renderer = temp._scheduler.renderer;
   this._scheduler.update();
 };


### PR DESCRIPTION
## What I did

When using a proxy, the `.prototype` property must always return the original value. This is a problem when modification the prototype, this happens for example when decorators are compiled away. 

I updated the HMR runtime to return a new proxy each time a class is replaced. We also need to update references to the `constructor` to this new proxy, to keep things in sync.