### PR TITLE
Feat/lint slot attribs

### DIFF
--- a/.changeset/slimy-grapes-protect.md
+++ b/.changeset/slimy-grapes-protect.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-lit-a11y': minor
+---
+
+added no-aria-slot rule to prevent invalid aria- and role attributes from appearing on slots

--- a/packages/eslint-plugin-lit-a11y/docs/rules/no-aria-slot.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/no-aria-slot.md
@@ -1,25 +1,27 @@
-# <TODO>
+# no-aria-slot
 
 ## Rule Details
 
-TODO
+Ensure aria- and role attributes aren't present on `<slot>` elements. While neither obvious nor clearly documented, these attributes aren't permitted on slots and cause problems for some assistive devices and accessibility checkers.
 
 Examples of **incorrect** code for this rule:
 
 ```js
-html`TODO`;
+html` <slot name="test" aria-label="test" role="button"></slot> `;
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-html`TODO`;
+html`
+  <div role="button" aria-label="test">
+    <slot></slot>
+  </div>
+`;
 ```
-
-## When Not To Use It
-
-TODO
 
 ## Further Reading
 
-[TODO](TODO)
+- [ARIA in HTML conformance requirements](https://www.w3.org/TR/html-aria/#el-slot)
+- [ARIA in HTML test cases](https://w3c.github.io/html-aria/tests/slot.html)
+- [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot#technical_summary)

--- a/packages/eslint-plugin-lit-a11y/docs/rules/no-aria-slot.md
+++ b/packages/eslint-plugin-lit-a11y/docs/rules/no-aria-slot.md
@@ -1,0 +1,25 @@
+# <TODO>
+
+## Rule Details
+
+TODO
+
+Examples of **incorrect** code for this rule:
+
+```js
+html`TODO`;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+html`TODO`;
+```
+
+## When Not To Use It
+
+TODO
+
+## Further Reading
+
+[TODO](TODO)

--- a/packages/eslint-plugin-lit-a11y/lib/index.js
+++ b/packages/eslint-plugin-lit-a11y/lib/index.js
@@ -38,6 +38,7 @@ module.exports.configs = {
       'lit-a11y/list': 'error',
       'lit-a11y/mouse-events-have-key-events': 'error',
       'lit-a11y/no-access-key': 'error',
+      'lit-a11y/no-aria-slot': 'error',
       'lit-a11y/no-autofocus': 'error',
       'lit-a11y/no-distracting-elements': 'error',
       'lit-a11y/no-invalid-change-handler': 'off',

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-aria-slot.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-aria-slot.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview <TODO>
+ * @author Cory Laviska & Konnor Rogers
+ */
+
+const ruleExtender = require('eslint-rule-extender');
+const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
+const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import("eslint").Rule.RuleModule} */
+const NoAriaSlot = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: '<TODO>',
+      category: 'Accessibility',
+      recommended: false,
+      url: 'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/no-aria-slot.md',
+    },
+    fixable: null,
+  },
+  create(context) {
+    return {
+      TaggedTemplateExpression(node) {
+        if (isHtmlTaggedTemplate(node, context)) {
+          const analyzer = TemplateAnalyzer.create(node);
+
+          analyzer.traverse({
+            enterElement(element) {
+              if (!element.sourceCodeLocation) {
+                return; // probably a tree correction node
+              }
+
+              if (
+                element.name === 'slot' &&
+                Object.keys(element.attribs).some(a => a.startsWith('aria'))
+              ) {
+                const loc =
+                  analyzer.resolveLocation(
+                    element.sourceCodeLocation.startTag,
+                    context.getSourceCode(),
+                  ) ?? node.loc;
+
+                if (loc) {
+                  context.report({ loc, message: '<TODO>' });
+                }
+              }
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+module.exports = ruleExtender(NoAriaSlot, HasLitHtmlImportRuleExtension);

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-aria-slot.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-aria-slot.js
@@ -1,6 +1,6 @@
 /**
- * @fileoverview <TODO>
- * @author Cory Laviska & Konnor Rogers
+ * @fileoverview Ensure that slots do not have aria or role attributes.
+ * @author Cory LaViska
  */
 
 const ruleExtender = require('eslint-rule-extender');
@@ -17,10 +17,13 @@ const NoAriaSlot = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: '<TODO>',
+      description: 'Slots do not allow aria or role attributes.',
       category: 'Accessibility',
       recommended: false,
       url: 'https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/docs/rules/no-aria-slot.md',
+    },
+    messages: {
+      noAriaSlot: 'Aria attributes and the role attribute are not permitted on slots.',
     },
     fixable: null,
   },
@@ -38,7 +41,7 @@ const NoAriaSlot = {
 
               if (
                 element.name === 'slot' &&
-                Object.keys(element.attribs).some(a => a.startsWith('aria'))
+                Object.keys(element.attribs).some(a => a === 'role' || a.startsWith('aria'))
               ) {
                 const loc =
                   analyzer.resolveLocation(
@@ -47,7 +50,10 @@ const NoAriaSlot = {
                   ) ?? node.loc;
 
                 if (loc) {
-                  context.report({ loc, message: '<TODO>' });
+                  context.report({
+                    loc,
+                    messageId: 'noAriaSlot',
+                  });
                 }
               }
             },

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-aria-slot.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-aria-slot.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview <TODO>
+ * @author Cory Laviska & Konnor Rogers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib/rules/no-aria-slot.js');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  settings: { litHtmlSources: false },
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run('no-aria-slot', rule, {
+  valid: [{ code: '<TODO>' }],
+  invalid: [
+    {
+      code: '<TODO>',
+      errors: [{ messageId: 'TODO' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-aria-slot.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/no-aria-slot.js
@@ -1,6 +1,6 @@
 /**
- * @fileoverview <TODO>
- * @author Cory Laviska & Konnor Rogers
+ * @fileoverview Ensure that slots do not contain aria or role attributes.
+ * @author Cory LaViska
  */
 
 //------------------------------------------------------------------------------
@@ -23,11 +23,19 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-aria-slot', rule, {
-  valid: [{ code: '<TODO>' }],
+  valid: [
+    { code: 'html`<slot></slot>`' },
+    { code: 'html`<slot name="test"></slot>`' },
+    { code: 'html`<div role="button" aria-label="test"><slot></slot></div>`' },
+  ],
   invalid: [
     {
-      code: '<TODO>',
-      errors: [{ messageId: 'TODO' }],
+      code: 'html`<slot role="button"></slot>`',
+      errors: [{ messageId: 'noAriaSlot' }],
+    },
+    {
+      code: 'html`<slot aria-label="test"></slot>`',
+      errors: [{ messageId: 'noAriaSlot' }],
     },
   ],
 });


### PR DESCRIPTION
This PR supercedes #2690. Big thanks to @thepassle for pointing me in the right direction!

## What I did

Added `no-aria-slot` rule to `eslint-plugin-lit-a11y`.

This rule ensures aria- and role attributes aren't present on `<slot>` elements. While neither obvious nor clearly documented, these attributes aren't permitted on slots and cause problems for some assistive devices and accessibility checkers.

The following pages support this claim:

- [ARIA in HTML conformance requirements](https://www.w3.org/TR/html-aria/#el-slot)
- [ARIA in HTML test cases](https://w3c.github.io/html-aria/tests/slot.html)
- [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot#technical_summary)
