### PR TITLE
Update lint-staged and husky examples

### DIFF
--- a/docs/guides/tools/linting-and-formatting.md
+++ b/docs/guides/tools/linting-and-formatting.md
@@ -74,13 +74,14 @@ And update your package.json:
 
 ```json
 {
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
-    "*.js": ["eslint --fix", "prettier --write", "git add"]
+    "*.js": ["eslint --fix", "prettier --write"]
   }
 }
+```
+
+Add the lint-staged hook
+
+```sh
+npx husky add .husky/pre-commit "npx lint-staged"
 ```


### PR DESCRIPTION
## What I did

1. Remove `gid add` because it isn't necessary anymore. See lint-staged [v10 changelog](https://github.com/okonet/lint-staged#v10)
2. Change the husky example to use a command to create the desired hook
