### PR TITLE
Change return type from Assertion to Promise<Assertion>

### DIFF
--- a/.changeset/three-dogs-rhyme.md
+++ b/.changeset/three-dogs-rhyme.md
@@ -1,0 +1,6 @@
+---
+"chai-a11y-axe": patch
+"@open-wc/semantic-dom-diff": patch
+---
+
+Change return type from Assertion to Promise<Assertion>

--- a/packages/chai-a11y-axe/chai-a11y-axe-plugin.d.ts
+++ b/packages/chai-a11y-axe/chai-a11y-axe-plugin.d.ts
@@ -2,11 +2,11 @@
 
 declare namespace Chai {
   interface Assertion {
-    accessible(options?: Object): Assertion;
+    accessible(options?: Object): Promise<Assertion>;
   }
 
   interface Assert {
-    isAccessible(fixture: any, options?: Object): Assertion;
-    isNotAccessible(fixture: any, options?: Object): Assertion;
+    isAccessible(fixture: any, options?: Object): Promise<Assertion>;
+    isNotAccessible(fixture: any, options?: Object): Promise<Assertion>;
   }
 }

--- a/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
+++ b/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
@@ -17,8 +17,8 @@ declare global {
       dom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
       lightDom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
       shadowDom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
-      equalSnapshot(fixture: any, options?: DiffOptions): Assertion;
-      notEqualSnapshot(fixture: any, options?: DiffOptions): Assertion;
+      equalSnapshot(fixture: unknown, options?: DiffOptions): Assertion;
+      notEqualSnapshot(fixture: unknown, options?: DiffOptions): Assertion;
 
       equal<T>(actual: T, expected: T, message?: string, options?: DiffOptions): void;
       equal<T>(actual: T, expected: T, message?: string): void;
@@ -30,9 +30,8 @@ declare global {
     }
 
     interface Equal {
-      (value: any, message?: string, options?: DiffOptions): Promise<Assertion>;
-      (value: any, options?: DiffOptions): Promise<Assertion>;
+      (value: unknown, message?: string, options?: DiffOptions): Promise<Assertion>;
+      (value: unknown, options?: DiffOptions): Promise<Assertion>;
     }
   }
 }
-

--- a/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
+++ b/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="chai" />
 
-import { DiffOptions } from "./get-diffable-html";
+import { DiffOptions } from './get-diffable-html';
 
 declare global {
   namespace Chai {
@@ -14,9 +14,9 @@ declare global {
     }
 
     interface Assert {
-      dom: Pick<Assertion, 'equal'|'notEqual'|'equalSnapshot'|'notEqualSnapshot'>;
-      lightDom: Pick<Assertion, 'equal'|'notEqual'|'equalSnapshot'|'notEqualSnapshot'>;
-      shadowDom: Pick<Assertion, 'equal'|'notEqual'|'equalSnapshot'|'notEqualSnapshot'>;
+      dom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
+      lightDom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
+      shadowDom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
       equalSnapshot(fixture: any, options?: DiffOptions): Assertion;
       notEqualSnapshot(fixture: any, options?: DiffOptions): Assertion;
 
@@ -30,8 +30,9 @@ declare global {
     }
 
     interface Equal {
-      (value: any, message?: string, options?: DiffOptions): Assertion;
-      (value: any, options?: DiffOptions): Assertion;
+      (value: any, message?: string, options?: DiffOptions): Promise<Assertion>;
+      (value: any, options?: DiffOptions): Promise<Assertion>;
     }
   }
 }
+


### PR DESCRIPTION
## What I did

1. Changed return type of Equal from `Assertion` to `Promise<Assertion>`
2. Changed type `any` to `unknown`, which is preferred in TypeScript

Without this change, `tsserver`  gives the following warning:

`[tsserver 80007] [I] 'await' has no effect on the type of this expression.`  

Yet examples show `await`ing the assertions and the assertions must be awaited to work (in some cases).