### PR TITLE
Feat/dont save equal snapshot

### DIFF
--- a/.changeset/ninety-chicken-crash.md
+++ b/.changeset/ninety-chicken-crash.md
@@ -1,0 +1,6 @@
+---
+'@open-wc/semantic-dom-diff': patch
+'@open-wc/testing': patch
+---
+
+Avoid saving unchanged snapshots

--- a/packages/semantic-dom-diff/chai-dom-diff.js
+++ b/packages/semantic-dom-diff/chai-dom-diff.js
@@ -176,7 +176,7 @@ export const chaiDomDiff = (chai, utils) => {
           chai.util.flag(this, 'ssfi'),
         );
       }
-    } else {
+    } else if (currentSnapshot !== snapshot) {
       await saveSnapshot({ name, content: snapshot });
     }
   }


### PR DESCRIPTION
## What I did

Follow up of https://github.com/modernweb-dev/web/pull/1987, part of the logic is implemented separately in semantic-dom-diff.
