### PR TITLE
Make `oneEvent` generic

### DIFF
--- a/.changeset/hot-pets-applaud.md
+++ b/.changeset/hot-pets-applaud.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/testing-helpers': patch
+---
+
+Add generics for oneEvent test helper function

--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -118,10 +118,10 @@ export async function triggerFocusFor(element) {
  * await oneEvent(el, 'done');
  * expect(el.done).to.be.true;
  *
- * @template {Event} [TEvent=CustomEvent]
- * @param {EventTarget} eventTarget Target of the event, usually an Element
- * @param {string} eventName Name of the event
- * @returns {Promise<TEvent>} Promise to await until the event has been fired
+ * @param eventTarget Target of the event, usually an Element
+ * @param eventName Name of the event
+ * @returns Promise to await until the event has been fired
+ * @type {import("./types").OneEventFn}
  */
 export function oneEvent(eventTarget, eventName) {
   return new Promise(resolve => {

--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -118,9 +118,10 @@ export async function triggerFocusFor(element) {
  * await oneEvent(el, 'done');
  * expect(el.done).to.be.true;
  *
+ * @template {Event} [TEvent=CustomEvent]
  * @param {EventTarget} eventTarget Target of the event, usually an Element
  * @param {string} eventName Name of the event
- * @returns {Promise<CustomEvent>} Promise to await until the event has been fired
+ * @returns {Promise<TEvent>} Promise to await until the event has been fired
  */
 export function oneEvent(eventTarget, eventName) {
   return new Promise(resolve => {

--- a/packages/testing-helpers/src/types.d.ts
+++ b/packages/testing-helpers/src/types.d.ts
@@ -1,0 +1,3 @@
+
+export type OneEventFn =
+  <TEvent extends Event = CustomEvent>(eventTarget: EventTarget, eventName: string)=> Promise<TEvent>


### PR DESCRIPTION
Currently `oneEvent` is documented to always return `Promise<CustomEvent>`, but there is no reason it has to be `CustomEvent`. 

We can add a generic type param `TEvent`, constrained to `Event` to make this function more flexible. The default type is `CustomEvent` for backward compatibility
