### PR TITLE
chore(semantic-dom-diff): update dependencies

### DIFF
--- a/.changeset/purple-dolphins-compete.md
+++ b/.changeset/purple-dolphins-compete.md
@@ -1,0 +1,5 @@
+---
+"@open-wc/semantic-dom-diff": patch
+---
+
+chore(semantic-dom-diff): updates dependencies

--- a/packages/semantic-dom-diff/package.json
+++ b/packages/semantic-dom-diff/package.json
@@ -32,7 +32,7 @@
     "snapshots"
   ],
   "dependencies": {
-    "@types/chai": "^4.2.11",
-    "@web/test-runner-commands": "^0.5.7"
+    "@types/chai": "^4.3.1",
+    "@web/test-runner-commands": "^0.6.1"
   }
 }


### PR DESCRIPTION
## What I did

1. bump dependencies in `semantic-dom-diff`

In monorepos, prevents

>  SyntaxError: The requested module './../../../node_modules/@web/test-runner-commands/browser/commands.mjs' does not provide an export named 'sendMouse' (at pfe-cta.spec.ts:6:1)
