### PR TITLE
fix: handle npm 404 for JSR-only packages in getBaseLibraries

### DIFF
--- a/docs/_data/baseLibraries.js
+++ b/docs/_data/baseLibraries.js
@@ -161,10 +161,20 @@ module.exports = async function getBaseLibraries() {
   const result = await Promise.all(
     baseLibraries.map(async lib => {
       const pkg = encodeURIComponent(lib.package);
-      const { downloads } = await cache(`https://api.npmjs.org/downloads/point/last-week/${pkg}`, {
-        duration: '1d',
-        type: 'json',
-      });
+      let downloads = 0;
+      try {
+        const data = await cache(
+          `https://api.npmjs.org/downloads/point/last-week/${pkg}`,
+          {
+            duration: '1d',
+            type: 'json',
+          },
+        );
+        downloads = data.downloads ?? 0;
+      } catch {
+        // Package not found on npm (e.g. JSR-only packages)
+        downloads = 0;
+      }
 
       return {
         ...lib,


### PR DESCRIPTION
## Problem

The `getBaseLibraries()` function in `docs/_data/baseLibraries.js` calls the npm downloads API without error handling. When a package is not published on npm (e.g. JSR-only packages like `@lessjs/core`), the API returns a 404 and the build crashes.

My project is not published on npm, but on [JSR](https://jsr.io/@lessjs)
## Fix

Wrap the npm API call in a `try/catch` block. On error (404 or otherwise), default `downloads` to `0` instead of crashing.

This also makes the function more resilient to temporary npm API outages.

### Before
```js
const { downloads } = await cache(url, opts);
```

### After
```js
let downloads = 0;
try {
  const data = await cache(url, opts);
  downloads = data.downloads ?? 0;
} catch {
  downloads = 0;
}
```