### PR TITLE
chore: add format action for PR reviews

### DIFF
--- a/.github/ISSUE_TEMPLATE/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,15 @@
+## What I Did
+
+<!-- Enter a concise summary of the changes you made here -->
+
+1.
+
+## Relevant Issues
+
+<!-- Please list relevant issues by issue number here -->
+
+## Notes to Reviewers
+
+<!-- Enter any notes you'd like to PR reviewers to pay attention to  -->
+
+Reviewers can trigger code formatting by commenting `CI format please` in a PR review thread.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Format PR Branch
+
+on:
+  # Run whenever a PR review comment is created or edited
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+
+jobs:
+  format:
+    name: Format Branch
+    # If the PR review comment contains the string 'CI format please', run this job
+    if: ${{ contains(github.event.comment.body, 'CI format please') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Check out the PR branch
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Format
+        # format the working dir, add *ALL* changed files, commit and push
+        run: |
+          yarn format:prettier
+          echo "Setting github user"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          echo "Committing"
+          git add .
+          git commit --message "chore: lint files"
+          git push

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Open Web Components provides a set of defaults, recommendations and tools to hel
 [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
+
+
+
+
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ Open Web Components provides a set of defaults, recommendations and tools to hel
 [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)](https://www.browserstack.com/automate/public-build/M2UrSFVRang2OWNuZXlWSlhVc3FUVlJtTDkxMnp6eGFDb2pNakl4bGxnbz0tLUE5RjhCU0NUT1ZWa0NuQ3MySFFWWnc9PQ==--86f7fac07cdbd01dd2b26ae84dc6c8ca49e45b50)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 
-
-
-
-
-
 ## Usage
 
 ```bash


### PR DESCRIPTION
## What I did

1. add an action which
    - any time a PR *REVIEW COMMENT* is created or edited
    - IFF the comment contains the string `CI format please`
    - run `yarn format:prettier && git add . && git commit && git push`
2. add a PR template which contains a note to reviewers 

## Questions:
- Do we want a different magic string, or to create an action with bash or JS or something to parse the comment?
- Would it be better to get a list of changed files and add them only? how? does prettier make that easy? (a cursory check of their docs didn't turn up much)
