### PR TITLE
fix(deps): Fix deps issues with @esm-bundle/chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.13.16",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@changesets/cli": "^2.16.0",
-    "@esm-bundle/chai": "4.3.4-fix.0",
+    "@esm-bundle/chai": "^4.3.4-fix.0",
     "@microsoft/fast-element": "^1.0.2",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.13.16",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@changesets/cli": "^2.16.0",
-    "@esm-bundle/chai": "^4.3.4",
+    "@esm-bundle/chai": "4.3.4-fix.0",
     "@microsoft/fast-element": "^1.0.2",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -36,7 +36,7 @@
     "chai"
   ],
   "dependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@esm-bundle/chai": "^4.3.4-fix.0",
     "@open-wc/chai-dom-equals": "^0.12.36",
     "@open-wc/semantic-dom-diff": "^0.19.5",
     "@open-wc/testing-helpers": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@esm-bundle/chai@^4.3.4":
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.4.tgz#74ed4a0794b3a9f9517ff235744ac6f4be0d34dc"
-  integrity sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==
+"@esm-bundle/chai@4.3.4-fix.0", "@esm-bundle/chai@^4.3.4-fix.0":
+  version "4.3.4-fix.0"
+  resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.4-fix.0.tgz#3084cff7eb46d741749f47f3a48dbbdcbaf30a92"
+  integrity sha512-26SKdM4uvDWlY8/OOOxSB1AqQWeBosCX3wRYUZO7enTAj03CtVxIiCimYVG2WpULcyV51qapK4qTovwkUr5Mlw==
   dependencies:
     "@types/chai" "^4.2.12"
 


### PR DESCRIPTION
## What I did

1. @esm-bundle/chai has an issue if I use vite/vitest for web component testing.  The hot fix version in @esm-bundle/chai has those deps fixed.  

Also, created a repo that reproduces the failure here, https://github.com/ianhuezo/vitest-failing-imports/tree/main/