### PR TITLE
fix(lit-helpers): peer dependency versions

### DIFF
--- a/.changeset/metal-hats-fly.md
+++ b/.changeset/metal-hats-fly.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/lit-helpers': patch
+---
+
+updated peer dependency version of lit-element to 2.x

--- a/packages/lit-helpers/package.json
+++ b/packages/lit-helpers/package.json
@@ -30,8 +30,8 @@
     "helpers"
   ],
   "peerDependencies": {
-    "lit-element": "^2",
-    "lit-html": ">= 1 < 2"
+    "lit-element": "^2.0.0",
+    "lit-html": "^1.0.0"
   },
   "sideEffects": false
 }

--- a/packages/lit-helpers/package.json
+++ b/packages/lit-helpers/package.json
@@ -30,8 +30,8 @@
     "helpers"
   ],
   "peerDependencies": {
-    "lit-element": "^1.0.0",
-    "lit-html": "^1.0.0"
+    "lit-element": "^2",
+    "lit-html": ">= 1 < 2"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
## What I did

1. widened the peerDependencies version constraints for lit-element and lit-html in the `lit-helpers` package
