### PR TITLE
fix: copy _redirects file to _site directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "setup": "npm run setup:ts-configs && npm run setup:postinstall",
     "setup:postinstall": "node scripts/workspaces-scripts-bin.mjs monorepo:postinstall",
     "setup:ts-configs": "node scripts/generate-ts-configs.mjs",
-    "site:build": "node scripts/workspaces-scripts-bin.mjs site:build && npm run codelabs:build && rocket build",
+    "site:build": "node scripts/workspaces-scripts-bin.mjs site:build && npm run codelabs:build && rocket build && copyfiles -f docs/_redirects _site",
     "start": "rocket start",
     "test": "yarn test:web && yarn test:node",
     "test:node": "mocha --exit --retries 3 --timeout 10000 \"packages/*/test-node/**/*.test.{ts,js,mjs,cjs}\" ",


### PR DESCRIPTION
Fixes https://github.com/open-wc/open-wc/issues/2392

## What I did

1. Copy the `_redirects` file to `_site` so that when being deployed over to netlify, the config follows along
