### PR TITLE
fix(scoped-elements): keep deprecated static getScopedTagName function

### DIFF
--- a/.changeset/old-chefs-wink.md
+++ b/.changeset/old-chefs-wink.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Keep deprecated static getScopedTagName function

--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -131,10 +131,21 @@ const ScopedElementsMixinImplementation = superclass =>
      * @deprecated use the native el.tagName instead
      *
      * @param {string} tagName
-     * @returns {string} the tag name in lowercase
+     * @returns {string} the tag name
      */
     // eslint-disable-next-line class-methods-use-this
     getScopedTagName(tagName) {
+      return tagName;
+    }
+
+    /**
+     * @deprecated use the native el.tagName instead
+     *
+     * @param {string} tagName
+     * @returns {string} the tag name
+     */
+    // eslint-disable-next-line class-methods-use-this
+    static getScopedTagName(tagName) {
       return tagName;
     }
   };

--- a/packages/scoped-elements/test-web/ScopedElementsMixin.test.js
+++ b/packages/scoped-elements/test-web/ScopedElementsMixin.test.js
@@ -575,6 +575,8 @@ describe('ScopedElementsMixin', () => {
 
       expect(el.getScopedTagName('feature-a')).to.equal('feature-a');
       expect(el.getScopedTagName('feature-b')).to.equal('feature-b');
+      expect(el.constructor.getScopedTagName('feature-a')).to.equal('feature-a');
+      expect(el.constructor.getScopedTagName('feature-b')).to.equal('feature-b');
     });
 
     it('should return the scoped tag name for a non already registered element', async () => {


### PR DESCRIPTION
## What I did

1. keep deprecated static getScopedTagName function
