### PR TITLE
Update rollup to fail on error

### DIFF
--- a/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
+++ b/packages/demoing-storybook/src/build/rollup/createRollupConfig.js
@@ -76,7 +76,7 @@ function createRollupConfig({ outputDir, indexFilename, indexHTMLString }) {
                 '@open-wc/testing-helpers': ['html', { name: 'css', encapsulation: 'style' }],
               },
               logOnError: true,
-              failOnError: false,
+              failOnError: true,
               strictCSS: true,
               htmlMinifier: {
                 collapseWhitespace: true,


### PR DESCRIPTION
I got ran into mysterious error in CI with no context and exit code 0. 

> html-minifier-terser deleted something major, cannot proceed.

It's because Rollup is configured to swallow exceptions. After making this change directly in my node_modules, I was able to get a stack trace and diagnose the problem immediately.



