### PR TITLE
Remove Morningstar Design System, as it doesn't seen to use web components

### DIFF
--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -103,12 +103,6 @@ const componentLibraries = [
       "Material Design Components from Material Design team themselves. Stay as close as possible to the changing specification with these components from Google's own Material Design team.",
   },
   {
-    name: 'Morningstar',
-    url: 'http://designsystem.morningstar.com/components/component-status.html',
-    description:
-      'The Morningstar Design System combines vanilla HTML/CSS with web components in just the right proportions to empower the design and development of wide reaching content and functionality.',
-  },
-  {
     name: 'Shoelace',
     url: 'https://shoelace.style/',
     description:


### PR DESCRIPTION
The docs don't mention web components and inspecting the demos doesn't show any actual web components. The "markup" shown looks like custom elements, but it's just Vue template syntax.

https://designsystem.morningstar.com/getting-started/for-engineers/

It looks like @daKmoR or @Westbrook might have been the original authors of the page that included this. Not sure if they have more context.