### PR TITLE
fix: [scoped-elements] expose all typings files for downstream typesc…

### DIFF
--- a/.changeset/legal-cobras-win.md
+++ b/.changeset/legal-cobras-win.md
@@ -2,4 +2,4 @@
 '@open-wc/scoped-elements': patch
 ---
 
-Update package.json exports field to expose all files matching pattern (allows downstream Typescript consumers to resolve references to internal types file)
+Update package.json exports field to include a synthetic types.js (allows downstream Typescript consumers to resolve references to internal types file)

--- a/.changeset/legal-cobras-win.md
+++ b/.changeset/legal-cobras-win.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/scoped-elements': patch
+---
+
+Update package.json exports field to expose all files matching pattern (allows downstream Typescript consumers to resolve references to internal types file)

--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -15,13 +15,9 @@
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/scoped-elements",
   "type": "module",
   "exports": {
-    "./html-element.js": {
-      "types": "./dist-types/html-element.d.ts",
-      "default": "./html-element.js"
-    },
-    "./lit-element.js": {
-      "types": "./dist-types/lit-element.d.ts",
-      "default": "./lit-element.js"
+    "./*.js": {
+      "types": "./dist-types/*.d.ts",
+      "default": "./*.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/scoped-elements/package.json
+++ b/packages/scoped-elements/package.json
@@ -15,9 +15,16 @@
   "homepage": "https://github.com/open-wc/open-wc/tree/master/packages/scoped-elements",
   "type": "module",
   "exports": {
-    "./*.js": {
-      "types": "./dist-types/*.d.ts",
-      "default": "./*.js"
+    "./html-element.js": {
+      "types": "./dist-types/html-element.d.ts",
+      "default": "./html-element.js"
+    },
+    "./lit-element.js": {
+      "types": "./dist-types/lit-element.d.ts",
+      "default": "./lit-element.js"
+    },
+    "./types.js": {
+      "types": "./dist-types/types.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## What I did

1. Updated `package.json` exports for `@open-wc/scoped-elements` so that all typing files are exposed. This resolve an issue where downstream TypeScript consumers would not be able to build declarations due to the `types.d.ts` file being unexported by this package.
