### PR TITLE
fix(semantic-dom-diff): add missed extension to import

### DIFF
--- a/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
+++ b/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="chai" />
 
-import { DiffOptions } from './get-diffable-html';
+import { DiffOptions } from './get-diffable-html.js';
 
 declare global {
   namespace Chai {


### PR DESCRIPTION
Add missed .js extension to import. This matches the convention in
packages/semantic-dom-diff/index.d.ts and fixes the typing error:

```
node_modules/@open-wc/semantic-dom-diff/chai-dom-diff-plugin.d.ts:3:29 - error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './get-diffable-html.js'?

3 import { DiffOptions } from './get-diffable-html';
```