### PR TITLE
fix: #2495 no export in package.json (fixing DeprecationWarning DEP0151)

### DIFF
--- a/packages/dedupe-mixin/package.json
+++ b/packages/dedupe-mixin/package.json
@@ -32,5 +32,8 @@
     "dedupe",
     "mixins"
   ],
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    ".": "./index.js"
+  }
 }


### PR DESCRIPTION
## What I did

1. I added the export in the package.json of dedup-mixin package.
