### PR TITLE
fix: override bad publication

### DIFF
--- a/.changeset/tame-seals-listen.md
+++ b/.changeset/tame-seals-listen.md
@@ -1,0 +1,5 @@
+---
+'chai-a11y-axe': patch
+---
+
+fix: override bad publication

--- a/packages/chai-a11y-axe/package.json
+++ b/packages/chai-a11y-axe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-a11y-axe",
-  "version": "1.3.2-next.0",
+  "version": "1.3.2-next.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## What I did

1. `chai-a11y-axe` got a 400 error that jacked up the publication on the last pre-release, I've manually bumped the number to see if we can get changesets to see this bump.