### PR TITLE
fix: remove trailing whitespace in componentLibraries.js

### DIFF
--- a/docs/_data/componentLibraries.js
+++ b/docs/_data/componentLibraries.js
@@ -4,7 +4,7 @@ const componentLibraries = [
     url: 'https://www.agnosticui.com/',
     description:
       "An open-source CLI-based UI component library that copies Lit web components directly into your project. Full React and Vue wrappers for native framework experience. Otherwise, Svelte, Astro, Angular, Solid, Preact, and more supported via direct web component import.",
-  },        
+  },
   {
     name: 'Auro',
     url: 'https://auro.alaskaair.com',


### PR DESCRIPTION
## Problem

Line 7 of `docs/_data/componentLibraries.js` has trailing whitespace after the AgnosticUI entry:

```js
  },        
```

This triggers Prettier/eslint failures in CI.

## Fix

Remove the trailing whitespace:

```js
  },
```