### PR TITLE
added semantic dom diff as dependency to fix lit jest test issues

### DIFF
--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -37,6 +37,7 @@
   ],
   "dependencies": {
     "@open-wc/scoped-elements": "^2.0.0-next.0",
+    "@open-wc/semantic-dom-diff": "^0.19.5-next.2",
     "lit": "^2.0.0-rc.1"
   },
   "types": "types/index.d.ts"


### PR DESCRIPTION
## What I did

1. Added @open-wc/semantic-dom-diff to package.json, as tests with Lit 2.0 components started to fail with jest-environment-jsdom setup.
