### PR TITLE
add Svelte to list of base libraries

### DIFF
--- a/docs/_data/baseLibraries.js
+++ b/docs/_data/baseLibraries.js
@@ -68,6 +68,12 @@ const baseLibraries = [
     description: 'Stencil is a toolchain for building reusable, scalable Design Systems.',
     url: 'https://stenciljs.com/',
   },
+    {
+    name: 'Svelte',
+    package: 'svelte',
+    description: 'Svelte is not only framework, but a compiler that brings you benefits of reactivity with minimal footrint and suports custom element as a build target.',
+    url: 'https://svelte.dev/docs/custom-elements-api',
+  },
   {
     name: 'CanJS',
     package: 'can',


### PR DESCRIPTION
There was always an option to build custom elements with svelte, but recently there was a [huge update](https://github.com/sveltejs/svelte/pull/8457) and now dev experience is much better that was before. Lots of issues were fixed and now svelte is a pretty solid solution to build reliable custom elements. It would be nice to add it to the list of base libraries.

For example lots of svelte libraries were complied to custom elements before, (slidy)[https://github.com/Valexr/slidy/tree/main/packages] for example, and now it's even much easier than befor.

## What I did

1.
