### PR TITLE
feat(eslint-config): add HTML extension

### DIFF
--- a/.changeset/tender-spies-hear.md
+++ b/.changeset/tender-spies-hear.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/eslint-config': minor
+---
+
+added HTML extension

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -41,11 +41,11 @@ module.exports = {
       'error',
       {
         devDependencies: [
-          '**/test/**/*.{js,mjs,ts}',
-          '**/stories/**/*.{js,mjs,ts}',
-          '**/demo/**/*.{js,mjs,ts}',
-          '**/*.config.{js,mjs,ts}',
-          '**/*.conf.{js,mjs,ts}',
+          '**/test/**/*.{html,js,mjs,ts}',
+          '**/stories/**/*.{html,js,mjs,ts}',
+          '**/demo/**/*.{html,js,mjs,ts}',
+          '**/*.config.{html,js,mjs,ts}',
+          '**/*.conf.{html,js,mjs,ts}',
         ],
       },
     ],
@@ -84,9 +84,9 @@ module.exports = {
   overrides: [
     {
       files: [
-        '**/test/**/*.{js,mjs,ts}',
-        '**/demo/**/*.{js,mjs,ts}',
-        '**/stories/**/*.{js,mjs,ts}',
+        '**/test/**/*.{html,js,mjs,ts}',
+        '**/demo/**/*.{html,js,mjs,ts}',
+        '**/stories/**/*.{html,js,mjs,ts}',
       ],
       rules: {
         'no-console': 'off',


### PR DESCRIPTION
## What I did

Added `html` extension to the config for excluding rules in test folders. This will allow me to write test files with [@web/dev-server-import-maps](https://modern-web.dev/docs/dev-server/plugins/import-maps/) (which requires using HTML files) without getting ESLint errors.