### PR TITLE
fix(lit-helpers): read-only-properties types

### DIFF
--- a/.changeset/soft-pillows-pump.md
+++ b/.changeset/soft-pillows-pump.md
@@ -1,0 +1,7 @@
+---
+"@open-wc/lit-helpers": patch
+---
+
+fix(lit-helpers): read-only-properties types
+
+Previous types had incorrect documentation, and caused compiler errors when consumed as a transient dependency.

--- a/packages/lit-helpers/src/read-only-properties-mixin.d.ts
+++ b/packages/lit-helpers/src/read-only-properties-mixin.d.ts
@@ -1,8 +1,4 @@
-// when we update to typescript 3.8
-// import type { LitElement } from "lit-element";
-import { LitElement } from "lit-element";
-
-declare type Constructor<T = {}> = new (...args: any[]) => T;
+import type { LitElement, Constructor } from "lit-element";
 
 declare module 'lit-element/lib/updating-element' {
   interface PropertyDeclaration {
@@ -10,18 +6,18 @@ declare module 'lit-element/lib/updating-element' {
   }
 }
 
-export interface ReadOnlyClass {
+/**
+ * Enables the optional readOnly property on property declarations, 
+ * and adds `setReadOnlyProperties(properties)` to elements
+ */
+export declare function ReadOnlyPropertiesMixin<T extends Constructor<LitElement>>(superclass: T): T & Constructor<{
   /**
    * Set read-only properties
+   * @protected
    */
   setReadOnlyProperties(props: {
     [s: string]: unknown;
   }): Promise<void>;
-}
-
-/**
- * Enables the nofity option for properties to fire change notification events
- */
-export declare function ReadOnlyPropertiesMixin<T extends Constructor<LitElement>>(superclass: T): T & Constructor<ReadOnlyClass>;
+}>;
 
 export {};


### PR DESCRIPTION
Previous types had incorrect documentation, and caused
compiler errors when consumed as a transient dependency.

## What I did

1. inline the class mixin interface to the function return type
2. correct the inline documentation
3. remove ts pre-4 comments
