### PR TITLE
fix: backport forward compatibility with registry property

### DIFF
--- a/.changeset/blue-ladybugs-bathe.md
+++ b/.changeset/blue-ladybugs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@open-wc/scoped-elements": patch
+---
+
+fix: Backport passing the scoped custom element registry via the registry option in addition to the customElement option to account for the change in the specification

--- a/packages/scoped-elements/src/ScopedElementsMixin.js
+++ b/packages/scoped-elements/src/ScopedElementsMixin.js
@@ -126,6 +126,7 @@ const ScopedElementsMixinImplementation = superclass =>
         mode: 'open',
         ...shadowRootOptions,
         customElements: this.registry,
+        registry: this.registry,
       };
 
       const createdRoot = this.attachShadow(options);

--- a/packages/scoped-elements/src/types.d.ts
+++ b/packages/scoped-elements/src/types.d.ts
@@ -51,6 +51,7 @@ export type ScopedElementsMixin = typeof ScopedElementsMixinImplementation;
 declare global {
   interface ShadowRootInit {
     customElements?: CustomElementRegistry;
+    registry?: CustomElementRegistry;
   }
 
   interface Window {


### PR DESCRIPTION
## What I did

1. Backport passing the scoped custom element registry via the `registry` option in addition to the `customElement` option to account for the change in the specification
