### PR TITLE
Use split versions for all lit dependencies

### DIFF
--- a/.changeset/proud-deers-study.md
+++ b/.changeset/proud-deers-study.md
@@ -1,0 +1,7 @@
+---
+"@open-wc/scoped-elements": patch
+"@open-wc/testing-helpers": patch
+"@open-wc/testing": patch
+---
+
+Use split versions for all lit dependencies

--- a/.changeset/rude-walls-divide.md
+++ b/.changeset/rude-walls-divide.md
@@ -1,0 +1,6 @@
+---
+"@open-wc/eslint-config": patch
+"eslint-plugin-lit-a11y": patch
+---
+
+Bump 'eslint-plugin-lit' version.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@rocket/core": "^0.1.2",
     "@rocket/launch": "^0.6.0",
     "@rocket/search": "^0.6.0",
-    "eslint-plugin-lit": "^1.8.0"
+    "eslint-plugin-lit": "^1.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",
@@ -103,8 +103,7 @@
     "typescript": "~4.1.3"
   },
   "resolutions": {
-    "@web/dev-server-core": "0.5.1",
-    "lit": "2.1.2"
+    "@web/dev-server-core": "0.5.1"
   },
   "lint-staged": {
     "*.js": [

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,7 +26,7 @@
     "eslint": ">=7.6.0",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-lit": "^1.3.0",
+    "eslint-plugin-lit": "^1.10.1",
     "eslint-plugin-lit-a11y": "^4.1.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-wc": "^1.2.0"
@@ -38,7 +38,7 @@
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-import-exports-imports-resolver": "^1.0.1",
-    "eslint-plugin-lit": "^1.8.0",
+    "eslint-plugin-lit": "^1.10.1",
     "eslint-plugin-lit-a11y": "^4.1.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-wc": "^1.2.0"

--- a/packages/eslint-plugin-lit-a11y/package.json
+++ b/packages/eslint-plugin-lit-a11y/package.json
@@ -34,7 +34,7 @@
     "axobject-query": "^2.2.0",
     "dom5": "^3.0.1",
     "emoji-regex": "^10.2.1",
-    "eslint-plugin-lit": "^1.6.0",
+    "eslint-plugin-lit": "^1.10.1",
     "eslint-rule-extender": "0.0.1",
     "language-tags": "^1.0.5",
     "parse5": "^7.1.2",

--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -49,7 +49,7 @@
     "helpers"
   ],
   "dependencies": {
-    "@lit/reactive-element": "^1.0.0",
+    "@lit/reactive-element": "^1.0.0 || ^2.0.0",
     "@open-wc/dedupe-mixin": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@open-wc/scoped-elements": "^2.2.0",
-    "lit": "^2.0.0",
+    "lit": "^2.0.0 || ^3.0.0",
     "lit-html": "^2.0.0"
   },
   "types": "types/index.d.ts"

--- a/tsconfig.browser-base.json
+++ b/tsconfig.browser-base.json
@@ -15,6 +15,7 @@
     "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
 
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,10 +1881,29 @@
     "@popperjs/core" "^2.5.4"
     singleton-manager "^1.4.3"
 
-"@lit/reactive-element@^1.0.0", "@lit/reactive-element@^1.1.0":
+"@lit-labs/ssr-dom-shim@^1.0.0", "@lit-labs/ssr-dom-shim@^1.1.0", "@lit-labs/ssr-dom-shim@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz#d693d972974a354034454ec1317eb6afd0b00312"
+  integrity sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g==
+
+"@lit/reactive-element@^1.0.0 || ^2.0.0", "@lit/reactive-element@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.1.tgz#b17d8818d9c72ccc489f44e35d87cfa18a9c8c93"
+  integrity sha512-eu50SQXHRthFwWJMp0oAFg95Rvm6MTPjxSXWuvAu7It90WVFLFpNBoIno7XOXSDvVgTrtKnUV4OLJqys2Svn4g==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.1.2"
+
+"@lit/reactive-element@^1.1.0":
   version "1.2.1"
   resolved "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.2.1.tgz"
   integrity sha512-03FYfMguIWo9E1y1qcTpXzoO8Ukpn0j5o4GjNFq/iHqJEPY6pYopsU44e7NSFIgCTorr8wdUU5PfVy8VeD6Rwg==
+
+"@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.6.0":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.6.3.tgz#25b4eece2592132845d303e091bad9b04cdcfe03"
+  integrity sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.0.0"
 
 "@lukeed/ms@^2.0.1":
   version "2.0.1"
@@ -7530,10 +7549,10 @@ eslint-plugin-import@^2.26.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-plugin-lit@^1.6.0, eslint-plugin-lit@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-lit/-/eslint-plugin-lit-1.8.0.tgz"
-  integrity sha512-wY/Z4SksuTkpELl4okhXHBf63V44PV2n19/HOBa7cPH6g+yyzvIMpIZ26BQbzEC54GwwWoYtONY3WvAjMNV8Cg==
+eslint-plugin-lit@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lit/-/eslint-plugin-lit-1.10.1.tgz#c5195518aeed91249d72f3a131cfecc86e2869a9"
+  integrity sha512-3eH++xFpe6efd+TN6B9kW1coULdPyK+3fMNws378nbYQ/HiWIz0+jVcsaGVs9BbLt6kVkDxZmUGF4Ivx3BatkA==
   dependencies:
     parse5 "^6.0.1"
     parse5-htmlparser2-tree-adapter "^6.0.1"
@@ -10874,6 +10893,24 @@ lit-element@^3.1.0:
     "@lit/reactive-element" "^1.1.0"
     lit-html "^2.1.0"
 
+lit-element@^3.3.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.3.3.tgz#10bc19702b96ef5416cf7a70177255bfb17b3209"
+  integrity sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.1.0"
+    "@lit/reactive-element" "^1.3.0"
+    lit-html "^2.8.0"
+
+lit-element@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.0.1.tgz#fe9d82e2d034f819156f561f6f23b0ed0c9d19dc"
+  integrity sha512-OxRMJem4HKZt0320HplLkBPoi4KHiEHoPHKd8Lzf07ZQVAOKIjZ32yPLRKRDEolFU1RgrQBfSHQMoxKZ72V3Kw==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.1.2"
+    "@lit/reactive-element" "^2.0.0"
+    lit-html "^3.0.0"
+
 lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz"
@@ -10886,7 +10923,21 @@ lit-html@^2.0.0, lit-html@^2.1.0, lit-html@^2.4.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit@2.1.2, lit@^2.0.0, lit@^2.0.2, lit@^2.2.5:
+lit-html@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.8.0.tgz#96456a4bb4ee717b9a7d2f94562a16509d39bffa"
+  integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit-html@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.0.1.tgz#bbdb94c8c13120940fd9b169047e06f665906005"
+  integrity sha512-1nmGaNNQg9rBvE1yJ6oS3ZNbLs3FXtlG4+jgGkix8O740qVEwwiFVTgDGIIH8N5TcQ8V9tBk5T+sxqBgffcjJg==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit@^2.0.0, lit@^2.0.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/lit/-/lit-2.1.2.tgz#e08c24c950fb15a98cc328a8c17e7b4d377f5c48"
   integrity sha512-XacK89dJXF7BJbpiZSMvzT4RxHag7Wt+yNx7tErEVgGVlOFAeN871bj7ivotCMgYeBFWVp/hjKF/PDTk6L7gMA==
@@ -10894,6 +10945,24 @@ lit@2.1.2, lit@^2.0.0, lit@^2.0.2, lit@^2.2.5:
     "@lit/reactive-element" "^1.1.0"
     lit-element "^3.1.0"
     lit-html "^2.1.0"
+
+"lit@^2.0.0 || ^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.0.1.tgz#bc9136cf9303ae8c23d0adcf7847c971cc94aee9"
+  integrity sha512-CYFv7/gwrs6bfPm299O9LD/HB4dgHvsEf/yqUOI//fi469i2OrT4xaptUcmhr05DNQEgsBFecFH8EJnN5So8oQ==
+  dependencies:
+    "@lit/reactive-element" "^2.0.0"
+    lit-element "^4.0.0"
+    lit-html "^3.0.0"
+
+lit@^2.2.5:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.8.0.tgz#4d838ae03059bf9cafa06e5c61d8acc0081e974e"
+  integrity sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==
+  dependencies:
+    "@lit/reactive-element" "^1.6.0"
+    lit-element "^3.3.0"
+    lit-html "^2.8.0"
 
 load-json-file@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What I did

1. Split all versions of `lit` dependencies for consumption of ^2 || ^3.
