### PR TITLE
docs(publishing): fix link in Additional Reading

### DIFF
--- a/docs/guides/developing-components/publishing.md
+++ b/docs/guides/developing-components/publishing.md
@@ -133,7 +133,7 @@ If you feel you need polyfills, for package demos or the like, feel free to add 
 
 #### Additional Reading
 
-- [How to Public Web Component to npm by Justing Fagnani](https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm/)
+- [How to Publish Web Component to npm by Justing Fagnani](https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm/)
 - [npm-publish](https://docs.npmjs.com/cli/publish)
 - [Contributing Packages to the npm Registry](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry)
 


### PR DESCRIPTION
## What I did

1. Fix a link typo in the Additional Reading section of "Publishing"
