### PR TITLE
fix material design components url

### DIFF
--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -103,8 +103,7 @@ const componentLibraries = [
   },
   {
     name: 'Material Web Components',
-    url:
-      'https://material-components.github.io/material-components-web-components/demos/index.html',
+    url: 'https://material-components.github.io/material-web',
     description:
       "Material Design Components from Material Design team themselves. Stay as close as possible to the changing specification with these components from Google's own Material Design team.",
   },


### PR DESCRIPTION
## What I did

1. Fixed the Material Design Components URL as the old one would point to a 404
