### PR TITLE
feat(eslint-config): add MJS and TS extensions

### DIFF
--- a/.changeset/wise-mayflies-buy.md
+++ b/.changeset/wise-mayflies-buy.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/eslint-config': minor
+---
+
+added MJS and TS extensions

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -41,11 +41,11 @@ module.exports = {
       'error',
       {
         devDependencies: [
-          '**/test/**/*.js',
-          '**/stories/**/*.js',
-          '**/demo/**/*.js',
-          '**/*.config.js',
-          '**/*.conf.js',
+          '**/test/**/*.{js,mjs,ts}',
+          '**/stories/**/*.{js,mjs,ts}',
+          '**/demo/**/*.{js,mjs,ts}',
+          '**/*.config.{js,mjs,ts}',
+          '**/*.conf.{js,mjs,ts}',
         ],
       },
     ],
@@ -83,7 +83,11 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/test/**/*.js', '**/demo/**/*.js', '**/stories/**/*.js'],
+      files: [
+        '**/test/**/*.{js,mjs,ts}',
+        '**/demo/**/*.{js,mjs,ts}',
+        '**/stories/**/*.{js,mjs,ts}',
+      ],
       rules: {
         'no-console': 'off',
         'no-unused-expressions': 'off',


### PR DESCRIPTION
## What I did

Allow MJS and TS file extensions in some of the eslint config overrides.
