### PR TITLE
Update lit-helpers.md to install correct package version

### DIFF
--- a/docs/docs/development/lit-helpers.md
+++ b/docs/docs/development/lit-helpers.md
@@ -5,7 +5,7 @@ A library with helpers functions for working with [lit](https://lit.dev/).
 ## Installation
 
 ```bash
-npm i --save @open-wc/lit-helpers@next
+npm i --save @open-wc/lit-helpers
 ```
 
 ## Privately Settable Read-Only Properties


### PR DESCRIPTION
Update installation command. Using @next installs version 0.4.0-next.1 and that version does not include the spread directives while this page implies that it does. Using without @next installs version 0.7.0 which does include the spread directives as the documentation describes.

## What I did

1. Updated the documentation for the lit-helpers page to show the correct installation command, the one currently showing is outdated.
