### PR TITLE
chore(testing-helpers): update @open-wc/scoped-elements to v3

### DIFF
--- a/.changeset/grumpy-owls-camp.md
+++ b/.changeset/grumpy-owls-camp.md
@@ -1,0 +1,13 @@
+---
+'@open-wc/testing-helpers': major
+---
+
+chore: update @open-wc/scoped-elements to v3
+
+If you're using a fixture like so with scoped elements:
+
+```ts
+await fixture(html`...`, { scopedElements: ... });
+```
+
+You're gonna have to load the [@webcomponents/scoped-custom-element-registry](https://www.npmjs.com/package/@webcomponents/scoped-custom-element-registry) polyfill yourself first.

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -43,7 +43,7 @@
     "fixtures"
   ],
   "dependencies": {
-    "@open-wc/scoped-elements": "^2.2.4",
+    "@open-wc/scoped-elements": "^3.0.0",
     "lit": "^2.0.0 || ^3.0.0",
     "lit-html": "^2.0.0 || ^3.0.0"
   },

--- a/packages/testing-helpers/package.json
+++ b/packages/testing-helpers/package.json
@@ -43,7 +43,7 @@
     "fixtures"
   ],
   "dependencies": {
-    "@open-wc/scoped-elements": "^3.0.0",
+    "@open-wc/scoped-elements": "^3.0.2",
     "lit": "^2.0.0 || ^3.0.0",
     "lit-html": "^2.0.0 || ^3.0.0"
   },

--- a/packages/testing-helpers/src/fixture-no-side-effect.js
+++ b/packages/testing-helpers/src/fixture-no-side-effect.js
@@ -17,7 +17,7 @@ import { isValidRenderArg } from './lib.js';
  * const el = fixtureSync('<my-el><span></span></my-el>');
  *
  * @template {Element} T
- * @param {import('./renderable').LitHTMLRenderable} template Either a string or lit-html TemplateResult
+ * @param {import('./renderable.js').LitHTMLRenderable} template Either a string or lit-html TemplateResult
  * @param {FixtureOptions} [options]
  * @returns {T} First child of the rendered DOM
  */
@@ -50,7 +50,7 @@ export function fixtureSync(template, options) {
  * expect(el.fullyRendered).to.be.true;
  *
  * @template {Element} T
- * @param {import('./renderable').LitHTMLRenderable} template Either a string or lit-html TemplateResult
+ * @param {import('./renderable.js').LitHTMLRenderable} template Either a string or lit-html TemplateResult
  * @param {FixtureOptions} [options]
  * @returns {Promise<T>} A Promise that will resolve to the first child of the rendered DOM
  */

--- a/packages/testing-helpers/src/fixture-no-side-effect.js
+++ b/packages/testing-helpers/src/fixture-no-side-effect.js
@@ -6,7 +6,7 @@ import { isValidRenderArg } from './lib.js';
  * @typedef {object} FixtureOptions
  * @property {*} [render] optional render function to use
  * @property {Element} [parentNode] optional parent node to render the fixture's template to
- * @property {import('@open-wc/scoped-elements').ScopedElementsMap} [scopedElements] optional scoped-elements
+ * @property {import('@open-wc/scoped-elements/html-element.js').ScopedElementsMap} [scopedElements] optional scoped-elements
  * definition map
  */
 

--- a/packages/testing-helpers/src/helpers.js
+++ b/packages/testing-helpers/src/helpers.js
@@ -123,7 +123,7 @@ export async function triggerFocusFor(element) {
  * @param eventTarget Target of the event, usually an Element
  * @param eventName Name of the event
  * @returns Promise to await until the event has been fired
- * @type {import("./types").OneEventFn}
+ * @type {import("./types.js").OneEventFn}
  */
 export function oneEvent(eventTarget, eventName) {
   return new Promise(resolve => {
@@ -147,7 +147,7 @@ export function oneEvent(eventTarget, eventName) {
  * @param eventTarget Target of the event, usually an Element
  * @param eventName Name of the event
  * @returns Promise to await until the event has been fired
- * @type {import("./types").OneEventFn}
+ * @type {import("./types.js").OneEventFn}
  */
 export function oneDefaultPreventedEvent(eventTarget, eventName) {
   return new Promise(resolve => {

--- a/packages/testing-helpers/src/litFixture.js
+++ b/packages/testing-helpers/src/litFixture.js
@@ -19,7 +19,7 @@ const isUsefulNode = ({ nodeType, textContent }) => {
  * Setups an element synchronously from the provided lit-html template and puts it in the DOM.
  *
  * @template {Element} T - Is an element or a node
- * @param {import('./renderable').LitHTMLRenderable} template
+ * @param {import('./renderable.js').LitHTMLRenderable} template
  * @param {import('./fixture-no-side-effect.js').FixtureOptions} [options]
  * @param {import('./scopedElementsWrapper.js').ScopedElementsTemplateGetter} [getScopedElementsTemplate]
  * @returns {T}
@@ -46,7 +46,7 @@ export function litFixtureSync(template, options = {}, getScopedElementsTemplate
  * Setups an element asynchronously from the provided lit-html template and puts it in the DOM.
  *
  * @template {Element} T - Is an element or a node
- * @param {import('./renderable').LitHTMLRenderable} template
+ * @param {import('./renderable.js').LitHTMLRenderable} template
  * @param {import('./fixture-no-side-effect.js').FixtureOptions} [options]
  * @returns {Promise<T>}
  */

--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -32,7 +32,7 @@ class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
     /** @type {ScopedElementsMap} */
     this.scopedElements = scopedElement;
 
-    /** @type {import('./renderable').LitHTMLRenderable} */
+    /** @type {import('./renderable.js').LitHTMLRenderable} */
     this.template = template;
   }
 
@@ -68,7 +68,7 @@ const getWrapperUniqueName = (counter = 0) => {
 /**
  * Wraps the template inside a scopedElements component
  *
- * @param {import('./renderable').LitHTMLRenderable} template
+ * @param {import('./renderable.js').LitHTMLRenderable} template
  * @param {ScopedElementsMap} scopedElements
  * @return {HTMLElement}
  */

--- a/packages/testing-helpers/src/scopedElementsWrapper.js
+++ b/packages/testing-helpers/src/scopedElementsWrapper.js
@@ -1,7 +1,7 @@
-import { ScopedElementsMixin } from '@open-wc/scoped-elements';
+import { ScopedElementsMixin } from '@open-wc/scoped-elements/html-element.js';
 import { LitElement } from 'lit';
 
-/** @typedef {import('@open-wc/scoped-elements').ScopedElementsMap} ScopedElementsMap */
+/** @typedef {import('@open-wc/scoped-elements/html-element.js').ScopedElementsMap} ScopedElementsMap */
 /** @typedef {import('lit/html.js').TemplateResult} TemplateResult */
 
 /**
@@ -33,7 +33,6 @@ class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
     this.scopedElements = scopedElement;
 
     /** @type {import('./renderable').LitHTMLRenderable} */
-    // eslint-disable-next-line no-unused-expressions
     this.template = template;
   }
 
@@ -42,7 +41,7 @@ class ScopedElementsTestWrapper extends ScopedElementsMixin(LitElement) {
 
     Object.keys(this.scopedElements).forEach(key =>
       // @ts-ignore
-      this.defineScopedElement(key, this.scopedElements[key]),
+      this.registry.define(key, this.scopedElements[key]),
     );
   }
 

--- a/packages/testing-helpers/tsconfig.json
+++ b/packages/testing-helpers/tsconfig.json
@@ -3,13 +3,14 @@
 {
   "extends": "../../tsconfig.browser-base.json",
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "NodeNext",
     "outDir": "./types",
     "rootDir": ".",
     "composite": true,
     "allowJs": true,
     "checkJs": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "moduleResolution": "Node16"
   },
   "references": [
     {

--- a/packages/testing-helpers/tsconfig.override.json
+++ b/packages/testing-helpers/tsconfig.override.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "Node16"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,7 +2678,7 @@
     "@open-wc/dedupe-mixin" "^1.3.0"
     lit-html "^1.0.0"
 
-"@open-wc/scoped-elements@^2.0.0", "@open-wc/scoped-elements@^2.0.1", "@open-wc/scoped-elements@^2.1.1", "@open-wc/scoped-elements@^2.2.4":
+"@open-wc/scoped-elements@^2.0.0", "@open-wc/scoped-elements@^2.0.1", "@open-wc/scoped-elements@^2.1.1":
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.2.4.tgz#081559b62d885ac0ec043546f17f1f680294d500"
   integrity sha512-12X4F4QGPWcvPbxAiJ4v8wQFCOu+laZHRGfTrkoj+3JzACCtuxHG49YbuqVzQ135QPKCuhP9wA0kpGGEfUegyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,6 +2686,14 @@
     "@lit/reactive-element" "^1.0.0 || ^2.0.0"
     "@open-wc/dedupe-mixin" "^1.4.0"
 
+"@open-wc/scoped-elements@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-3.0.2.tgz#0295b15cb8d6e872b87d015020f1432a1662dd0a"
+  integrity sha512-TZ9NjcAGjrfoZ8GjbMYDTuztFL1YPHtvFgqlcTrYy6C7jHSgCv67Rv9Cgf55VDNZgzRu+yBi5IjcyLzWNZ17eg==
+  dependencies:
+    "@open-wc/dedupe-mixin" "^1.4.0"
+    lit "^3.0.0"
+
 "@pnpm/config.env-replace@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,14 +2686,6 @@
     "@lit/reactive-element" "^1.0.0 || ^2.0.0"
     "@open-wc/dedupe-mixin" "^1.4.0"
 
-"@open-wc/scoped-elements@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-3.0.2.tgz#0295b15cb8d6e872b87d015020f1432a1662dd0a"
-  integrity sha512-TZ9NjcAGjrfoZ8GjbMYDTuztFL1YPHtvFgqlcTrYy6C7jHSgCv67Rv9Cgf55VDNZgzRu+yBi5IjcyLzWNZ17eg==
-  dependencies:
-    "@open-wc/dedupe-mixin" "^1.4.0"
-    lit "^3.0.0"
-
 "@pnpm/config.env-replace@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz"


### PR DESCRIPTION
## What I did

chore: update @open-wc/scoped-elements to v3

If you're using a fixture like so with scoped elements:

```ts
await fixture(html`...`, { scopedElements: ... });
```

You're gonna have to load the [@webcomponents/scoped-custom-element-registry](https://www.npmjs.com/package/@webcomponents/scoped-custom-element-registry) polyfill yourself first.
