### PR TITLE
fix(scoped-elements): adjust the renderBefore node

### DIFF
--- a/.changeset/short-lies-burn.md
+++ b/.changeset/short-lies-burn.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Adjust the renderBefore node so that any styles in Lit content render before adoptedStyleSheets.

--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -111,8 +111,12 @@ const ScopedElementsMixinImplementation = superclass =>
 
       this.renderOptions.creationScope = this.attachShadow(options);
 
-      if (this.renderOptions.creationScope instanceof ShadowRoot)
+      if (this.renderOptions.creationScope instanceof ShadowRoot) {
         adoptStyles(this.renderOptions.creationScope, elementStyles);
+
+        this.renderOptions.renderBefore =
+          this.renderOptions.renderBefore || this.renderOptions.creationScope.firstChild;
+      }
 
       return this.renderOptions.creationScope;
     }

--- a/packages/scoped-elements/src/types.d.ts
+++ b/packages/scoped-elements/src/types.d.ts
@@ -9,6 +9,7 @@ export type ScopedElementsMap = {
 
 export interface RenderOptions {
   creationScope: Node|ShadowRoot;
+  renderBefore: Node|undefined;
 }
 
 export declare class ScopedElementsHost {

--- a/packages/scoped-elements/test-web/ScopedElementsMixin.test.js
+++ b/packages/scoped-elements/test-web/ScopedElementsMixin.test.js
@@ -1,5 +1,5 @@
 import { expect, fixture, defineCE, waitUntil } from '@open-wc/testing';
-import { LitElement, html } from 'lit';
+import { LitElement, html, css } from 'lit';
 import { until } from 'lit/directives/until.js';
 
 import { ScopedElementsMixin } from '../index.js';
@@ -519,6 +519,37 @@ describe('ScopedElementsMixin', () => {
 
     expect(firstElement.tagName.toLowerCase()).to.be.equal('item-a');
     expect(firstElement).to.be.instanceof(ItemA);
+  });
+
+  it('should adjust the `renderBefore` for shimmed adoptedStyleSheets', async () => {
+    const tag = defineCE(
+      class extends ScopedElementsMixin(LitElement) {
+        static get styles() {
+          return css`
+            p {
+              color: blue;
+            }
+          `;
+        }
+
+        render() {
+          return html`
+            <style>
+              p {
+                color: red;
+              }
+            </style>
+            <p>This should be blue!</p>
+          `;
+        }
+      },
+    );
+
+    const el = await fixture(`<${tag}></${tag}>`);
+
+    expect(
+      getComputedStyle(el.shadowRoot.querySelector('p')).getPropertyValue('color'),
+    ).to.be.equal('rgb(0, 0, 255)');
   });
 
   describe('directives integration', () => {


### PR DESCRIPTION
## What I did

1. Adjust the renderBefore node so that any styles in Lit content render before adoptedStyleSheets

fixes #2230
