### PR TITLE
fix(chai-dom-diff): scope promise result to dom assertions

### DIFF
--- a/.changeset/rude-eels-switch.md
+++ b/.changeset/rude-eels-switch.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/semantic-dom-diff': patch
+---
+
+Refines TypeScript typings for DOM assertions

--- a/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
+++ b/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
@@ -5,33 +5,46 @@ import { DiffOptions } from './get-diffable-html';
 declare global {
   namespace Chai {
     interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
-      dom: Assertion;
-      lightDom: Assertion;
-      shadowDom: Assertion;
+      dom: DomDiffAssertion;
+      lightDom: DomDiffAssertion;
+      shadowDom: DomDiffAssertion;
+      equal: DomDiffEqual;
+      equals: DomDiffEqual;
+      eq: DomDiffEqual;
+      eql: DomDiffEqual;
+      eqls: DomDiffEqual;
+      to: DomDiffAssertion;
+      be: DomDiffAssertion;
+      been: DomDiffAssertion;
+      is: DomDiffAssertion;
+      that: DomDiffAssertion;
+      which: DomDiffAssertion;
+      and: DomDiffAssertion;
+      has: DomDiffAssertion;
+      have: DomDiffAssertion;
+      with: DomDiffAssertion;
+      at: DomDiffAssertion;
+      of: DomDiffAssertion;
+      same: DomDiffAssertion;
+      but: DomDiffAssertion;
+      does: DomDiffAssertion;
+    }
+
+    interface DomDiffEqual {
+      (value: unknown, message?: string, options?: DiffOptions): Promise<Assertion>;
+      (value: unknown, options?: DiffOptions): Promise<Assertion>;
+    }
+
+    interface DomDiffAssertion extends Assertion {
       notEqual(actual: Object, expected: Object, message?: string): void;
-      equalSnapshot(options?: Object): Assertion;
-      notEqualSnapshot(options?: Object): Assertion;
+      equalSnapshot(options?: Object): Promise<Assertion>;
+      notEqualSnapshot(options?: Object): Promise<Assertion>;
     }
 
     interface Assert {
-      dom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
-      lightDom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
-      shadowDom: Pick<Assertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
-      equalSnapshot(fixture: unknown, options?: DiffOptions): Assertion;
-      notEqualSnapshot(fixture: unknown, options?: DiffOptions): Assertion;
-
-      equal<T>(actual: T, expected: T, message?: string, options?: DiffOptions): void;
-      equal<T>(actual: T, expected: T, message?: string): void;
-      equal<T>(actual: T, expected: T, options?: DiffOptions): void;
-
-      notEqual<T>(actual: T, expected: T, message?: string, options?: DiffOptions): void;
-      notEqual<T>(actual: T, expected: T, message?: string): void;
-      notEqual<T>(actual: T, expected: T, options?: DiffOptions): void;
-    }
-
-    interface Equal {
-      (value: unknown, message?: string, options?: DiffOptions): Promise<Assertion>;
-      (value: unknown, options?: DiffOptions): Promise<Assertion>;
+      dom: Pick<DomDiffAssertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
+      lightDom: Pick<DomDiffAssertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
+      shadowDom: Pick<DomDiffAssertion, 'equal' | 'notEqual' | 'equalSnapshot' | 'notEqualSnapshot'>;
     }
   }
 }


### PR DESCRIPTION
Fixes #2675 

## What I did

1. Remove our augmentations from Chai's global namespace
2. Extend Chai's namespace for our methods
3. Re-implement language chains on our namespace objects

step 3 there is particularly brittle. I have my :crossed_fingers: that chai 5 will be out before this becomes a real problem.

## Testing instructions

Please test with both TDD/BDD styles (`assert`/`expect`). I typically use `expect` so I didn't exhaustively test `assert.`
