### PR TITLE
fix(dev-server-hmr): fix compatibility with scoped-elements

### DIFF
--- a/.changeset/unlucky-rings-relax.md
+++ b/.changeset/unlucky-rings-relax.md
@@ -1,0 +1,5 @@
+---
+"@open-wc/dev-server-hmr": patch
+---
+
+fix(dev-server-hmr): fix compatibility with scoped-elements

--- a/packages/dev-server-hmr/src/wcHmrRuntime.js
+++ b/packages/dev-server-hmr/src/wcHmrRuntime.js
@@ -90,9 +90,12 @@ export class WebComponentHmr extends HTMLElement {
   constructor(...args) {
     super(...args);
     const key = keysForClasses.get(this.constructor);
-    const p = proxiesForKeys.get(key);
-    // replace the constructor with a proxy that references the latest implementation of this class
-    this.constructor = p.currentProxy;
+    // check if the constructor is registered
+    if (key) {
+      const p = proxiesForKeys.get(key);
+      // replace the constructor with a proxy that references the latest implementation of this class
+      this.constructor = p.currentProxy;
+    }
     // replace prototype chain with a proxy to the latest prototype implementation
     replacePrototypesWithProxies(this);
   }


### PR DESCRIPTION
fixes: https://github.com/modernweb-dev/web/issues/1177

## What I did

1. I added a check for the constructor of the `WebComponentHmr` class so that it doesn't assume that the class the component is an instance of was actually registered in the `keysForClasses` map

## Background information

When delving into https://github.com/modernweb-dev/web/issues/1177 , I found out that the reason for the problems mentioned there were:

- [The way scoped-elements creates a class that extends the original class](https://github.com/open-wc/open-wc/blob/master/packages/scoped-elements/src/registerElement.js#L21)
- The way data is stored and accessed in the [`keyForClasses` map in wcHmrRuntime](https://github.com/open-wc/open-wc/blob/master/packages/dev-server-hmr/src/wcHmrRuntime.js#L92)

From what I've been able to understand, the `register` function in wcHmrRuntime is called for every class that extends the `baseClasses` declared when configuring hmr, so those are the classes stored in `keysForClasses`

But when accessing the data in `keysForClasses`, `this.constructor` is used as a way of getting the reference to the class the web component instanced

This would normally not be a problem, but since scoped-elements creates an anonymous class extending the original one, it also tries to look for that anonymous class rather than the original one

But I noticed that the `replacePrototypesWithProxies` method already seems to be doing the replacing for all the classes the component inherits

So for this case, just 'ignoring' the constructor for the first class seems to solve the issue without breaking any other parts
