### PR TITLE
Include spread types and exclude their TS source

### DIFF
--- a/packages/lit-helpers/index.d.ts
+++ b/packages/lit-helpers/index.d.ts
@@ -1,1 +1,2 @@
 export { ReadOnlyPropertiesMixin } from './src/read-only-properties-mixin';
+export { spread, spreadEvents, spreadProps } from './src/spread';

--- a/packages/lit-helpers/package.json
+++ b/packages/lit-helpers/package.json
@@ -24,7 +24,8 @@
   "files": [
     "*.d.ts",
     "*.js",
-    "src"
+    "src",
+    "!src/spread.ts"
   ],
   "keywords": [
     "lit",


### PR DESCRIPTION
## What I did

1. Ensure the types for the spread decorators were included in the type export
2. Prevent compiling from source in a consuming application by taking `spread.ts` out of the `files` listing

I tested consumption of the packages manually shaped this way in SWC and it worked as expected.