### PR TITLE
Add lit-html as depenency to support the generated types in strict package managers

### DIFF
--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -38,7 +38,8 @@
   ],
   "dependencies": {
     "@open-wc/scoped-elements": "^2.0.1",
-    "lit": "^2.0.0"
+    "lit": "^2.0.0",
+    "lit-html": "^2.0.0"
   },
   "types": "types/index.d.ts"
 }


### PR DESCRIPTION
## What I did

Package managers like PNPM, and possibly Yarn 2, do not allow you to leverage packages as dependencies just because they are in your project as dependencies of other packages. That means that the current type delivery of will fail in those contexts.

```js
// ...
import { html } from "lit-html/static";
import { unsafeStatic } from "lit-html/static";
// ...
```

Adding `lit-html` as a direct dependency to correct.