### PR TITLE
fix: relax waitUntil (fixes #2361)

### DIFF
--- a/.changeset/wicked-maps-press.md
+++ b/.changeset/wicked-maps-press.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/testing-helpers': patch
+---
+
+Relax type of `waitUntil` predicate parameter

--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -145,7 +145,7 @@ export function oneEvent(eventTarget, eventName) {
  * await waitUntil(() => element.someAsyncProperty, 'element should become ready');
  * ```
  *
- * @param {() => boolean | Promise<boolean>} predicate - predicate function which is called each poll interval.
+ * @param {() => unknown | Promise<unknown>} predicate - predicate function which is called each poll interval.
  *   The predicate is awaited, so it can return a promise.
  * @param {string} [message] an optional message to display when the condition timed out
  * @param {{ interval?: number, timeout?: number }} [options] timeout and polling interval


### PR DESCRIPTION
## What I did

By changing the declared signature of `waitUntil`, it will be possible call it in TypeScript without explicitly coercing the value to a boolean
