### PR TITLE
Add Graphite Design System to Component Libraries

### DIFF
--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -48,6 +48,12 @@ const componentLibraries = [
       'FAST is a web component library built by Microsoft. The core, `fast-element`, is a lightweight means to easily build performant and standards-compliant Web Components. `fast-foundation` is a library of Web Component classes, templates, and other utilities built on fast-element intended to be composed into registered web components by design systems.',
   },
   {
+    name: 'Graphite Design System',
+    url: 'https://graphitedesignsystem.com',
+    description:
+      "Graphite is PAQT's white-label design system for digital products and experiences. The system consists of working code, design kits, and human interface guidelines.",
+  },
+  {
     name: 'HelixUI',
     url: 'https://helixdesignsystem.github.io/helix-ui/',
     description:


### PR DESCRIPTION
## What I did

I've added the [Graphite Design System](https://graphitedesignsystem.com/) to the list of component libraries or design systems which are based on web-components (we've used Stencil).

Thanks for your consideration, and thanks for your very valuable guides, tools, and libraries for developing web components.