### PR TITLE
Use relative path in snippet instead of absolute

### DIFF
--- a/docs/docs/building/rollup.md
+++ b/docs/docs/building/rollup.md
@@ -400,7 +400,7 @@ export default merge(baseConfig, {
   input: './index.html',
   plugins: [
     copy({
-      targets: [{ src: 'assets/**/*', dest: '/dist' }],
+      targets: [{ src: 'assets/**/*', dest: './dist' }],
       // set flatten to false to preserve folder structure
       flatten: false,
     }),


### PR DESCRIPTION
Copy pasted the snippet tonight and got a bit of a surprise: 

```
./index.html → dist...
[!] (plugin copy) Error: EROFS: read-only file system, mkdir '/dist'
Error: EROFS: read-only file system, mkdir '/dist'

npm ERR! code 1
npm ERR! path /Users/jlengrand/Developer/paper-dashboard
npm ERR! command failed
npm ERR! command sh -c rimraf dist && tsc && rollup -c rollup.config.js

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jlengrand/.npm/_logs/2021-02-02T23_00_23_984Z-debug.log
```

A little scary ?! :)

## What I did

1.
