### PR TITLE
Preserve error stacktrace when timing out

### DIFF
--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -181,12 +181,21 @@ export function oneDefaultPreventedEvent(eventTarget, eventName) {
 export function waitUntil(predicate, message, options = {}) {
   const { interval = 50, timeout = 1000 } = options;
 
+  // Save the current stack so that we can reference it later if we timeout.
+  const { stack } = new Error();
+
   return new Promise((resolve, reject) => {
     let timeoutId;
 
     setTimeout(() => {
       clearTimeout(timeoutId);
-      reject(new Error(message ? `Timeout: ${message}` : `waitUntil timed out after ${timeout}ms`));
+
+      const error = new Error(
+        message ? `Timeout: ${message}` : `waitUntil timed out after ${timeout}ms`,
+      );
+      error.stack = stack;
+
+      reject(error);
     }, timeout);
 
     async function nextInterval() {


### PR DESCRIPTION
## What I did

1. I made sure to create a new Error in `waitUntil` before returning the promise and save that stack trace.
2. I then overwrite the stack trace of the timeout error with the saved stacktrace.

This change adds a stacktrace to the error which tells me where in my tests the `waitUntil` was called. Before this change I only saw a single line of stacktrace coming from `@open-wc/testing-helpers/src/helpers.js:189:14`.

I had some issues with writing a test for this but in my project tests I can see a clear difference.

```sh
 ❌ [super secret project] > config > is called in plugins
      Error: Timeout: secret thing did not resolve in time
        at node_modules/@open-wc/testing-helpers/src/helpers.js:189:14
```
