### PR TITLE
Check if `__registry` actually exists on the current class, not a parent

### DIFF
--- a/.changeset/curly-rice-greet.md
+++ b/.changeset/curly-rice-greet.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Check if `__registry` actually exists on the current class, not a parent.

--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -95,7 +95,9 @@ const ScopedElementsMixinImplementation = superclass =>
         elementStyles,
       } = /** @type {typeof ScopedElementsHost} */ (this.constructor);
 
-      if (!this.registry) {
+      // Polyfill implementation for Object.hasOwn
+      // https://github.com/tc39/proposal-accessible-object-hasownproperty/blob/main/polyfill.js
+      if (!Object.prototype.hasOwnProperty.call(Object(this.constructor), '__registry')) {
         this.registry = supportsScopedRegistry ? new CustomElementRegistry() : customElements;
         for (const [tagName, klass] of Object.entries(scopedElements)) {
           this.defineScopedElement(tagName, klass);


### PR DESCRIPTION
Fixes #2455 