### PR TITLE
[WIP / Discussion] Allow for non-lit specific implementation

### DIFF
--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -123,8 +123,7 @@ const ScopedElementsMixinImplementation = superclass =>
       }
 
       if (createdRoot instanceof ShadowRoot) {
-        adoptStyles(createdRoot, elementStyles);
-        this.renderOptions.renderBefore = this.renderOptions.renderBefore || createdRoot.firstChild;
+        this.adoptStyles(createdRoot)
       }
 
       return createdRoot;
@@ -134,6 +133,15 @@ const ScopedElementsMixinImplementation = superclass =>
       const root = supportsScopedRegistry ? this.shadowRoot : document;
       // @ts-ignore polyfill to support createElement on shadowRoot is loaded
       return root.createElement(tagName);
+    }
+    
+    // This would move to a separate file and enhance the mixin for Lit specifically.
+    // This doesn't accomplish the goal of the PR, but ideally an "adoptStyles" hook allows it to be extended
+    // for libraries that use constructable stylesheets.
+    adoptStyles(createdRoot) {
+      const { elementStyles } = this.constructor
+      adoptStyles(createdRoot, elementStyles);
+      this.renderOptions.renderBefore = this.renderOptions.renderBefore || createdRoot.firstChild;
     }
 
     /**


### PR DESCRIPTION
## What I did

1. Moved the `adoptStyles` call to be a hook

## Why?

Ideally I would love to be able to use this mixin with any web component, and as far as I can tell this is really the only Lit-specific portion.

Technically this PR doesn't solve the problem, but if the base mixin has a hook to adopt styles, we could get a separate entrypoint for the Mixin for Lit-specific implementations with the actual `adoptStyles` implementation.

I didn't do it here because I figured I'd open it up to discussion first if this is a use-case you all would like to support and making sure I didn't miss anything along the way.
