### PR TITLE
docs: udpate documentation about Intellij

### DIFF
--- a/docs/guides/tools/ide.md
+++ b/docs/guides/tools/ide.md
@@ -47,7 +47,7 @@ Syntax highlighting from HTML and CSS in template literals should be supported o
 
 ![intellij-syntax0-highlighting](./assets/intellij-syntax-highlighting.png)
 
-Due to the support available directly in the IDE, the ecosystem for plugins is very limited and we do not recommend any.
+Support in the IDE is partially provided via the [Styled Components & Styled JSX](https://plugins.jetbrains.com/plugin/9997-styled-components--styled-jsx) plugin which should be bundled by default. Otherwise, the ecosystem for plugins is very limited and we do not recommend any.
 
 ## Sublime Text 3
 


### PR DESCRIPTION
## What I did

1. Some JetBrains IDE users are missing the plugin responsible for highlighting CSS in JS (should be bundled by default). I added info about that plugin so users don't need to search JetBrains issue tracker: https://youtrack.jetbrains.com/issue/WEB-48358/css-in-JS-string-literal-not-recognized#focus=Comments-27-4534401.0-0