### PR TITLE
fix: correctly define rules object options schemas

### DIFF
--- a/packages/eslint-plugin-lit-a11y/lib/rules/accessible-name.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/accessible-name.js
@@ -39,43 +39,43 @@ const ButtonHasContentRule = {
     fixable: null,
     schema: [
       {
-        customButtonElements: {
-          type: 'array',
-          description: 'list of custom elements tag names which should be considered buttons',
-          default: [],
-          uniqueItems: true,
-          additionalItems: false,
-          items: {
-            type: 'string',
-            pattern: '^[a-z]\\w+-\\w+',
+        type: 'object',
+        properties: {
+          customButtonElements: {
+            type: 'array',
+            description: 'list of custom elements tag names which should be considered buttons',
+            default: [],
+            uniqueItems: true,
+            additionalItems: false,
+            items: {
+              type: 'string',
+              pattern: '^[a-z]\\w+-\\w+',
+            },
+          },
+          customLinkElements: {
+            type: 'array',
+            description: 'list of custom elements tag names which should be considered links',
+            default: [],
+            uniqueItems: true,
+            additionalItems: false,
+            items: {
+              type: 'string',
+              pattern: '^[a-z]\\w+-\\w+',
+            },
+          },
+          customHeadingElements: {
+            type: 'array',
+            description: 'list of custom elements tag names which should be considered headings',
+            default: [],
+            uniqueItems: true,
+            additionalItems: false,
+            items: {
+              type: 'string',
+              pattern: '^[a-z]\\w+-\\w+',
+            },
           },
         },
-      },
-      {
-        customLinkElements: {
-          type: 'array',
-          description: 'list of custom elements tag names which should be considered links',
-          default: [],
-          uniqueItems: true,
-          additionalItems: false,
-          items: {
-            type: 'string',
-            pattern: '^[a-z]\\w+-\\w+',
-          },
-        },
-      },
-      {
-        customHeadingElements: {
-          type: 'array',
-          description: 'list of custom elements tag names which should be considered headings',
-          default: [],
-          uniqueItems: true,
-          additionalItems: false,
-          items: {
-            type: 'string',
-            pattern: '^[a-z]\\w+-\\w+',
-          },
-        },
+        additionalProperties: false,
       },
     ],
   },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/click-events-have-key-events.js
@@ -32,24 +32,28 @@ const ClickEventsHaveKeyEventsRule = {
     fixable: null,
     schema: [
       {
-        allowList: {
-          type: 'array',
-          description:
-            'list of tag names which are permitted to have click listeners without key listeners',
-          default: [],
-          uniqueItems: true,
-          additionalItems: false,
-          items: {
-            type: 'string',
-            pattern: '^[a-z]\\w+-\\w+',
+        type: 'object',
+        properties: {
+          allowList: {
+            type: 'array',
+            description:
+              'list of tag names which are permitted to have click listeners without key listeners',
+            default: [],
+            uniqueItems: true,
+            additionalItems: false,
+            items: {
+              type: 'string',
+              pattern: '^[a-z]\\w+-\\w+',
+            },
+          },
+          allowCustomElements: {
+            type: 'boolean',
+            description:
+              'When true, permits all custom elements to have click listeners without key listeners',
+            default: true,
           },
         },
-        allowCustomElements: {
-          type: 'boolean',
-          description:
-            'When true, permits all custom elements to have click listeners without key listeners',
-          default: true,
-        },
+        additionalProperties: false,
       },
     ],
   },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/heading-hidden.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/heading-hidden.js
@@ -32,17 +32,21 @@ const HeadingHiddenRule = {
     fixable: null,
     schema: [
       {
-        customHeadingElements: {
-          type: 'array',
-          description: 'list of custom elements tag names which should be considered headings',
-          default: [],
-          uniqueItems: true,
-          additionalItems: false,
-          items: {
-            type: 'string',
-            pattern: '^[a-z]\\w+-\\w+',
+        type: 'object',
+        properties: {
+          customHeadingElements: {
+            type: 'array',
+            description: 'list of custom elements tag names which should be considered headings',
+            default: [],
+            uniqueItems: true,
+            additionalItems: false,
+            items: {
+              type: 'string',
+              pattern: '^[a-z]\\w+-\\w+',
+            },
           },
         },
+        additionalProperties: false,
       },
     ],
   },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/img-redundant-alt.js
@@ -35,15 +35,19 @@ const ImgRedundantAltRule = {
     fixable: null,
     schema: [
       {
-        keywords: {
-          type: 'array',
-          default: DEFAULT_KEYWORDS,
-          items: {
-            type: 'string',
+        type: 'object',
+        properties: {
+          keywords: {
+            type: 'array',
+            default: DEFAULT_KEYWORDS,
+            items: {
+              type: 'string',
+            },
+            uniqueItems: true,
+            additionalItems: false,
           },
-          uniqueItems: true,
-          additionalItems: false,
         },
+        additionalProperties: false,
       },
     ],
   },

--- a/packages/eslint-plugin-lit-a11y/lib/rules/mouse-events-have-key-events.js
+++ b/packages/eslint-plugin-lit-a11y/lib/rules/mouse-events-have-key-events.js
@@ -30,24 +30,28 @@ const MouseEventsHaveKeyEventsRule = {
     fixable: null,
     schema: [
       {
-        allowList: {
-          type: 'array',
-          description:
-            'list of tag names which are permitted to have mouse event listeners without key listeners',
-          default: [],
-          uniqueItems: true,
-          additionalItems: false,
-          items: {
-            type: 'string',
-            pattern: '^[a-z]\\w+-\\w+',
+        type: 'object',
+        properties: {
+          allowList: {
+            type: 'array',
+            description:
+              'list of tag names which are permitted to have mouse event listeners without key listeners',
+            default: [],
+            uniqueItems: true,
+            additionalItems: false,
+            items: {
+              type: 'string',
+              pattern: '^[a-z]\\w+-\\w+',
+            },
+          },
+          allowCustomElements: {
+            type: 'boolean',
+            description:
+              'When true, permits all custom elements to have mouse event listeners without key listeners',
+            default: true,
           },
         },
-        allowCustomElements: {
-          type: 'boolean',
-          description:
-            'When true, permits all custom elements to have mouse event listeners without key listeners',
-          default: true,
-        },
+        additionalProperties: false,
       },
     ],
   },

--- a/packages/eslint-plugin-lit-a11y/lib/utils/schemas.js
+++ b/packages/eslint-plugin-lit-a11y/lib/utils/schemas.js
@@ -31,6 +31,7 @@ const generateObjSchema = (properties = {}, required) => ({
   type: 'object',
   properties,
   required,
+  additionalProperties: false,
 });
 
 export { generateObjSchema, enumArraySchema, arraySchema };

--- a/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-name.js
+++ b/packages/eslint-plugin-lit-a11y/tests/lib/rules/accessible-name.js
@@ -114,7 +114,7 @@ ruleTester.run('accessible-name', rule, {
       code: 'html`<custom-heading level="1">${this.foo()}</custom-heading>`',
       options: [
         {
-          customHeadingElements: 'custom-heading',
+          customHeadingElements: ['custom-heading'],
         },
       ],
     },


### PR DESCRIPTION
## What I did

This PR fixes object options schemas of some `eslint-plugin-lit-a11y` rules to ensure validation actually works and no additional properties are allowed.