### PR TITLE
fix: move eslint plugins to devDependencies

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,9 @@
   "dependencies": {
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-syntax-import-assertions": "^7.20.0",
-    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-base": "^15.0.0"
+  },
+  "devDependencies": {
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-import-exports-imports-resolver": "^1.0.1",


### PR DESCRIPTION
## What I did

1. I moved the eslint plugins to devDependencies in the package.json because peerDepencies must not be listed as regular dependencies since they are installed alongside this package. Still, we want it to be installed by the user of this package.
