### PR TITLE
Bugfix/fix scoped elements example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ npm run test
 # testing via browserstack
 npm run test:bs
 
-# run commands only for a specific scope
-lerna run <command> --scope @open-wc/<package-name> --stream
+# run commands only for a specific package
+yarn workspace @open-wc/<package-name> <command>
 ```

--- a/packages/scoped-elements/demo/before-nesting/server.js
+++ b/packages/scoped-elements/demo/before-nesting/server.js
@@ -1,6 +1,6 @@
 module.exports = {
   rootDir: '../../',
-  appIndex: 'packages/scoped-elements/demo/before-nesting/index.html',
+  appIndex: 'demo/before-nesting/index.html',
   nodeResolve: true,
   open: true,
 };

--- a/packages/scoped-elements/demo/no-scope/server.js
+++ b/packages/scoped-elements/demo/no-scope/server.js
@@ -1,6 +1,6 @@
 module.exports = {
   rootDir: '../../',
-  appIndex: 'packages/scoped-elements/demo/no-scope/index.html',
+  appIndex: 'demo/no-scope/index.html',
   nodeResolve: true,
   open: true,
 };

--- a/packages/scoped-elements/demo/with-scope/server.js
+++ b/packages/scoped-elements/demo/with-scope/server.js
@@ -1,6 +1,6 @@
 module.exports = {
   rootDir: '../../',
-  appIndex: 'packages/scoped-elements/demo/with-scope/index.html',
+  appIndex: 'demo/with-scope/index.html',
   nodeResolve: true,
   open: true,
 };


### PR DESCRIPTION
## What I did

I fixed the `appIndex` for [packages/scoped-elements/demo](https://github.com/open-wc/open-wc/tree/master/packages/scoped-elements/demo), so that the examples work again out-of-the-box. Furthermore I updated the main `README.md` to not use `lerna` anymore, but the corresponding (and working!) `yarn` command.

This fixes https://github.com/open-wc/open-wc/issues/2653 .