### PR TITLE
fix: bump versions to be able to publish to npm

### DIFF
--- a/.changeset/tall-pillows-divide.md
+++ b/.changeset/tall-pillows-divide.md
@@ -1,0 +1,8 @@
+---
+'@open-wc/building-rollup': patch
+'@open-wc/scoped-elements': patch
+'@open-wc/testing': patch
+'@open-wc/testing-helpers': patch
+---
+
+Release bump version as major versions have already been used and unpublished in an accidental publish about a year ago.


### PR DESCRIPTION
## What I did

1. Release bump version as major versions have already been used and unpublished in an accidental publish about a year ago.
