### PR TITLE
Force lit-html dependency tree for correct types construction

### DIFF
--- a/.changeset/chilly-dragons-end.md
+++ b/.changeset/chilly-dragons-end.md
@@ -1,0 +1,6 @@
+---
+"@open-wc/testing-helpers": patch
+"@open-wc/testing": patch
+---
+
+Force lit-html dependency tree for correct types construction

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "http-server": "^13.1.0",
     "husky": "^7.0.4",
     "lint-staged": "^10.5.4",
+    "lit-html": "^2.0.0",
     "mocha": "^8.3.2",
     "mocha-chai-snapshot": "^1.0.0",
     "mock-require": "^3.0.3",

--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -1,5 +1,5 @@
 import { ScopedElementsMixin } from '@open-wc/scoped-elements';
-import { html, LitElement } from 'lit';
+import { LitElement } from 'lit';
 
 /** @typedef {import('@open-wc/scoped-elements').ScopedElementsMap} ScopedElementsMap */
 /** @typedef {import('lit/html.js').TemplateResult} TemplateResult */
@@ -26,15 +26,15 @@ class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
     };
   }
 
-  constructor() {
+  constructor(scopedElement, template) {
     super();
 
     /** @type {ScopedElementsMap} */
-    this.scopedElements = {};
+    this.scopedElements = scopedElement;
 
     /** @type {import('./renderable').LitHTMLRenderable} */
     // eslint-disable-next-line no-unused-expressions
-    this.template;
+    this.template = template;
   }
 
   firstUpdated(_changed) {
@@ -71,22 +71,19 @@ const getWrapperUniqueName = (counter = 0) => {
  *
  * @param {import('./renderable').LitHTMLRenderable} template
  * @param {ScopedElementsMap} scopedElements
- * @return {TemplateResult}
+ * @return {HTMLElement}
  */
 export function getScopedElementsTemplate(template, scopedElements) {
   const wrapperTagName = getWrapperUniqueName();
+  class Scope extends ScopedElementsTestWrapper {}
 
   // @ts-ignore
-  customElements.define(wrapperTagName, class extends ScopedElementsTestWrapper {});
+  customElements.define(wrapperTagName, Scope);
 
-  const strings = [
-    `<${wrapperTagName} .scopedElements="`,
-    '" .template="',
-    `"></${wrapperTagName}>`,
-  ];
+  /** @type {ScopedElementsTestWrapper} */
+  const scope = new Scope(scopedElements, template);
 
-  // @ts-ignore
-  return html(strings, scopedElements, template);
+  return scope;
 }
 
 /** @typedef {typeof getScopedElementsTemplate} ScopedElementsTemplateGetter */

--- a/packages/testing-helpers/src/stringFixture.js
+++ b/packages/testing-helpers/src/stringFixture.js
@@ -1,4 +1,5 @@
-import { html } from 'lit/html.js';
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { fixtureWrapper } from './fixtureWrapper.js';
 import { elementUpdated } from './elementUpdated.js';
 import { litFixture } from './litFixture.js';
@@ -30,7 +31,7 @@ export function stringFixtureSync(template, options = {}) {
 export async function stringFixture(template, options = {}) {
   if (options.scopedElements) {
     // @ts-ignore
-    return litFixture(html([template]), options);
+    return litFixture(html`${unsafeHTML(template)}`, options);
   }
 
   const el = stringFixtureSync(template, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0.tgz#7b6e6a85709cda0370c47e425ac2f3b553696a4b"
   integrity sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA==
 
-"@lit/reactive-element@^1.1.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.2.1.tgz#8620d7f0baf63e12821fa93c34d21e23477736f7"
-  integrity sha512-03FYfMguIWo9E1y1qcTpXzoO8Ukpn0j5o4GjNFq/iHqJEPY6pYopsU44e7NSFIgCTorr8wdUU5PfVy8VeD6Rwg==
+"@lit/reactive-element@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.3.0.tgz#c85c5a5fea41d7230e52fb9017307f473ab947ea"
+  integrity sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw==
 
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
@@ -10616,58 +10616,34 @@ lit-element@^2.4.0, lit-element@~2.4.0:
   dependencies:
     lit-html "^1.1.1"
 
-lit-element@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0.tgz#0e9e64ddbc3dd6a8da4d6fbfadbc070a54cf0597"
-  integrity sha512-oPqRhhBBhs+AlI62QLwtWQNU/bNK/h2L1jI3IDroqZubo6XVAkyNy2dW3CRfjij8mrNlY7wULOfyyKKOnfEePA==
+lit-element@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.2.0.tgz#9c981c55dfd9a8f124dc863edb62cc529d434db7"
+  integrity sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==
   dependencies:
-    "@lit/reactive-element" "^1.0.0"
-    lit-html "^2.0.0"
-
-lit-element@^3.1.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.1.2.tgz#fe29b9a362cf6c0de93c7769f29f1b6c37c79e15"
-  integrity sha512-5VLn5a7anAFH7oz6d7TRG3KiTZQ5GEFsAgOKB8Yc+HDyuDUGOT2cL1CYTz/U4b/xlJxO+euP14pyji+z3Z3kOg==
-  dependencies:
-    "@lit/reactive-element" "^1.1.0"
-    lit-html "^2.1.0"
+    "@lit/reactive-element" "^1.3.0"
+    lit-html "^2.2.0"
 
 lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
 
-lit-html@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0.tgz#ba6779269c382e66d7403a96ed99516ccc3d658b"
-  integrity sha512-tJsCapCmc0vtLj6harqd6HfCxnlt/RSkgowtz4SC9dFE3nSL38Tb33I5HMDiyJsRjQZRTgpVsahrnDrR9wg27w==
+lit-html@^2.0.0, lit-html@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.2.0.tgz#99345d944611e34543cd9f153d8cc3163b8bbab8"
+  integrity sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit-html@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.1.2.tgz#8ae974f3899e6aa919cb977d7b99cc8884578f94"
-  integrity sha512-fp7oBzUdc7SEmOoSUNUZ6PM8se8eaIvc3pviQ5M+iCYuCpv9E23Nnb4hlxVzGhLWMnHSrnRVooNio0aAgjjrFw==
+lit@^2.0.0, lit@^2.0.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.2.0.tgz#1b83a2c1e4c5ecf3be785292b1a13e193597f610"
+  integrity sha512-FDyxUuczo6cJJY/2Bkgfh1872U4ikUvmK1Cb6+lYC1CW+QOo8CaWXCpvPKFzYsz0ojUxoruBLVrECc7VI2f1dQ==
   dependencies:
-    "@types/trusted-types" "^2.0.2"
-
-lit@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.0.tgz#7710095dc518d9858dde579e9c76b9eed71e98ba"
-  integrity sha512-pqi5O/wVzQ9Bn4ERRoYQlt1EAUWyY5Wv888vzpoArbtChc+zfUv1XohRqSdtQZYCogl0eHKd+MQwymg2XJfECg==
-  dependencies:
-    "@lit/reactive-element" "^1.0.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
-
-lit@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.1.2.tgz#e08c24c950fb15a98cc328a8c17e7b4d377f5c48"
-  integrity sha512-XacK89dJXF7BJbpiZSMvzT4RxHag7Wt+yNx7tErEVgGVlOFAeN871bj7ivotCMgYeBFWVp/hjKF/PDTk6L7gMA==
-  dependencies:
-    "@lit/reactive-element" "^1.1.0"
-    lit-element "^3.1.0"
-    lit-html "^2.1.0"
+    "@lit/reactive-element" "^1.3.0"
+    lit-element "^3.2.0"
+    lit-html "^2.2.0"
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## What I did

1. Ensure that `lit-html@2.0` is the preferred version so that it can be depended on via bare module specifiers in types.