### PR TITLE
add "types" to "exports" in package.json to fix node16 typescript module resolution

### DIFF
--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -16,8 +16,11 @@
   "module": "index.js",
   "type": "module",
   "exports": {
-    ".": "./index.js",
-    "./pure": "./index-no-side-effects.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "pure": "./index-no-side-effects.js",
+      "default": "./index.js"
+    }
   },
   "scripts": {
     "debug": "cd ../../ && yarn debug --group testing-helpers",
@@ -41,5 +44,5 @@
     "lit": "^2.0.0",
     "lit-html": "^2.0.0"
   },
-  "types": "types/index.d.ts"
+  "types": "./types/index.d.ts"
 }


### PR DESCRIPTION
This PR follows the same pattern set in #2454.

Resolves #2453

This PR fixes typescript errors when using "moduleResolution": "node16", because it is not using the types in the `@open-wc/testing-helpers` package.

Tested:

* Still works with "moduleResolution": "node"
* Works with "moduleResolution": "node16"

See https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#esm-nodejs