### PR TITLE
Add Porsche Design System to componentLibraries

### DIFF
--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -136,6 +136,11 @@ const componentLibraries = [
     description: "Red Hat's set of community-created web components based on PatternFly design.",
   },
   {
+    name: 'Porsche Design System',
+    url: 'https://designsystem.porsche.com/',
+    description: "The Porsche Design System provides the design fundamentals and elements for efficiently creating aesthetic and high-quality web applications, including easy-to-use Figma and UX Pin libraries, coded Web Components and comprehensive usage guidelines. Everything is built and tested following the Porsche quality standards and corporate design principles.",
+  },
+  {
     name: 'Siemenx IX',
     url: 'https://ix.siemens.io/',
     description:


### PR DESCRIPTION
## What I did

Hi, I'd like to introduce the Porsche Design System component library to the _Community: Component Libraries_ list under https://open-wc.org/guides/community/component-libraries/ which is based on Web Components.

> Porsche Design System provides developers with versioned packages of Web components, Angular components, React components and Vue components to build clean and high-quality frontends that innately come with the latest design definitions.

https://designsystem.porsche.com/