### PR TITLE
fix: getScopedTagName bug

### DIFF
--- a/.changeset/shaggy-geckos-smash.md
+++ b/.changeset/shaggy-geckos-smash.md
@@ -1,0 +1,5 @@
+---
+"@open-wc/scoped-elements": patch
+---
+
+fix: getScopedTagName bug

--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -171,7 +171,8 @@ const ScopedElementsMixinImplementation = superclass =>
      */
     // eslint-disable-next-line class-methods-use-this
     getScopedTagName(tagName) {
-      return tagName;
+      // @ts-ignore
+      return this.constructor.getScopedTagName(tagName);
     }
 
     /**
@@ -182,7 +183,8 @@ const ScopedElementsMixinImplementation = superclass =>
      */
     // eslint-disable-next-line class-methods-use-this
     static getScopedTagName(tagName) {
-      return tagName;
+      // @ts-ignore
+      return this.__registry.get(tagName) ? tagName : undefined;
     }
   };
 

--- a/packages/scoped-elements/test-web/ScopedElementsMixinWithPolyfill.test.js
+++ b/packages/scoped-elements/test-web/ScopedElementsMixinWithPolyfill.test.js
@@ -275,4 +275,32 @@ describe('ScopedElementsMixin features needing a real scope', () => {
     await waitUntil(() => $el1.shadowRoot.children[1] instanceof LazyElementA);
     await waitUntil(() => $el2.shadowRoot.children[1] instanceof LazyElementA);
   });
+
+  describe('[deprecated] getScopedTagName', () => {
+    it('should return the scoped tag name for a registered element', async () => {
+      const tag = defineCE(
+        class extends ScopedElementsMixin(LitElement) {
+          static get scopedElements() {
+            return {
+              'feature-a': FeatureA,
+            };
+          }
+
+          render() {
+            return html`
+              <feature-a></feature-a>
+              <feature-b></feature-b>
+            `;
+          }
+        },
+      );
+
+      const el = await fixture(`<${tag}></${tag}>`);
+
+      expect(el.getScopedTagName('feature-a')).to.equal('feature-a');
+      expect(el.getScopedTagName('feature-b')).to.equal(undefined);
+      expect(el.constructor.getScopedTagName('feature-a')).to.equal('feature-a');
+      expect(el.constructor.getScopedTagName('feature-b')).to.equal(undefined);
+    });
+  });
 });

--- a/packages/scoped-elements/test-web/runScopedElementsMixinSuite.js
+++ b/packages/scoped-elements/test-web/runScopedElementsMixinSuite.js
@@ -399,32 +399,6 @@ export function runScopedElementsMixinSuite({ label }) {
     });
 
     describe('[deprecated] getScopedTagName', () => {
-      it('should return the scoped tag name for a registered element', async () => {
-        const tag = defineCE(
-          class extends ScopedElementsMixin(LitElement) {
-            static get scopedElements() {
-              return {
-                'feature-a': FeatureA,
-              };
-            }
-
-            render() {
-              return html`
-                <feature-a></feature-a>
-                <feature-b></feature-b>
-              `;
-            }
-          },
-        );
-
-        const el = await fixture(`<${tag}></${tag}>`);
-
-        expect(el.getScopedTagName('feature-a')).to.equal('feature-a');
-        expect(el.getScopedTagName('feature-b')).to.equal('feature-b');
-        expect(el.constructor.getScopedTagName('feature-a')).to.equal('feature-a');
-        expect(el.constructor.getScopedTagName('feature-b')).to.equal('feature-b');
-      });
-
       it('should return the scoped tag name for a non already registered element', async () => {
         class UnregisteredFeature extends LitElement {
           render() {


### PR DESCRIPTION
## What I did

In v1, the ScopedElementsMixin would add a random ID to your custom elements, like for example: `<ing-feat-foo-43539>` as the scoping mechanism to avoid duplicate custom elements being defined, which results in runtime errors. In @open-wc/scoped-elements v2, the ScopedElementsMixin has been aligned more closely with the Scoped Custom Element Registries proposal, which uses a CustomElementRegistry as the scoping mechanism, so we no longer have to add a random ID to the custom elements.

ScopedElementsMixin v1 provided a getScopedTagName method, to easily get the generated tagName for a given element, for example:

```js
this.getScopedTagName('ing-feat-foo'); // 'ing-feat-foo-43439'
```

This method has been deprecated in @open-wc/scoped-elements v2 (and frankly, should have just been removed in v2). In v2, `getScopedTagName` just returns the `tagName`:

```js
getScopedTagName(tagName) {
  return tagName;
}
```

Which is a bit of a problem, because this causes the following statement:

```js
if(!this.getScopedTagName(tag)) {
  this.defineScopedElement(tag, klass);
}
```

To return `true` in v1, and
To return `false` in v2

This change makes the behavior of `getScopedTagName` more in line with how it was in v1.