### PR TITLE
release(dedupe-mixin): type module pkg json change release

### DIFF
--- a/.changeset/smooth-experts-share.md
+++ b/.changeset/smooth-experts-share.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/dedupe-mixin': patch
+---
+
+Release with "type": "module", marking this package as ES Module format.


### PR DESCRIPTION
8 months ago, "type": "module" was added to all ESM packages. It seems like every package got released at one point or another afterwards, with the exception of dedupe-mixin. This package still needs a release for this change to be able to arrive in NPM registry :).

See file history https://github.com/open-wc/open-wc/commits/master/packages/dedupe-mixin/package.json