### PR TITLE
docs: fix web dev server config file name

### DIFF
--- a/docs/docs/development/hot-module-replacement.md
+++ b/docs/docs/development/hot-module-replacement.md
@@ -18,7 +18,7 @@ Install the package:
 npm i --save-dev @open-wc/dev-server-hmr@next
 ```
 
-Add the plugin to your `web-dev-server-config.mjs`:
+Add the plugin to your `web-dev-server.config.mjs`:
 
 ```js
 import { hmrPlugin } from '@open-wc/dev-server-hmr';


### PR DESCRIPTION
## What I did

1. Corrected the web dev server config file name, which according to the [docs](https://modern-web.dev/docs/dev-server/cli-and-configuration/#configuration-file) should be `web-dev-server.config.mjs`
