### PR TITLE
Update helpers.md to include correct timeout

### DIFF
--- a/docs/docs/testing/helpers.md
+++ b/docs/docs/testing/helpers.md
@@ -189,7 +189,7 @@ await waitUntil(
 );
 ```
 
-`waitUntil` has a default timeout of 2000ms and a polling interval of 50ms. This can be customized:
+`waitUntil` has a default timeout of 1000ms and a polling interval of 50ms. This can be customized:
 
 ```js
 await waitUntil(predicate, 'Element should become visible', { interval: 10, timeout: 10000 });


### PR DESCRIPTION
## What I did

1. Updated helpers.md to include the correct default timeout for `waitUntil`.
