### PR TITLE
feat(eslint-config): bump eslint-plugin-no-only-tests to v3

### DIFF
--- a/.changeset/six-pears-hunt.md
+++ b/.changeset/six-pears-hunt.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/eslint-config': minor
+---
+
+Update eslint-plugin-no-only-tests to 3.1.0

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-html": "^6.1.2",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-no-only-tests": "^2.6.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-wc": "^1.3.0",
     "fs-extra": "^10.0.0",
     "haunted": "^4.7.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-lit": "^1.3.0",
     "eslint-plugin-lit-a11y": "^2.2.2",
-    "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-wc": "^1.2.0"
   },
   "dependencies": {
@@ -37,7 +37,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-lit": "^1.2.0",
     "eslint-plugin-lit-a11y": "^2.2.2",
-    "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-wc": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6692,10 +6692,10 @@ eslint-plugin-lit@^1.2.0, eslint-plugin-lit@^1.6.0:
     parse5-htmlparser2-tree-adapter "^6.0.1"
     requireindex "^1.2.0"
 
-eslint-plugin-no-only-tests@^2.4.0, eslint-plugin-no-only-tests@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz#19f6c9620bda02b9b9221b436c5f070e42628d76"
-  integrity sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
+eslint-plugin-no-only-tests@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
+  integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
 
 eslint-plugin-wc@^1.2.0, eslint-plugin-wc@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
## What I did

1. Upgraded `eslint-plugin-no-only-tests` to `3.1.0` - the only breaking change in v3 is [suite small](https://github.com/levibuzolic/eslint-plugin-no-only-tests/pull/35).
