### PR TITLE
Fix typescript import error on nodenext/nodenext.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39104,7 +39104,7 @@
     },
     "packages/lit-helpers": {
       "name": "@open-wc/lit-helpers",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "peerDependencies": {
         "lit": "^2.0.0 || ^3.0.0"

--- a/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
+++ b/packages/semantic-dom-diff/chai-dom-diff-plugin.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="chai" />
 
-import { DiffOptions } from './get-diffable-html';
+import { DiffOptions } from './get-diffable-html.js';
 
 declare global {
   namespace Chai {


### PR DESCRIPTION
## What I did

I added a .js extension to an import. Was getting this error from tsc:

```
node_modules/@open-wc/semantic-dom-diff/chai-dom-diff-plugin.d.ts(3,29): error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './get-diffable-html.js'?
```
