### PR TITLE
Remove babel from eslint config

### DIFF
--- a/.changeset/blue-lions-brake.md
+++ b/.changeset/blue-lions-brake.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/eslint-config': patch
+---
+
+Remove dependency on `@babel/eslint-parser`

--- a/docs/guides/knowledge/lit-element/rendering.md
+++ b/docs/guides/knowledge/lit-element/rendering.md
@@ -40,9 +40,9 @@ In the case of direct values, equality is determined by directly comparing the v
 But in the case of reference types, the thing that is compared is the _reference_ to the object, not its contents.
 
 ```js
-const o = { foo: 'bar' }
-const p = { foo: 'bar' }
-o === p // false
+const o = { foo: 'bar' };
+const p = { foo: 'bar' };
+o === p; // false
 ```
 
 ### LitElement's Property System

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,31 +397,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.15.tgz",
-      "integrity": "sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==",
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
@@ -3699,34 +3674,6 @@
       "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
       "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA==",
       "dev": true
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -39052,8 +38999,6 @@
       "version": "12.0.3",
       "license": "MIT",
       "dependencies": {
-        "@babel/eslint-parser": "^7.19.1",
-        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-html": "^7.1.0",
         "eslint-plugin-import": "^2.26.0",
@@ -39105,7 +39050,7 @@
     },
     "packages/lit-helpers": {
       "name": "@open-wc/lit-helpers",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "peerDependencies": {
         "lit": "^2.0.0 || ^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "concurrently": "^6.0.2",
         "copyfiles": "^2.4.1",
         "core-js": "^3.26.1",
+        "deepmerge": "^4.3.1",
         "eslint": "^8.27.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "concurrently": "^6.0.2",
     "copyfiles": "^2.4.1",
     "core-js": "^3.26.1",
+    "deepmerge": "^4.3.1",
     "eslint": "^8.27.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -4,17 +4,9 @@ module.exports = {
     require.resolve('./src/eslint-plugin-wc-export'),
     'plugin:lit-a11y/recommended',
   ],
-  /**
-   * When import assertions are stage 4 and supported by eslint by default,
-   * we can remove the babel parser, `requireConfigFile` and `babelOptions` again
-   */
-  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 'latest',
     requireConfigFile: false,
-    babelOptions: {
-      plugins: ['@babel/plugin-syntax-import-assertions'],
-    },
   },
   env: {
     browser: true,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,8 +32,6 @@
     "eslint-plugin-wc": "^1.2.0"
   },
   "dependencies": {
-    "@babel/eslint-parser": "^7.19.1",
-    "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.26.0",


### PR DESCRIPTION
## What I did

1. I removed the babel parser dependency as I don't think that's needed any more.
