### PR TITLE
fix(testing|testing-helpers): export oneDefaultPreventedEvent through…

### DIFF
--- a/.changeset/ninety-jokes-kick.md
+++ b/.changeset/ninety-jokes-kick.md
@@ -1,0 +1,6 @@
+---
+'@open-wc/testing': patch
+'@open-wc/testing-helpers': patch
+---
+
+Add oneDefaultPreventedEvent export into testing package and no-side-effect indexes

--- a/packages/testing-helpers/index-no-side-effects.js
+++ b/packages/testing-helpers/index-no-side-effects.js
@@ -9,6 +9,7 @@ export {
   isIE,
   nextFrame,
   oneEvent,
+  oneDefaultPreventedEvent,
   triggerBlurFor,
   triggerFocusFor,
   waitUntil,

--- a/packages/testing/index-no-side-effects.js
+++ b/packages/testing/index-no-side-effects.js
@@ -13,6 +13,7 @@ export {
   triggerBlurFor,
   triggerFocusFor,
   oneEvent,
+  oneDefaultPreventedEvent,
   isIE,
   defineCE,
   aTimeout,

--- a/packages/testing/index.d.ts
+++ b/packages/testing/index.d.ts
@@ -4,7 +4,7 @@ export { html } from '@open-wc/testing-helpers';
 export { unsafeStatic } from '@open-wc/testing-helpers';
 export { triggerBlurFor } from '@open-wc/testing-helpers';
 export { triggerFocusFor } from '@open-wc/testing-helpers';
-export { oneEvent } from '@open-wc/testing-helpers';
+export { oneEvent, oneDefaultPreventedEvent } from '@open-wc/testing-helpers';
 export { isIE } from '@open-wc/testing-helpers';
 export { defineCE } from '@open-wc/testing-helpers';
 export { aTimeout } from '@open-wc/testing-helpers';

--- a/packages/testing/index.js
+++ b/packages/testing/index.js
@@ -11,6 +11,7 @@ export {
   triggerBlurFor,
   triggerFocusFor,
   oneEvent,
+  oneDefaultPreventedEvent,
   isIE,
   defineCE,
   aTimeout,


### PR DESCRIPTION
… testing and add to no-side-effects indexes

## What I did

1. Added the `oneDefaultPreventedEvent` export from testing-helpers as an export through the `testing` package as well alongside `oneEvent`.
2. Added `oneDefaultPreventedEvent` export into the pure no-side-effect index js files of `testing` and `testing-helpers`

fixes #2656