### PR TITLE
fix(sb-md-docs): user provided code blocks should remain in final output

### DIFF
--- a/.changeset/shaggy-pigs-applaud.md
+++ b/.changeset/shaggy-pigs-applaud.md
@@ -1,0 +1,5 @@
+---
+'storybook-addon-markdown-docs': patch
+---
+
+User provided code blocks should remain in the final output

--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -162,7 +162,8 @@ const componentLibraries = [
   {
     name: 'Vivid',
     url: 'https://github.com/Vonage/vivid',
-    description: "Vonage's web UI 🎨 toolbelt. A library that favors lock-down and coherence over white labeling strategy, utilizing high-level design tokens to customize UI systematically rather than permuting components directly (to a balanced degree).",
+    description:
+      "Vonage's web UI 🎨 toolbelt. A library that favors lock-down and coherence over white labeling strategy, utilizing high-level design tokens to customize UI systematically rather than permuting components directly (to a balanced degree).",
   },
 ];
 

--- a/packages/storybook-addon-markdown-docs/src/mdjsToMd.js
+++ b/packages/storybook-addon-markdown-docs/src/mdjsToMd.js
@@ -123,6 +123,7 @@ const mdjsToMdPlugins = [
     name: 'mdStringify',
     plugin: mdStringify,
     options: {
+      sanitize: false,
       handlers: {
         code,
         image,


### PR DESCRIPTION
## What I did

1. set sanitize to false (which was the default before but changed) => that should not be an issue as it's "revalidated" by storybooks mdx anyways

closes https://github.com/open-wc/open-wc/issues/2393
