### PR TITLE
build: add canary publish workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,46 @@
+name: Pre-release
+
+on:
+  push:
+    branches:
+      - next
+      - snapshot-releases
+
+jobs:
+  release:
+    # Prevents changesets action from creating a PR on forks
+    if: github.repository == 'open-wc/open-wc'
+    name: Pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+       - name: Setup Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build types
+        run: yarn types
+
+      - name: Version canary release
+        run: yarn changeset version --snapshot canary
+
+      - name: Release canary snapshots
+        id: changesets
+        uses: changesets/action@master
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: yarn changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What I did

1. Add a canary release workflow.

Looking to support test release cycles for #2399 and #2407 in hopes of clearing up some of the dependency vulnerabilities.