### PR TITLE
Fix installation instructions for scoped-elements

### DIFF
--- a/docs/docs/development/scoped-elements.md
+++ b/docs/docs/development/scoped-elements.md
@@ -5,7 +5,7 @@ Scope element tag names avoiding naming collision and allowing to use different 
 ## Installation
 
 ```bash
-npm i --save @open-wc/scoped-elements@next
+npm i --save @open-wc/scoped-elements
 ```
 
 <inline-notification type="warning">


### PR DESCRIPTION
Remove `@next` specifier from scoped-elements installation instructions, the latest release is no longer tagged `next`.