### PR TITLE
Add LessJS framwork to baseLibraries.js with description and URL

### DIFF
--- a/docs/_data/baseLibraries.js
+++ b/docs/_data/baseLibraries.js
@@ -155,6 +155,13 @@ const baseLibraries = [
       "An easy to use, lightweight library for web-components that doesn't need a build step but can be included in a build step if you want to. It's a great way to create reusable components for your projects. It's available as a NPM package or module and doesn't use any dependencies and is around 4.5kb minified + gzipped. It also doesn't use eval or new Function so can be used in strict CSP polices without a build step. For documentation and demos go to Bayjs.org.",
     url: 'https://bayjs.org/examples/index.html',
   },
+  {
+  name: 'LessJS',
+  package: '@lessjs/core',
+  description:
+    'A Web Standards-first DSD application framework — Declarative Shadow DOM rendering, Island Architecture, and Vite-free ESG pipeline for Web Components.',
+  url: 'https://lessjs.run/',
+},
 ];
 
 module.exports = async function getBaseLibraries() {

--- a/docs/_data/baseLibraries.js
+++ b/docs/_data/baseLibraries.js
@@ -160,7 +160,7 @@ const baseLibraries = [
   package: '@lessjs/core',
   description:
     'A Web Standards-first DSD application framework — Declarative Shadow DOM rendering, Island Architecture, and Vite-free ESG pipeline for Web Components.',
-  url: 'https://lessjs.run/',
+  url: 'https://lessjs.com',
 },
 ];
 


### PR DESCRIPTION
## What I did

1.Add LessJS framwork to baseLibraries.js with description and URL
A Web Standards-first DSD application framework — Declarative Shadow DOM rendering, Island Architecture, and Vite-free ESG pipeline for Web Components.