### PR TITLE
Add types export to testing & testing-helpers

### DIFF
--- a/.changeset/few-mayflies-wave.md
+++ b/.changeset/few-mayflies-wave.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/testing': patch
+---
+
+Add types export for node16 module resolution

--- a/.changeset/lazy-teachers-study.md
+++ b/.changeset/lazy-teachers-study.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/testing-helpers': patch
+---
+
+Add missing types export when using node16 module resolution

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -16,8 +16,14 @@
   "module": "index.js",
   "type": "module",
   "exports": {
-    ".": "./index.js",
-    "./pure": "./index-no-side-effects.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    },
+    "./pure": {
+      "types": "./types/index-no-side-effects.d.ts",
+      "default": "./index-no-side-effects.js"
+    }
   },
   "scripts": {
     "debug": "cd ../../ && yarn debug --group testing-helpers",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -16,8 +16,14 @@
   "module": "index.js",
   "type": "module",
   "exports": {
-    ".": "./index.js",
-    "./pure": "./index-no-side-effects.js"
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./pure": {
+      "types": "./index-no-side-effects.d.ts",
+      "default": "./index-no-side-effects.js"
+    }
   },
   "scripts": {
     "build-plugins": "rollup -c rollup.config.js",


### PR DESCRIPTION
Fixes missing type info when used with `node16` module resolution.