### PR TITLE
fix(scoped-elements): add constructor to type definition

### DIFF
--- a/.changeset/clean-impalas-study.md
+++ b/.changeset/clean-impalas-study.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Add constructor to ScopedElementsHost type so that base constructors have the same return type as extensions. See [TypeScript issue](https://github.com/microsoft/TypeScript/issues/40110).

--- a/packages/scoped-elements/src/types.d.ts
+++ b/packages/scoped-elements/src/types.d.ts
@@ -1,11 +1,12 @@
-import { Constructor } from "@open-wc/dedupe-mixin";
-import { LitElement } from "lit-element";
+import { Constructor } from '@open-wc/dedupe-mixin';
+import { LitElement } from 'lit-element';
 
 export type ScopedElementsMap = {
-    [key: string]: typeof HTMLElement;
-}
+  [key: string]: typeof HTMLElement;
+};
 
 export declare class ScopedElementsHost {
+  constructor(...args: any[]);
   /**
    * Obtains the scoped elements definitions map
    */
@@ -24,9 +25,11 @@ export declare class ScopedElementsHost {
   /**
    * Defines a scoped element
    */
-  defineScopedElement<T extends HTMLElement>(tagName: string, klass: Constructor<T>): void
+  defineScopedElement<T extends HTMLElement>(tagName: string, klass: Constructor<T>): void;
 }
 
-declare function ScopedElementsMixinImplementation<T extends Constructor<LitElement>>(superclass: T): T & Constructor<ScopedElementsHost> & typeof ScopedElementsHost
+declare function ScopedElementsMixinImplementation<T extends Constructor<LitElement>>(
+  superclass: T,
+): T & Constructor<ScopedElementsHost> & typeof ScopedElementsHost;
 
 export type ScopedElementsMixin = typeof ScopedElementsMixinImplementation;


### PR DESCRIPTION
In short: In order to implement the mixin in a LitElement, which has a constructor, the scoped elements host (base class) also needs a constructor with the same return type (void I guess?). Otherwise TSC will scream at you. 

More details: https://github.com/microsoft/TypeScript/issues/40110

