### PR TITLE
Scoped elements no side effects

### DIFF
--- a/.changeset/sweet-clocks-share.md
+++ b/.changeset/sweet-clocks-share.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Marked `@open-wc/scoped-elements` as side-effect free

--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -138,7 +138,8 @@ const componentLibraries = [
   {
     name: 'Porsche Design System',
     url: 'https://designsystem.porsche.com/',
-    description: "The Porsche Design System provides the design fundamentals and elements for efficiently creating aesthetic and high-quality web applications, including easy-to-use Figma and UX Pin libraries, coded Web Components and comprehensive usage guidelines. Everything is built and tested following the Porsche quality standards and corporate design principles.",
+    description:
+      'The Porsche Design System provides the design fundamentals and elements for efficiently creating aesthetic and high-quality web applications, including easy-to-use Figma and UX Pin libraries, coded Web Components and comprehensive usage guidelines. Everything is built and tested following the Porsche quality standards and corporate design principles.',
   },
   {
     name: 'Siemenx IX',

--- a/packages/scoped-elements/html-element.js
+++ b/packages/scoped-elements/html-element.js
@@ -88,6 +88,6 @@ const ScopedElementsMixinImplementation = superclass => {
       });
     }
   };
-}
+};
 
 export const ScopedElementsMixin = dedupeMixin(ScopedElementsMixinImplementation);

--- a/packages/scoped-elements/html-element.js
+++ b/packages/scoped-elements/html-element.js
@@ -5,21 +5,20 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
  * @typedef {import('./types.js').ScopedElementsMap} ScopedElementsMap
  */
 
+const version = '3.0.0';
+const versions = window.scopedElementsVersions || (window.scopedElementsVersions = []);
+if (!versions.includes(version)) {
+  versions.push(version);
+}
+
 /**
  * @template {import('./types.js').Constructor<HTMLElement>} T
  * @param {T} superclass
  * @return {T & import('./types.js').Constructor<ScopedElementsHost>}
  */
-const ScopedElementsMixinImplementation = superclass => {
-  const version = '3.0.0';
-
-  const versions = window.scopedElementsVersions || (window.scopedElementsVersions = []);
-  if (!versions.includes(version)) {
-    versions.push(version);
-  }
-
+const ScopedElementsMixinImplementation = superclass =>
   /** @type {ScopedElementsHost} */
-  return class ScopedElementsHost extends superclass {
+  class ScopedElementsHost extends superclass {
     /**
      * Obtains the scoped elements definitions map if specified.
      *
@@ -88,6 +87,5 @@ const ScopedElementsMixinImplementation = superclass => {
       });
     }
   };
-};
 
 export const ScopedElementsMixin = dedupeMixin(ScopedElementsMixinImplementation);

--- a/packages/scoped-elements/html-element.js
+++ b/packages/scoped-elements/html-element.js
@@ -5,20 +5,21 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
  * @typedef {import('./types.js').ScopedElementsMap} ScopedElementsMap
  */
 
-const version = '3.0.0';
-const versions = window.scopedElementsVersions || (window.scopedElementsVersions = []);
-if (!versions.includes(version)) {
-  versions.push(version);
-}
-
 /**
  * @template {import('./types.js').Constructor<HTMLElement>} T
  * @param {T} superclass
  * @return {T & import('./types.js').Constructor<ScopedElementsHost>}
  */
-const ScopedElementsMixinImplementation = superclass =>
+const ScopedElementsMixinImplementation = superclass => {
+  const version = '3.0.0';
+
+  const versions = window.scopedElementsVersions || (window.scopedElementsVersions = []);
+  if (!versions.includes(version)) {
+    versions.push(version);
+  }
+
   /** @type {ScopedElementsHost} */
-  class ScopedElementsHost extends superclass {
+  return class ScopedElementsHost extends superclass {
     /**
      * Obtains the scoped elements definitions map if specified.
      *
@@ -87,5 +88,6 @@ const ScopedElementsMixinImplementation = superclass =>
       });
     }
   };
+}
 
 export const ScopedElementsMixin = dedupeMixin(ScopedElementsMixinImplementation);

--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -55,5 +55,6 @@
   "devDependencies": {
     "@open-wc/testing": "^3.2.2",
     "@webcomponents/scoped-custom-element-registry": "^0.0.9"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
I think in https://github.com/open-wc/open-wc/pull/2224 we just removed `sideEffects` instead of setting it to `false` which I believe is the correct value as `dedupeMixin` is side-effect free and by moving some top-level code into the `ScopedElementsMixin` we can make that side-effect free as well.