### PR TITLE
Update index.md

### DIFF
--- a/docs/blog/announcing-open-web-components/index.md
+++ b/docs/blog/announcing-open-web-components/index.md
@@ -142,7 +142,7 @@ Our open-wc-app-starter will set you up with a full configuration, with the foll
 - **Testing suite with Karma**
 - **Linting with ESLint, Prettier and commitlint**
   ​
-  You can find more documentation on our `open-wc-app-starter` [here](https://github.com/open-wc/open-wc-starter-app). We try to provide the best, user friendly set up available and your feedback is extremely valuable to us, so if you feel like anything is missing or you have any kind of feedback, please feel free to create an issue on our repo.
+  You can find more documentation on our `open-wc-app-starter` [here](https://github.com/open-wc/open-wc). We try to provide the best, user friendly set up available and your feedback is extremely valuable to us, so if you feel like anything is missing or you have any kind of feedback, please feel free to create an issue on our repo.
   ​
 
 ## And much, much more


### PR DESCRIPTION
link to starter app was pointing to old repo

## What I did

1. changed link in body text from `https://github.com/open-wc/open-wc-starter-app` to `https://github.com/open-wc/open-wc`
