### PR TITLE
Add lit-a11y/list to eslint-plugin-lit-a11y docs/../overview.md

### DIFF
--- a/docs/docs/linting/eslint-plugin-lit-a11y/overview.md
+++ b/docs/docs/linting/eslint-plugin-lit-a11y/overview.md
@@ -94,6 +94,7 @@ If you're importing lit-html from a package that re-exports lit-html, like for e
 - [lit-a11y/heading-has-content](./rules/heading-has-content.md)
 - [lit-a11y/iframe-title](./rules/iframe-title.md)
 - [lit-a11y/img-redundant-alt](./rules/img-redundant-alt.md)
+- [lit-a11y/list](./rules/list.md)
 - [lit-a11y/mouse-events-have-key-events](./rules/mouse-events-have-key-events.md)
 - [lit-a11y/no-access-key](./rules/no-access-key.md)
 - [lit-a11y/no-autofocus](./rules/no-autofocus.md)

--- a/docs/docs/linting/eslint-plugin-lit-a11y/rules/list.md
+++ b/docs/docs/linting/eslint-plugin-lit-a11y/rules/list.md
@@ -1,0 +1,50 @@
+# list
+
+`<ul>` and `<ol>` must only directly contain `<li>`, `<script>` or `<template>` elements.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+html` 
+<ul>
+  <div></div>
+  <li></li>
+</ul
+`;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+html` 
+<ul>
+  <li></li>
+</ul
+`;
+```
+
+```js
+html` 
+<ul>
+  <li>
+    <ul>
+      <li></li>
+    </ul>
+  </li>
+</ul
+`;
+```
+
+```js
+html` 
+<ol>
+  <li></li>
+</ol
+`;
+```
+
+## Further Reading
+
+- [Deque](https://dequeuniversity.com/rules/axe/4.6/list)


### PR DESCRIPTION
## What I did
Address https://github.com/open-wc/open-wc/issues/2796 via the following changes

1. Add copy of list.md to ``docs/docs/linting/eslint-plugin-lit-a11y/rules`` from the package rules
2. Add a reference to this newly copied file in ``docs/docs/linting/eslint-plugin-lit-a11y/overview.md``


Side note: I noticed that the list of rules within the package && this docs folder are not aligned for other rules as well - is maintaining this documentation in two locations like this adding unnecessary maintenance cost? Just an observation as an outsider.