### PR TITLE
fix(scoped-elements): mark loadPolyfill.js as a side effect

### DIFF
--- a/.changeset/gorgeous-hotels-lay.md
+++ b/.changeset/gorgeous-hotels-lay.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Mark `loadPolyfill.js` as a side effect

--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -46,5 +46,7 @@
     "@webcomponents/scoped-custom-element-registry": "0.0.1"
   },
   "types": "types/index.d.ts",
-  "sideEffects": false
+  "sideEffects": [
+    "./src/loadPolyfill.js"
+  ]
 }


### PR DESCRIPTION
## What I did

1. Mark `loadPolyfill.js` as a side effect.

Fixes #2156 
