### PR TITLE
fix: use latest axe-core and allow not required attributes in role testing

### DIFF
--- a/.changeset/fluffy-beds-pump.md
+++ b/.changeset/fluffy-beds-pump.md
@@ -1,0 +1,9 @@
+---
+'chai-a11y-axe': patch
+'eslint-plugin-lit-a11y': patch
+'@open-wc/semantic-dom-diff': patch
+'@open-wc/testing': patch
+---
+
+- use latest axe-core
+- allow not required attributes in role testing

--- a/packages/chai-a11y-axe/package.json
+++ b/packages/chai-a11y-axe/package.json
@@ -29,7 +29,7 @@
     "testing"
   ],
   "dependencies": {
-    "axe-core": "^4.0.2"
+    "axe-core": "^4.3.3"
   },
   "contributors": [
     "Pawel Psztyc"

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
@@ -60,8 +60,8 @@ const RoleHasRequiredAriaAttrsRule = {
                   const presentAriaAttributes = Object.keys(element.attribs)
                     .filter(attr => attr.startsWith('aria-'))
                     .sort();
-                  const hasRequiredAriaAttributes = requiredAriaAttributes.every(
-                    (attr, i) => attr === presentAriaAttributes[i],
+                  const hasRequiredAriaAttributes = requiredAriaAttributes.every(attr =>
+                    presentAriaAttributes.includes(attr),
                   );
 
                   if (!hasRequiredAriaAttributes) {

--- a/packages/eslint-plugin-lit-a11y/package.json
+++ b/packages/eslint-plugin-lit-a11y/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "publish-docs --github-url https://github.com/open-wc/open-wc/ --git-root-dir ../../",
     "test": "npm run test:node",
     "test:node": "mocha tests --recursive",
-    "test:single": "mocha tests/lib/rules/aria-attr-valid-value.js --watch"
+    "test:single": "mocha tests/lib/rules/role-has-required-aria-attrs.js --watch"
   },
   "keywords": [
     "eslint",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "aria-query": "^4.2.2",
-    "axe-core": "^4.0.2",
+    "axe-core": "^4.3.3",
     "axobject-query": "^2.2.0",
     "dom5": "^3.0.1",
     "emoji-regex": "^9.2.0",

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/autocomplete-valid.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/autocomplete-valid.js
@@ -36,6 +36,32 @@ ruleTester.run('autocomplete-valid', rule, {
     { code: 'html`<input type="text" autocomplete=${autocompl} />;`' },
     { code: 'html`<input type="text" autocomplete="${autocompl || \'name\'}" />;`' },
     { code: 'html`<input type="text" autocomplete="${autocompl || \'foo\'}" />;`' },
+    // PASSED "autocomplete-appropriate"
+    // see also: https://github.com/dequelabs/axe-core/issues/2912
+    {
+      code: 'html`<input type="date" autocomplete="email" />;`',
+      errors: [
+        {
+          message: 'the autocomplete value is inappropriate for this type of input',
+        },
+      ],
+    },
+    {
+      code: 'html`<input type="number" autocomplete="url" />;`',
+      errors: [
+        {
+          message: 'the autocomplete value is inappropriate for this type of input',
+        },
+      ],
+    },
+    {
+      code: 'html`<input type="month" autocomplete="tel" />;`',
+      errors: [
+        {
+          message: 'the autocomplete value is inappropriate for this type of input',
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -68,30 +94,6 @@ ruleTester.run('autocomplete-valid', rule, {
       errors: [
         {
           message: 'the autocomplete attribute is incorrectly formatted',
-        },
-      ],
-    },
-    {
-      code: 'html`<input type="date" autocomplete="email" />;`',
-      errors: [
-        {
-          message: 'the autocomplete value is inappropriate for this type of input',
-        },
-      ],
-    },
-    {
-      code: 'html`<input type="number" autocomplete="url" />;`',
-      errors: [
-        {
-          message: 'the autocomplete value is inappropriate for this type of input',
-        },
-      ],
-    },
-    {
-      code: 'html`<input type="month" autocomplete="tel" />;`',
-      errors: [
-        {
-          message: 'the autocomplete value is inappropriate for this type of input',
         },
       ],
     },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/role-has-required-aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/role-has-required-aria-attrs.js
@@ -31,7 +31,15 @@ ruleTester.run('role-has-required-aria-attrs', rule, {
     },
     { code: 'html`<span role="row"></span>`' },
     { code: 'html`<input type="checkbox" role="switch" aria-checked="true" />`' },
-    { code: 'html`<div role="combobox" aria-controls="foo"  aria-expanded="foo"></div>`' },
+    { code: 'html`<div role="combobox" aria-controls="foo" aria-expanded="foo"></div>`' },
+    {
+      code:
+        'html`<div role="combobox" aria-activedescendant="child" aria-autocomplete="none" aria-controls="listbox" aria-expanded="false"></div>`;',
+    },
+    {
+      code:
+        'html`<div role="combobox" aria-activedescendant=${"child"} aria-autocomplete=${"none"} aria-controls="listbox" aria-expanded=${"false"}></div>`;',
+    },
   ],
 
   invalid: [

--- a/packages/semantic-dom-diff/test-web/__snapshots__/chai-dom-equals-snapshots.test.snap.js
+++ b/packages/semantic-dom-diff/test-web/__snapshots__/chai-dom-equals-snapshots.test.snap.js
@@ -38,7 +38,7 @@ snapshots["component-a error states matches shadow dom snapshot"] =
 
 snapshots["component-a failed snapshots does not throw an error when a snapshot does not match using negate"] = 
 `<div>
-  0.7128290778096771
+  0.2451530753255171
 </div>
 `;
 /* end snapshot component-a failed snapshots does not throw an error when a snapshot does not match using negate */

--- a/packages/testing/test-web/chai-a11y-axe.test.js
+++ b/packages/testing/test-web/chai-a11y-axe.test.js
@@ -22,7 +22,7 @@ describe('chaiA11yAxe', () => {
         </div>
       `);
       await expect(el).to.be.accessible({
-        ignoredRules: ['aria-valid-attr-value', 'aria-command-name'],
+        ignoredRules: ['aria-allowed-attr', 'aria-command-name'],
       });
     });
 
@@ -41,7 +41,7 @@ describe('chaiA11yAxe', () => {
     it('accepts ignored rules list', async () => {
       const el = await fixture(html` <div aria-labelledby="test-x"></div> `);
       await assert.isAccessible(el, {
-        ignoredRules: ['aria-valid-attr-value'],
+        ignoredRules: ['aria-allowed-attr'],
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4697,10 +4697,10 @@ aws-sdk@^2.689.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-axe-core@^4.0.2:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
-  integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
+axe-core@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
+  integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
 
 axios@0.21.1:
   version "0.21.1"


### PR DESCRIPTION
## What I did

1. updated `axe-core` to get the freshest and hottest a11y rules
2. corrected `RoleHasRequiredAriaAttrsRule` to test for all required attributes but not to fail when there are more attributes beyond that list on the element.
