### PR TITLE
docs: fix type in reference types example

### DIFF
--- a/docs/guides/knowledge/lit-element/rendering.md
+++ b/docs/guides/knowledge/lit-element/rendering.md
@@ -41,7 +41,7 @@ But in the case of reference types, the thing that is compared is the _reference
 
 ```js
 const o = { foo: 'bar' }
-const p === { foo: 'bar' }
+const p = { foo: 'bar' }
 o === p // false
 ```
 


### PR DESCRIPTION
Code sample uses equality check when it meant to be an assignment