### PR TITLE
scoped-elements: add lit ^2.0.0 dependency

### DIFF
--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^2.0.0",
-    "lit": "^3.0.0"
+    "lit": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.2.2",


### PR DESCRIPTION
Uses the same lit dependency as testing-helpers

"lit": "^2.0.0 || ^3.0.0"

This avoids duplicating lit in projects that still use lit 2

## What I did

1. changed lit dependency to "lit": "^2.0.0 || ^3.0.0"
