### PR TITLE
Fix/scoped elements1 hybrid

### DIFF
--- a/.changeset/friendly-elephants-wash.md
+++ b/.changeset/friendly-elephants-wash.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+support lit2 elements (using scoped-custom-element-registry) in ScopedElementsMixin v1


### PR DESCRIPTION
## What I did

Allows to use Lit2 elements (using scoped-custom-element-registry) created via 'NativeHTMLElement' inside ScopedElementsMixin v1

closes https://github.com/open-wc/open-wc/issues/2247