### PR TITLE
fix(testing-helpers): correct type declaration for `oneEvent`

### DIFF
--- a/.changeset/moody-panthers-visit.md
+++ b/.changeset/moody-panthers-visit.md
@@ -1,0 +1,7 @@
+---
+'@open-wc/testing-helpers': patch
+---
+
+fix(testing-helpers): correct type declaration for `oneEvent`
+
+`preventDefault` parameter is not used

--- a/packages/testing-helpers/src/types.d.ts
+++ b/packages/testing-helpers/src/types.d.ts
@@ -1,3 +1,3 @@
 
 export type OneEventFn =
-  <TEvent extends Event = CustomEvent>(eventTarget: EventTarget, eventName: string, preventDefault: boolean)=> Promise<TEvent>
+  <TEvent extends Event = CustomEvent>(eventTarget: EventTarget, eventName: string) => Promise<TEvent>


### PR DESCRIPTION
## What I did

1. Corrected the type declaration for `oneEvent` and `oneDefaultPreventedEvent` functions

fixes #2746