### PR TITLE
feat(testing): add oneDefaultPreventedEvent function

### DIFF
--- a/.changeset/poor-days-cross.md
+++ b/.changeset/poor-days-cross.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/testing-helpers': minor
+---
+
+Added oneDefaultPreventedEvent() helper function

--- a/docs/docs/testing/helpers.md
+++ b/docs/docs/testing/helpers.md
@@ -269,6 +269,25 @@ it('can await an event', async () => {
 });
 ```
 
+### Events with preventDefault()
+
+If you want to test events that have a default behavior, like a forms `submit` event, some testing tools can be interrupted if `event.preventDefault()` is not called on the event handler. For example, a form's `submit` event's default behavior is to navigate to the `action` of the form (or reload the page if no `action` is set). If the "page" gets reloaded in a test environment, tests can't easily recover/continue. Use the `oneDefaultPreventedEvent` function and `event.preventDefault()` will be called on the event handler and your tests can continue normally.
+
+```js
+it('can await an event and prevent the default', async () => {
+  const form = await fixture(`<form>
+    <input type="text" />
+    <button>Submit button</button>
+  </form>`);
+
+  form.querySelector('button').click();
+
+  const { detail } = await oneDefaultPreventedEvent(el, 'submit');
+
+  expect(detail).to.be.true;
+});
+```
+
 ## Testing Focus & Blur on IE11
 
 Focus and blur events are synchronous events in all browsers except IE11.

--- a/packages/testing-helpers/index.js
+++ b/packages/testing-helpers/index.js
@@ -9,6 +9,7 @@ export {
   isIE,
   nextFrame,
   oneEvent,
+  oneDefaultPreventedEvent,
   triggerBlurFor,
   triggerFocusFor,
   waitUntil,

--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -136,6 +136,31 @@ export function oneEvent(eventTarget, eventName) {
 }
 
 /**
+ * Listens for one event, calls `event.preventDefault()` and resolves with this event object after it was fired.
+ *
+ * @example
+ * const form = document.querySelector('form);
+ * form.querySelector('button[type="submit"]).click();
+ * const payload = await oneDefaultPreventedEvent(form, 'submit');
+ * expect(payload).to.be.true;
+ *
+ * @param eventTarget Target of the event, usually an Element
+ * @param eventName Name of the event
+ * @returns Promise to await until the event has been fired
+ * @type {import("./types").OneEventFn}
+ */
+export function oneDefaultPreventedEvent(eventTarget, eventName) {
+  return new Promise(resolve => {
+    function listener(ev) {
+      ev.preventDefault();
+      resolve(ev);
+      eventTarget.removeEventListener(eventName, listener);
+    }
+    eventTarget.addEventListener(eventName, listener);
+  });
+}
+
+/**
  * Waits until the given predicate returns a truthy value. Calls and awaits the predicate
  * function at the given interval time. Can be used to poll until a certain condition is true.
  *

--- a/packages/testing-helpers/src/types.d.ts
+++ b/packages/testing-helpers/src/types.d.ts
@@ -1,3 +1,3 @@
 
 export type OneEventFn =
-  <TEvent extends Event = CustomEvent>(eventTarget: EventTarget, eventName: string)=> Promise<TEvent>
+  <TEvent extends Event = CustomEvent>(eventTarget: EventTarget, eventName: string, preventDefault: boolean)=> Promise<TEvent>

--- a/packages/testing-helpers/test-web/helpers.test.js
+++ b/packages/testing-helpers/test-web/helpers.test.js
@@ -1,5 +1,12 @@
 import { expect } from './setup.js';
-import { defineCE, oneEvent, triggerFocusFor, triggerBlurFor, fixture } from '../index.js';
+import {
+  defineCE,
+  oneEvent,
+  oneDefaultPreventedEvent,
+  triggerFocusFor,
+  triggerBlurFor,
+  fixture,
+} from '../index.js';
 import { waitUntil, aTimeout } from '../src/helpers.js';
 
 describe('Helpers', () => {
@@ -15,7 +22,7 @@ describe('Helpers', () => {
     expect(element2.constructor).to.equal(TestClass2);
   });
 
-  it('provides oneEvent() to await an event beeing fired', async () => {
+  it('provides oneEvent() to await an event being fired', async () => {
     const el = document.createElement('div');
     const detail = { some: 'thing' };
     const customEvent = new CustomEvent('my-custom-event', { detail });
@@ -23,6 +30,21 @@ describe('Helpers', () => {
     setTimeout(() => el.dispatchEvent(customEvent));
 
     const ev = await oneEvent(el, 'my-custom-event');
+    expect(ev).to.be.an.instanceOf(CustomEvent);
+    expect(ev).to.equal(customEvent);
+    expect(ev.detail).to.equal(detail);
+  });
+
+  it('provides oneDefaultPreventedEvent() to await an event being fired', async () => {
+    const el = document.createElement('div');
+    const detail = { some: 'thing' };
+    const customEvent = new CustomEvent('my-custom-event', { detail, cancelable: true });
+
+    setTimeout(() => el.dispatchEvent(customEvent));
+
+    const ev = await oneDefaultPreventedEvent(el, 'my-custom-event');
+
+    expect(ev.defaultPrevented).to.be.true;
     expect(ev).to.be.an.instanceOf(CustomEvent);
     expect(ev).to.equal(customEvent);
     expect(ev.detail).to.equal(detail);


### PR DESCRIPTION
## What I did

Per this thread on slack: https://lit-and-friends.slack.com/archives/C0S7J1E86/p1646949557548319

1. added a new event helper function `oneDefaultPreventedEvent` so that events with a default that need to be prevented like form submits or anchor click events can be listened for without causing test issues
2. updated docs and imports
