### PR TITLE
fix(scoped-elements): update mixin type info to include createScopedElement

### DIFF
--- a/.changeset/tall-stingrays-roll.md
+++ b/.changeset/tall-stingrays-roll.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Update `ScopedElementsMixin` type info to include `createScopedElement`

--- a/packages/scoped-elements/src/types.d.ts
+++ b/packages/scoped-elements/src/types.d.ts
@@ -1,15 +1,15 @@
 import { Constructor } from '@open-wc/dedupe-mixin';
 import { ReactiveElement } from '@lit/reactive-element';
 
-export { Constructor }
+export { Constructor };
 
 export type ScopedElementsMap = {
   [key: string]: typeof HTMLElement;
 };
 
 export interface RenderOptions {
-  creationScope: Node|ShadowRoot;
-  renderBefore: Node|undefined;
+  creationScope: Node | ShadowRoot;
+  renderBefore: Node | undefined;
 }
 
 export declare class ScopedElementsHost {
@@ -32,7 +32,14 @@ export declare class ScopedElementsHost {
    */
   defineScopedElement<T extends HTMLElement>(tagName: string, klass: Constructor<T>): void;
 
-  declare public renderOptions: RenderOptions
+  /**
+   * Create a scoped element inside the CustomElementRegistry bound to the shadowRoot.
+   *
+   * @param tagName string The tag name of the element to create
+   */
+  createScopedElement(tagName: string): HTMLElement;
+
+  public declare renderOptions: RenderOptions;
 }
 
 declare function ScopedElementsMixinImplementation<T extends Constructor<ReactiveElement>>(


### PR DESCRIPTION
## What I did

1. Update `ScopedElementsMixin` type info to include `createScopedElement`
