### PR TITLE
Replace context.getSourceCode with context.sourcecode 

### DIFF
--- a/.changeset/two-bikes-return.md
+++ b/.changeset/two-bikes-return.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-lit-a11y': patch
+---
+
+Changed context.getSourceCode to context.sourceCode with backward compatibility

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-emoji.js
@@ -10,6 +10,7 @@ const { isTextNode } = require('../utils/ast.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -80,7 +81,7 @@ const AccessibleEmojiRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
                 if (loc) {
                   context.report({ loc, messageId: 'wrapEmoji' });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-name.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-name.js
@@ -10,6 +10,7 @@ const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
 const { hasAccessibleName } = require('../utils/hasAccessibleName.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -134,7 +135,7 @@ const ButtonHasContentRule = {
                   const loc =
                     analyzer.resolveLocation(
                       element.sourceCodeLocation.startTag,
-                      context.getSourceCode(),
+                      getContextSourceCode(context),
                     ) ?? node.loc;
 
                   if (loc) {
@@ -156,7 +157,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                   ) ?? node.loc;
 
                 if (loc) {
@@ -182,7 +183,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                   ) ?? node.loc;
 
                 if (loc) {
@@ -206,7 +207,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                   ) ?? node.loc;
 
                 if (loc) {
@@ -228,7 +229,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                   ) ?? node.loc;
 
                 if (loc) {
@@ -246,7 +247,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                   ) ?? node.loc;
 
                 if (loc) {
@@ -267,7 +268,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                   ) ?? node.loc;
 
                 if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-name.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-name.js
@@ -157,7 +157,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {
@@ -183,7 +183,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {
@@ -207,7 +207,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {
@@ -229,7 +229,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {
@@ -247,7 +247,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {
@@ -268,7 +268,7 @@ const ButtonHasContentRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/alt-text.js
@@ -9,6 +9,7 @@ const { elementHasAttribute, elementHasSomeAttribute } = require('../utils/eleme
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -96,7 +97,7 @@ const AltTextRule = {
               const loc =
                 analyzer.resolveLocation(
                   element.sourceCodeLocation.startTag,
-                  context.getSourceCode(),
+                  getContextSourceCode(context),
                 ) ?? node.loc;
 
               if (!loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
@@ -9,6 +9,7 @@ const { generateObjSchema, enumArraySchema } = require('../utils/schemas.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
 const { getLiteralAttributeValue } = require('../utils/getLiteralAttributeValue.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -86,7 +87,7 @@ const AnchorIsValidRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode(),
+                        getContextSourceCode(context),
                       ) ?? node.loc;
                     if (loc) {
                       context.report({ loc, messageId: 'noHrefErrorMessage' });
@@ -98,7 +99,7 @@ const AnchorIsValidRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode(),
+                        context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                       ) ?? node.loc;
                     if (loc) {
                       context.report({ loc, messageId: 'preferButtonErrorMessage' });
@@ -112,7 +113,7 @@ const AnchorIsValidRule = {
                   analyzer,
                   element,
                   'href',
-                  context.getSourceCode(),
+                  context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                 );
 
                 const invalidHrefValue =
@@ -127,7 +128,7 @@ const AnchorIsValidRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode(),
+                        context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                       ) ?? node.loc;
                     if (loc) {
                       context.report({ loc, messageId: 'preferButtonErrorMessage' });
@@ -136,7 +137,7 @@ const AnchorIsValidRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode(),
+                        context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                       ) ?? node.loc;
                     if (loc) {
                       context.report({ loc, messageId: 'invalidHrefErrorMessage' });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/anchor-is-valid.js
@@ -99,7 +99,7 @@ const AnchorIsValidRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                        getContextSourceCode(context),
                       ) ?? node.loc;
                     if (loc) {
                       context.report({ loc, messageId: 'preferButtonErrorMessage' });
@@ -113,7 +113,7 @@ const AnchorIsValidRule = {
                   analyzer,
                   element,
                   'href',
-                  context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                  getContextSourceCode(context),
                 );
 
                 const invalidHrefValue =
@@ -128,7 +128,7 @@ const AnchorIsValidRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                        getContextSourceCode(context),
                       ) ?? node.loc;
                     if (loc) {
                       context.report({ loc, messageId: 'preferButtonErrorMessage' });
@@ -137,7 +137,7 @@ const AnchorIsValidRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                        getContextSourceCode(context),
                       ) ?? node.loc;
                     if (loc) {
                       context.report({ loc, messageId: 'invalidHrefErrorMessage' });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
@@ -68,7 +68,7 @@ const AriaActiveDescendantHasTabindexRule = {
               const loc =
                 analyzer.resolveLocation(
                   element.sourceCodeLocation.startTag,
-                  context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
+                  getContextSourceCode(context),
                 ) ?? node.loc;
 
               if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-activedescendant-has-tabindex.js
@@ -8,6 +8,7 @@ const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRule
 const { isInteractiveElement } = require('../utils/isInteractiveElement.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { getLiteralAttributeValue } = require('../utils/getLiteralAttributeValue.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -55,7 +56,7 @@ const AriaActiveDescendantHasTabindexRule = {
                 analyzer,
                 element,
                 'tabindex',
-                context.getSourceCode(),
+                getContextSourceCode(context),
               );
 
               if (tabindex && value === undefined) return;
@@ -67,7 +68,7 @@ const AriaActiveDescendantHasTabindexRule = {
               const loc =
                 analyzer.resolveLocation(
                   element.sourceCodeLocation.startTag,
-                  context.getSourceCode(),
+                  context.getSourceCode() ? context.getSourceCode() : context.sourceCode,
                 ) ?? node.loc;
 
               if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
@@ -8,6 +8,7 @@ const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js
 const { getElementAriaAttributes } = require('../utils/aria.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -140,7 +141,7 @@ const AriaAttrTypesRule = {
                   }
 
                   const loc =
-                    analyzer.getLocationForAttribute(element, attr, context.getSourceCode()) ??
+                    analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
                     node.loc;
 
                   if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attr-valid-value.js
@@ -141,8 +141,11 @@ const AriaAttrTypesRule = {
                   }
 
                   const loc =
-                    analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
-                    node.loc;
+                    analyzer.getLocationForAttribute(
+                      element,
+                      attr,
+                      getContextSourceCode(context),
+                    ) ?? node.loc;
 
                   if (loc) {
                     context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
@@ -8,6 +8,7 @@ const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js
 const { isInvalidAriaAttribute } = require('../utils/aria.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -38,7 +39,7 @@ const AriaAttrsRule = {
               for (const attr of Object.keys(element.attribs)) {
                 if (isInvalidAriaAttribute(attr)) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, attr, context.getSourceCode()) ??
+                    analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
                     node.loc;
 
                   if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-attrs.js
@@ -39,8 +39,11 @@ const AriaAttrsRule = {
               for (const attr of Object.keys(element.attribs)) {
                 if (isInvalidAriaAttribute(attr)) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
-                    node.loc;
+                    analyzer.getLocationForAttribute(
+                      element,
+                      attr,
+                      getContextSourceCode(context),
+                    ) ?? node.loc;
 
                   if (loc) {
                     context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -9,6 +9,7 @@ const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
 const { isConcreteAriaRole } = require('../utils/aria.js');
 const { getLiteralAttributeValue } = require('../utils/getLiteralAttributeValue.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -46,7 +47,7 @@ const AriaRoleRule = {
                   analyzer,
                   element,
                   'role',
-                  context.getSourceCode(),
+                  getContextSourceCode(context),
                 );
 
                 if (role === undefined) return;

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -54,8 +54,11 @@ const AriaRoleRule = {
 
                 if (!isConcreteAriaRole(role)) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
-                    node.loc;
+                    analyzer.getLocationForAttribute(
+                      element,
+                      attr,
+                      getContextSourceCode(context),
+                    ) ?? node.loc;
                   if (loc) {
                     context.report({
                       loc,

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-role.js
@@ -54,7 +54,7 @@ const AriaRoleRule = {
 
                 if (!isConcreteAriaRole(role)) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, attr, context.getSourceCode()) ??
+                    analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
                     node.loc;
                   if (loc) {
                     context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
@@ -42,8 +42,11 @@ const AriaUnsupportedElementsRule = {
                 for (const attr of Object.keys(element.attribs)) {
                   if (attr.startsWith('aria-') || attr === 'role') {
                     const loc =
-                      analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
-                      node.loc;
+                      analyzer.getLocationForAttribute(
+                        element,
+                        attr,
+                        getContextSourceCode(context),
+                      ) ?? node.loc;
                     if (loc) {
                       context.report({
                         loc,

--- a/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/aria-unsupported-elements.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -41,7 +42,7 @@ const AriaUnsupportedElementsRule = {
                 for (const attr of Object.keys(element.attribs)) {
                   if (attr.startsWith('aria-') || attr === 'role') {
                     const loc =
-                      analyzer.getLocationForAttribute(element, attr, context.getSourceCode()) ??
+                      analyzer.getLocationForAttribute(element, attr, getContextSourceCode(context)) ??
                       node.loc;
                     if (loc) {
                       context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js
@@ -9,6 +9,7 @@ const { runVirtualRule } = require('axe-core');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -72,7 +73,7 @@ const AutocompleteValidRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
                 if (loc) {
                   context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
@@ -9,6 +9,7 @@ const { isIncludedInAOM } = require('../utils/isIncludedInAOM.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { isNonInteractiveElement } = require('../utils/isNonInteractiveElement.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -93,7 +94,7 @@ const ClickEventsHaveKeyEventsRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
                 if (loc) {
                   context.report({ loc, messageId: 'clickableNonInteractiveElements' });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/definition-list.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/definition-list.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -52,7 +53,7 @@ const DefinitionListRule = {
                   const loc =
                     analyzer.resolveLocation(
                       element.sourceCodeLocation.startTag,
-                      context.getSourceCode(),
+                      getContextSourceCode(context),
                     ) ?? node.loc;
 
                   const messageId = 'list';

--- a/packages/eslint-plugin-lit-a11y/lib/rules/heading-hidden.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/heading-hidden.js
@@ -8,6 +8,7 @@ const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -72,7 +73,7 @@ const HeadingHiddenRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -53,7 +54,7 @@ const IframeTitleRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
                 if (loc) {
                   context.report({ loc, messageId: 'iframeTitle' });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
@@ -10,6 +10,7 @@ const { isAriaHidden } = require('../utils/aria.js');
 const { elementHasAttribute } = require('../utils/elementHasAttribute.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
 const { getLiteralAttributeValue } = require('../utils/getLiteralAttributeValue.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -75,7 +76,7 @@ const ImgRedundantAltRule = {
                 analyzer,
                 element,
                 'alt',
-                context.getSourceCode(),
+                getContextSourceCode(context),
               );
 
               if (!alt) return;
@@ -87,7 +88,7 @@ const ImgRedundantAltRule = {
               if (contraband.length > 0) {
                 const banned = formatter.format(contraband);
                 const loc =
-                  analyzer.getLocationForAttribute(element, 'alt', context.getSourceCode()) ??
+                  analyzer.getLocationForAttribute(element, 'alt', getContextSourceCode(context)) ??
                   node.loc;
 
                 if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/list.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/list.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -52,7 +53,7 @@ const ListRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 const messageId = 'list';

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -36,7 +37,7 @@ const NoAccessKeyRule = {
             enterElement(element) {
               if (Object.keys(element.attribs).includes('accesskey')) {
                 const loc =
-                  analyzer.getLocationForAttribute(element, 'accesskey', context.getSourceCode()) ??
+                  analyzer.getLocationForAttribute(element, 'accesskey', getContextSourceCode(context)) ??
                   node.loc;
                 if (loc) {
                   context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-access-key.js
@@ -37,8 +37,11 @@ const NoAccessKeyRule = {
             enterElement(element) {
               if (Object.keys(element.attribs).includes('accesskey')) {
                 const loc =
-                  analyzer.getLocationForAttribute(element, 'accesskey', getContextSourceCode(context)) ??
-                  node.loc;
+                  analyzer.getLocationForAttribute(
+                    element,
+                    'accesskey',
+                    getContextSourceCode(context),
+                  ) ?? node.loc;
                 if (loc) {
                   context.report({
                     loc,

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-aria-slot.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-aria-slot.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -46,7 +47,7 @@ const NoAriaSlot = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
@@ -40,8 +40,11 @@ const NoAutofocusRule = {
             enterElement(element) {
               if ('autofocus' in element.attribs) {
                 const loc =
-                  analyzer.getLocationForAttribute(element, 'autofocus', getContextSourceCode(context)) ??
-                  node.loc;
+                  analyzer.getLocationForAttribute(
+                    element,
+                    'autofocus',
+                    getContextSourceCode(context),
+                  ) ?? node.loc;
                 if (loc) {
                   context.report({
                     loc,

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-autofocus.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -39,7 +40,7 @@ const NoAutofocusRule = {
             enterElement(element) {
               if ('autofocus' in element.attribs) {
                 const loc =
-                  analyzer.getLocationForAttribute(element, 'autofocus', context.getSourceCode()) ??
+                  analyzer.getLocationForAttribute(element, 'autofocus', getContextSourceCode(context)) ??
                   node.loc;
                 if (loc) {
                   context.report({
@@ -54,7 +55,7 @@ const NoAutofocusRule = {
                   analyzer.getLocationForAttribute(
                     element,
                     '.autofocus',
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
                 if (loc) {
                   context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-distracting-elements.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -43,7 +44,7 @@ const NoDistractingElementsRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
                 if (loc) {
                   context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-invalid-change-handler.js
@@ -7,6 +7,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -49,7 +50,7 @@ const NoInvalidChangeHandlerRule = {
                   const loc =
                     analyzer.resolveLocation(
                       element.sourceCodeLocation.startTag,
-                      context.getSourceCode(),
+                      getContextSourceCode(context),
                     ) ?? node.loc;
                   if (loc) {
                     context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/no-redundant-role.js
@@ -9,6 +9,7 @@ const { getImplicitRole } = require('../utils/getImplicitRole.js');
 const { getExplicitRole } = require('../utils/getExplicitRole.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -59,7 +60,7 @@ const NoRedundantRoleRule = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
                 if (loc) {
                   context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/obj-alt.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/obj-alt.js
@@ -9,6 +9,7 @@ const { hasAccessibleName } = require('../utils/hasAccessibleName.js');
 const { isHiddenFromScreenReader } = require('../utils/isHiddenFromScreenReader.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -54,7 +55,7 @@ const ObjAlt = {
                 const loc =
                   analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   ) ?? node.loc;
 
                 if (loc) {

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
@@ -9,6 +9,7 @@ const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js
 const { isAriaRole } = require('../utils/aria.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -61,7 +62,7 @@ const RoleHasRequiredAriaAttrsRule = {
                     const loc =
                       analyzer.resolveLocation(
                         element.sourceCodeLocation.startTag,
-                        context.getSourceCode(),
+                        getContextSourceCode(context),
                       ) ?? node.loc;
                     if (loc) {
                       context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/role-supports-aria-attr.js
@@ -9,6 +9,7 @@ const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js
 const { isAriaPropertyName, isAriaRole } = require('../utils/aria.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -57,7 +58,7 @@ const RoleSupportsAriaAttrRule = {
                           analyzer.getLocationForAttribute(
                             element,
                             attr,
-                            context.getSourceCode(),
+                            getContextSourceCode(context),
                           ) ?? node.loc;
                         if (loc) {
                           context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
@@ -49,8 +49,11 @@ const ScopeRule = {
 
                 if (element.name !== 'th' && !element.name.includes('-')) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, 'scope', getContextSourceCode(context)) ??
-                    node.loc;
+                    analyzer.getLocationForAttribute(
+                      element,
+                      'scope',
+                      getContextSourceCode(context),
+                    ) ?? node.loc;
                   if (loc) {
                     context.report({
                       loc,
@@ -62,8 +65,11 @@ const ScopeRule = {
                   !validScopeValues.includes(element.attribs.scope)
                 ) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, 'scope', getContextSourceCode(context)) ??
-                    node.loc;
+                    analyzer.getLocationForAttribute(
+                      element,
+                      'scope',
+                      getContextSourceCode(context),
+                    ) ?? node.loc;
                   if (loc) {
                     context.report({
                       loc,

--- a/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/scope.js
@@ -7,6 +7,7 @@ const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
 const { getLiteralAttributeValue } = require('../utils/getLiteralAttributeValue.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -42,13 +43,13 @@ const ScopeRule = {
                   analyzer,
                   element,
                   'scope',
-                  context.getSourceCode(),
+                  getContextSourceCode(context),
                 );
                 if (role === undefined) return;
 
                 if (element.name !== 'th' && !element.name.includes('-')) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, 'scope', context.getSourceCode()) ??
+                    analyzer.getLocationForAttribute(element, 'scope', getContextSourceCode(context)) ??
                     node.loc;
                   if (loc) {
                     context.report({
@@ -61,7 +62,7 @@ const ScopeRule = {
                   !validScopeValues.includes(element.attribs.scope)
                 ) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, 'scope', context.getSourceCode()) ??
+                    analyzer.getLocationForAttribute(element, 'scope', getContextSourceCode(context)) ??
                     node.loc;
                   if (loc) {
                     context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/tabindex-no-positive.js
@@ -6,6 +6,7 @@ const ruleExtender = require('eslint-rule-extender');
 const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -46,7 +47,7 @@ const TabindexNoPositiveRule = {
                 const expr = analyzer.getAttributeValue(
                   element,
                   attributeName,
-                  context.getSourceCode(),
+                  getContextSourceCode(context),
                 );
 
                 if (typeof expr !== 'string') {
@@ -64,7 +65,7 @@ const TabindexNoPositiveRule = {
                     analyzer.getLocationForAttribute(
                       element,
                       attributeName,
-                      context.getSourceCode(),
+                      getContextSourceCode(context),
                     ) ?? node.loc;
                   if (loc) {
                     context.report({
@@ -81,7 +82,7 @@ const TabindexNoPositiveRule = {
                     analyzer.getLocationForAttribute(
                       element,
                       attributeName,
-                      context.getSourceCode(),
+                      getContextSourceCode(context),
                     ) ?? node.loc;
                   if (loc) {
                     context.report({ loc, messageId: 'avoidPositiveTabindex' });

--- a/packages/eslint-plugin-lit-a11y/lib/rules/valid-lang.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/valid-lang.js
@@ -9,6 +9,7 @@ const { TemplateAnalyzer } = require('eslint-plugin-lit/lib/template-analyzer');
 const { getLiteralAttributeValue } = require('../utils/getLiteralAttributeValue.js');
 const { HasLitHtmlImportRuleExtension } = require('../utils/HasLitHtmlImportRuleExtension.js');
 const { isHtmlTaggedTemplate } = require('../utils/isLitHtmlTemplate.js');
+const { getContextSourceCode } = require('../utils/getContextSourceCode.js');
 
 const ValidLangRule = {
   meta: {
@@ -40,13 +41,13 @@ const ValidLangRule = {
                   analyzer,
                   element,
                   'lang',
-                  context.getSourceCode(),
+                  getContextSourceCode(context),
                 );
 
                 if (!lang) {
                   const loc = analyzer.resolveLocation(
                     element.sourceCodeLocation.startTag,
-                    context.getSourceCode(),
+                    getContextSourceCode(context),
                   );
 
                   return context.report({
@@ -58,7 +59,7 @@ const ValidLangRule = {
                 // We cast this as string, as lang could be a number, since getLiteralAttributeValue returns a primitive, this would throw an error as `language-tags` performs string methods on the argument
                 if (!tags.check(`${lang}`)) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, 'lang', context.getSourceCode()) ??
+                    analyzer.getLocationForAttribute(element, 'lang', getContextSourceCode(context),) ??
                     node.loc;
 
                   return context.report({

--- a/packages/eslint-plugin-lit-a11y/lib/rules/valid-lang.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/valid-lang.js
@@ -59,8 +59,11 @@ const ValidLangRule = {
                 // We cast this as string, as lang could be a number, since getLiteralAttributeValue returns a primitive, this would throw an error as `language-tags` performs string methods on the argument
                 if (!tags.check(`${lang}`)) {
                   const loc =
-                    analyzer.getLocationForAttribute(element, 'lang', getContextSourceCode(context),) ??
-                    node.loc;
+                    analyzer.getLocationForAttribute(
+                      element,
+                      'lang',
+                      getContextSourceCode(context),
+                    ) ?? node.loc;
 
                   return context.report({
                     loc,

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
@@ -3,15 +3,15 @@
  *
  */
 function getContextSourceCode(context) {
-    try{
-        if (context.getSourceCode()) {
-            return context.getSourceCode();
-        }
-    }catch(e){
-        return context.sourceCode;
+  try {
+    if (context.getSourceCode()) {
+      return context.getSourceCode();
     }
+  } catch (e) {
+    return context.sourceCode;
+  }
 }
 
 module.exports = {
-    getContextSourceCode,
+  getContextSourceCode,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
@@ -3,10 +3,13 @@
  *
  */
 function getContextSourceCode(context) {
-  if (typeof context.getSourceCode() === 'function') {
-    return context.getSourceCode();
-  }
-  return context.sourceCode;
+    try{
+        if (context.getSourceCode()) {
+            return context.getSourceCode();
+        }
+    }catch(e){
+        return context.sourceCode;
+    }
 }
 
 module.exports = {

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
@@ -1,6 +1,8 @@
 /**
- * Returns checks backward compatiblity and returns context.sourceCode
- *
+ * The new eslint v9 alpha version which has breaking changes
+ * This version has deprecated context.getSourceCode() instead context.sourceCode should be used
+ * The getContextSourceCode() checks backward compatiblity and returns context.sourceCode
+ * This method can be removed once v9 is released
  */
 function getContextSourceCode(context) {
   try {

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
@@ -8,6 +8,11 @@ function getContextSourceCode(context) {
   return context?.sourceCode ?? context.getSourceCode();
 }
 
+function getParserServices(context) {
+  return context?.sourceCode?.parserServices ?? context.parserServices;
+}
+
 module.exports = {
   getContextSourceCode,
+  getParserServices,
 };

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
@@ -1,0 +1,14 @@
+/**
+ * Returns checks backward compatiblity and returns context.sourceCode
+ *
+ */
+function getContextSourceCode(context) {
+  if (typeof context.getSourceCode() === 'function') {
+    return context.getSourceCode();
+  }
+  return context.sourceCode;
+}
+
+module.exports = {
+    getContextSourceCode,
+};

--- a/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/getContextSourceCode.js
@@ -5,13 +5,7 @@
  * This method can be removed once v9 is released
  */
 function getContextSourceCode(context) {
-  try {
-    if (context.getSourceCode()) {
-      return context.getSourceCode();
-    }
-  } catch (e) {
-    return context.sourceCode;
-  }
+  return context?.sourceCode ?? context.getSourceCode();
 }
 
 module.exports = {

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isLitHtmlTemplate.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isLitHtmlTemplate.js
@@ -2,7 +2,7 @@
  * @template {'html'|'svg'|'css'} Name
  * @typedef {import('estree').TaggedTemplateExpression & { tag: { type: 'Identifier'; name: Name } }} LitTaggedExpression
  */
-
+const { getParserServices } = require('./getContextSourceCode.js');
 /**
  * Whether a node is a lit-html html-tagged template expression
  * @param {import('eslint').Rule.Node} node
@@ -11,7 +11,7 @@
  */
 function isHtmlTaggedTemplate(node, context) {
   if (node.type !== 'TaggedTemplateExpression') return false;
-  const { litHtmlTags = ['html'], litHtmlNamespaces = [] } = context.parserServices || {};
+  const { litHtmlTags = ['html'], litHtmlNamespaces = [] } = getParserServices(context) || {};
 
   switch (node.tag.type) {
     case 'Identifier':


### PR DESCRIPTION
## What I did

1.Eslint has released the alpha version which consists a breaking change - This version has deprecated context.getSourceCode() instead we can use context.sourceCode
2. This PR consists this change with backward compatibility (for version < 9)
