### PR TITLE
ESLint Flat Config for eslint-plugin-lit-a11y - README Update

### DIFF
--- a/docs/docs/linting/eslint-plugin-lit-a11y/overview.md
+++ b/docs/docs/linting/eslint-plugin-lit-a11y/overview.md
@@ -62,7 +62,7 @@ Then configure the rules you want to use under the rules section.
 }
 ```
 
-## Configuration
+## Flat Config Configuration (old)
 
 You may also extend the recommended configuration like so:
 


### PR DESCRIPTION
Thanks to @Lassepitkanen, in https://github.com/open-wc/open-wc/pull/2844 `eslint-plugin-lit-a11y` supports the ESLint 9.x "flat config" format directly, which addresses https://github.com/open-wc/open-wc/issues/2829 🎉 

This PR adds documentation to the README about how to get set up with it.