### PR TITLE
fix(eslint-plugin-lit-a11y) fix improper regex

### DIFF
--- a/.changeset/pink-squids-attend.md
+++ b/.changeset/pink-squids-attend.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-lit-a11y': patch
+---
+
+Makes regex for detecting custom elements match the spec closer

--- a/packages/eslint-plugin-lit-a11y/lib/utils/isCustomElement.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/isCustomElement.js
@@ -1,4 +1,4 @@
-const CE_TAGNAME_RE = /^[a-z]\w+-\w+/;
+const CE_TAGNAME_RE = /^[a-z]\w*-\w+/;
 
 /**
  * Is the element a custom element (i.e. does it contain a '-')?

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/click-events-have-key-events.js
@@ -51,6 +51,10 @@ ruleTester.run('click-events-have-key-events', rule, {
       code: 'html`<another-button @click=${foo}></another-button>`',
       options: [{ allowCustomElements: true }],
     },
+    {
+      code: 'html`<a-button-with-single-starting-letter @click=${foo}></a-button-with-single-starting-letter>`',
+      options: [{ allowCustomElements: true }],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
The existing regex would prevent valid custom elements from being detected appropriately.

The [spec](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) indicates that a valid custom name must start with a lowercase a-z but the next word between that character and the hyphen doesn't necessarily need to be present as the `+` in the existing regex indicates.

This makes it so custom elements such as `<d-button>` or `<q-tooltip>` are detected as such.
