### PR TITLE
Re-export chai so that it doesn't lose its typing

### DIFF
--- a/packages/testing/index.d.ts
+++ b/packages/testing/index.d.ts
@@ -17,9 +17,5 @@ export { fixtureCleanup } from '@open-wc/testing-helpers';
 export { elementUpdated } from '@open-wc/testing-helpers';
 export { waitUntil } from '@open-wc/testing-helpers';
 
-import Chai from 'chai';
-
-export declare const chai: typeof Chai;
-export declare const expect: typeof Chai.expect;
-export declare const assert: typeof Chai.assert;
-export declare const should: typeof Chai.should;
+export * as chai from 'chai';
+export { expect, assert, should } from 'chai';


### PR DESCRIPTION
## What I did

1. Change the way that Chai's utilities are re-exported via this package.

The current way that chai is being exported causes it to lose its typing information and gets inferred as `any`, which causes a number of problems.

![image](https://user-images.githubusercontent.com/1246453/228639250-6e23c549-df15-40cc-a5f0-f1906dc7db48.png)

Instead of manually declaring the elements that are exported from Chai and setting their types, just export directly from the Chai module and that resolves typing issue.

![image](https://user-images.githubusercontent.com/1246453/228639644-6a1f94e4-fcfa-4743-9c37-f0cd5e126690.png)

This shouldn't have any functional behavior changes.