### PR TITLE
fix(testing): support for Node16 TypeScript module resolution

### DIFF
--- a/.changeset/quiet-walls-punch.md
+++ b/.changeset/quiet-walls-punch.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/testing': patch
+---
+
+Support for Node16 TypeScript module resolution

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -13,8 +13,7 @@
   },
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/testing",
-  "module": "index.js",
-  "type": "module",
+  "main": "index.js",
   "exports": {
     ".": "./index.js",
     "./pure": "./index-no-side-effects.js"


### PR DESCRIPTION
Similar to #2454, adds support for Node16 module resolution in TypeScript for the `testing` package.

Tested:
- Still works with "moduleResolution": "node"
- Works with "moduleResolution": "node16"