### PR TITLE
docs: replace afterEach with teardown

### DIFF
--- a/docs/docs/testing/helpers.md
+++ b/docs/docs/testing/helpers.md
@@ -302,8 +302,8 @@ it('can instantiate an element with properties', async () => {
   fixtureCleanup();
 }
 
-// Alternatively, you can add the fixtureCleanup in the afterEach function, but note that this is exactly what the automatically registered side-effect does.
-afterEach(() => {
+// Alternatively, you can add the fixtureCleanup in the teardown function, but note that this is exactly what the automatically registered side-effect does.
+teardown(() => {
   fixtureCleanup();
 });
 ```


### PR DESCRIPTION
## What I did

1. Replaced instance of `afterEach` with `teardown`. In newer versions of testing helpers beforeEach and afterEach do not appear to be added to the global scope. This proved quite confusing in attempts to spin up a new web component with no prior knowledge.

See this [example test](https://github.com/bobbyg603/medium-feed/blob/0fcb7ac2ebe1c5a3d21377677e4b05692fbcc326/test/medium-feed_test.ts) in a project created from the Lit Element TS starter.
