### PR TITLE
chore(deps): remove unneeded babel plugins

### DIFF
--- a/.changeset/good-starfishes-brake.md
+++ b/.changeset/good-starfishes-brake.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/building-rollup': minor
+---
+
+Remove unneeded babel plugins

--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -50,14 +50,12 @@
     "rollup"
   ],
   "peerDependencies": {
-    "rollup": "^2.7.2"
+    "rollup": "^2.11.0"
   },
   "dependencies": {
     "@babel/core": "^7.11.1",
     "@babel/helpers": "^7.10.4",
     "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-    "@babel/plugin-proposal-optional-chaining": "^7.11.0",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-transform-modules-systemjs": "^7.10.5",

--- a/packages/building-rollup/src/babel/babel-configs.js
+++ b/packages/building-rollup/src/babel/babel-configs.js
@@ -24,10 +24,6 @@ const createBabelConfigRollupBuild = ({ developmentMode, rootDir }) => ({
     ],
   ],
   plugins: [
-    // rollup doesn't support optional chaining yet, so we compile it during input
-    [require.resolve('@babel/plugin-proposal-optional-chaining'), { loose: true }],
-    [require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'), { loose: true }],
-
     // plugins that aren't part of @babel/preset-env should be applied regularly in
     // the rollup build phase
     [require.resolve('babel-plugin-bundled-import-meta'), { bundleDir: rootDir }],


### PR DESCRIPTION
Now Rollup already support it.

- https://github.com/rollup/rollup/pull/3582
- https://github.com/rollup/rollup/pull/3548