### PR TITLE
docs: Revert "add Nord Design System component library"

### DIFF
--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -131,12 +131,6 @@ const componentLibraries = [
       "Material Design Components from Material Design team themselves. Stay as close as possible to the living specification with these components from Google's own Material Design team.",
   },
   {
-    name: 'Nord Design System',
-    url: 'https://nordhealth.design/components/',
-    description:
-      'Nord Design System is a collection of reusable components and tools, guided by clear standards, that can be assembled together to build digital products and experiences.',
-  },
-  {
     name: 'Patternfly Elements',
     url: 'https://patternflyelements.org/',
     description: "Red Hat's set of community-created web components based on PatternFly design.",


### PR DESCRIPTION
## What I did

1. This reverts commit 50d1d7c6f21b7cd7dbd7089c67bdaa9e86cf4007.

Nord is not intended for use outside of Nordhealth.
See the following links to confirm:
- https://nordhealth.design/faq/#can-i-use-nord-in-any-project
- https://nordhealth.design/terms/

<img width="530" alt="image" src="https://github.com/open-wc/open-wc/assets/309310/1cfcf5aa-0b9c-4dd0-b541-43687497abfb">