### PR TITLE
fix(lit-helpers): Removed references to removed type definitions

### DIFF
--- a/.changeset/tame-queens-divide.md
+++ b/.changeset/tame-queens-divide.md
@@ -1,0 +1,5 @@
+---
+"@open-wc/lit-helpers": patch
+---
+
+fix(lit-helpers): Removed type references to deprecated `live`, `spread`, and `spreadAttributes` directives

--- a/packages/lit-helpers/index.d.ts
+++ b/packages/lit-helpers/index.d.ts
@@ -1,4 +1,1 @@
-export { live } from './src/live';
-export { spread } from './src/spread';
-export { spreadProps } from './src/spreadProps';
 export { ReadOnlyPropertiesMixin } from './src/read-only-properties-mixin';


### PR DESCRIPTION
## What I did

1. Removed references to already removed d.ts files. This caused compilation issues when using it in a typescript enabled project.
