### PR TITLE
fix(scoped-elements): remove types.js from exports

### DIFF
--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -18,8 +18,7 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./index.js"
-    },
-    "./types.js": "./types/src/types.d.ts"
+    }
   },
   "scripts": {
     "debug": "cd ../../ && yarn debug --group scoped-elements",


### PR DESCRIPTION
## What I did

1. remove `types.js` from package exports, as we have both types export condition (nodenext) and top-level "types" fallback
