### PR TITLE
fix(scoped-elements): getScopedTagName returns the tag passed in

### DIFF
--- a/.changeset/slow-parents-develop.md
+++ b/.changeset/slow-parents-develop.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+fix getScopedTagName returning the tag that was passed in

--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -129,10 +129,13 @@ const ScopedElementsMixinImplementation = superclass =>
 
     /**
      * @deprecated use the native el.tagName instead
+     *
+     * @param {string} tagName
      * @returns {string} the tag name in lowercase
      */
-    getScopedTagName() {
-      return this.tagName.toLowerCase();
+    // eslint-disable-next-line class-methods-use-this
+    getScopedTagName(tagName) {
+      return tagName;
     }
   };
 


### PR DESCRIPTION
## What I did

1. `getScopedTagName(tagName: string): string` now returns the tag passed in

Fixes #2157
